### PR TITLE
feat(browser-semantic): Path A observe/act/extract primitives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,10 @@ Example script tool in Python, using `uv` script dependencies:
 import sys
 from rich import print
 
+
 def main():
     print("[bold green]Hello from a script tool![/bold green]")
+
 
 if __name__ == "__main__":
     main()
@@ -80,8 +82,11 @@ easier testability.
 ```python
 import click
 
+
 @click.command()
-@click.option("--workspace", type=click.Path(path_type=Path), default=".", show_default=True)
+@click.option(
+    "--workspace", type=click.Path(path_type=Path), default=".", show_default=True
+)
 def main(workspace: Path) -> None:
     """Short description shown in --help."""
     ...

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A capability-oriented map of this repo. Each entry links to a plugin (`plugins/`
 | **Email** | [gptmail](./packages/gptmail/) — universal email for agents, incl. agent-to-agent messaging |
 | **Chat & social** | [gptme-whatsapp](./packages/gptme-whatsapp/), [gptme-forum](./packages/gptme-forum/) (git-native agent forum), [discord](./scripts/discord/) / [telegram](./scripts/telegram/) / [twitter](./scripts/twitter/) / [bluesky](./scripts/bluesky/) scripts |
 | **Voice** | [gptme-voice](./packages/gptme-voice/) (real-time voice via OpenAI/Grok Realtime APIs), [gptme-tts](./plugins/gptme-tts/) (local Kokoro TTS) |
+| **Computer use** | [gptme-browser-semantic](./packages/gptme-browser-semantic/) (observe/act/extract over gptme's ARIA snapshot; no stagehand) |
 | **GitHub** | [github](./scripts/github/) scripts (context, notifications), [github_hygiene](./scripts/github_hygiene/), [github_resolver](./scripts/github_resolver/); core's `gh` tool |
 | **Autonomous operation** | [gptme-runloops](./packages/gptme-runloops/) (run loop framework), [gptme-gupp](./plugins/gptme-gupp/) (work persistence), [gptme-ralph](./plugins/gptme-ralph/) (iterate with context reset), [gptme-coordination](./packages/gptme-coordination/) (work claims, message bus), [credential-slots](./packages/credential-slots/) + [gptme-subscription](./packages/gptme-subscription/) (credential rotation, capacity-aware routing), [gptme-backoff](./packages/gptme-backoff/) |
 | **Context management** | [gptme-ace](./plugins/gptme-ace/), [gptme-attention-tracker](./plugins/gptme-attention-tracker/), [gptme-headroom-compressor](./plugins/gptme-headroom-compressor/), [gptme-tooloutput-trimmer](./plugins/gptme-tooloutput-trimmer/) |
@@ -81,6 +82,7 @@ Reusable Python packages, installable individually. See [packages/README.md](./p
 | [gptme-activity-summary](./packages/gptme-activity-summary/) | Activity summarization — journals, GitHub, sessions, tweets, email |
 | [gptme-backoff](./packages/gptme-backoff/) | Retry utilities: exponential backoff, jitter, async/sync decorators |
 | [gptme-bob-status](./packages/gptme-bob-status/) | Bob-specific StatusProvider for `gptme-util status` |
+| [gptme-browser-semantic](./packages/gptme-browser-semantic/) | Semantic observe/act/extract primitives over gptme's existing Playwright ARIA snapshot (Path A; no stagehand) |
 | [gptme-cc-memory](./packages/gptme-cc-memory/) | Typed, git-tracked, hook-injected session memory for Claude Code |
 | [gptme-codegraph](./packages/gptme-codegraph/) | Structural code retrieval with tree-sitter (call graph, blast/impact analysis, MCP tools) |
 | [gptme-contrib-lib](./packages/gptme-contrib-lib/) | Shared utilities |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A capability-oriented map of this repo. Each entry links to a plugin (`plugins/`
 | **Email** | [gptmail](./packages/gptmail/) — universal email for agents, incl. agent-to-agent messaging |
 | **Chat & social** | [gptme-whatsapp](./packages/gptme-whatsapp/), [gptme-forum](./packages/gptme-forum/) (git-native agent forum), [discord](./scripts/discord/) / [telegram](./scripts/telegram/) / [twitter](./scripts/twitter/) / [bluesky](./scripts/bluesky/) scripts |
 | **Voice** | [gptme-voice](./packages/gptme-voice/) (real-time voice via OpenAI/Grok Realtime APIs), [gptme-tts](./plugins/gptme-tts/) (local Kokoro TTS) |
-| **Computer use** | [gptme-browser-semantic](./packages/gptme-browser-semantic/) (observe/act/extract over gptme's ARIA snapshot; no stagehand) |
 | **GitHub** | [github](./scripts/github/) scripts (context, notifications), [github_hygiene](./scripts/github_hygiene/), [github_resolver](./scripts/github_resolver/); core's `gh` tool |
 | **Autonomous operation** | [gptme-runloops](./packages/gptme-runloops/) (run loop framework), [gptme-gupp](./plugins/gptme-gupp/) (work persistence), [gptme-ralph](./plugins/gptme-ralph/) (iterate with context reset), [gptme-coordination](./packages/gptme-coordination/) (work claims, message bus), [credential-slots](./packages/credential-slots/) + [gptme-subscription](./packages/gptme-subscription/) (credential rotation, capacity-aware routing), [gptme-backoff](./packages/gptme-backoff/) |
 | **Context management** | [gptme-ace](./plugins/gptme-ace/), [gptme-attention-tracker](./plugins/gptme-attention-tracker/), [gptme-headroom-compressor](./plugins/gptme-headroom-compressor/), [gptme-tooloutput-trimmer](./plugins/gptme-tooloutput-trimmer/) |
@@ -82,7 +81,6 @@ Reusable Python packages, installable individually. See [packages/README.md](./p
 | [gptme-activity-summary](./packages/gptme-activity-summary/) | Activity summarization — journals, GitHub, sessions, tweets, email |
 | [gptme-backoff](./packages/gptme-backoff/) | Retry utilities: exponential backoff, jitter, async/sync decorators |
 | [gptme-bob-status](./packages/gptme-bob-status/) | Bob-specific StatusProvider for `gptme-util status` |
-| [gptme-browser-semantic](./packages/gptme-browser-semantic/) | Semantic observe/act/extract primitives over gptme's existing Playwright ARIA snapshot (Path A; no stagehand) |
 | [gptme-cc-memory](./packages/gptme-cc-memory/) | Typed, git-tracked, hook-injected session memory for Claude Code |
 | [gptme-codegraph](./packages/gptme-codegraph/) | Structural code retrieval with tree-sitter (call graph, blast/impact analysis, MCP tools) |
 | [gptme-contrib-lib](./packages/gptme-contrib-lib/) | Shared utilities |

--- a/packages/README.md
+++ b/packages/README.md
@@ -13,6 +13,7 @@ Python packages for gptme agents.
 | **gptmail** | Email/message handling | `uv pip install -e packages/gptmail` |
 | **gptodo** | Task management and work queues | `uv pip install -e packages/gptodo` |
 | **gptme-activity-summary** | Activity summarization (journals, GitHub, sessions, tweets, email) | `uv pip install -e packages/gptme-activity-summary` |
+| **gptme-browser-semantic** | Semantic observe/act/extract over gptme's ARIA snapshot (Path A; no stagehand) | `uv pip install -e packages/gptme-browser-semantic` |
 | **gptme-sessions** | Session tracking, analytics, and trajectory extraction | `uv pip install -e packages/gptme-sessions` |
 | **gptme-voice** | Voice interface using OpenAI Realtime API | `uv pip install -e packages/gptme-voice` |
 | **gptme-whatsapp** | WhatsApp integration for agents | `uv pip install -e packages/gptme-whatsapp` |

--- a/packages/gptme-browser-semantic/Makefile
+++ b/packages/gptme-browser-semantic/Makefile
@@ -1,0 +1,11 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+
+test:
+	uv run --extra test pytest tests/ -v
+
+typecheck:
+	uv run --with mypy mypy src/ --ignore-missing-imports
+
+benchmark:
+	uv run python benchmark.py

--- a/packages/gptme-browser-semantic/README.md
+++ b/packages/gptme-browser-semantic/README.md
@@ -1,0 +1,136 @@
+# gptme-browser-semantic
+
+Semantic **observe / act / extract** primitives for gptme computer-use,
+implemented as **Path A**: a pure-Python layer over gptme's *existing*
+Playwright browser tools and its ARIA snapshot. No stagehand dependency, no
+new browser-launching code — the module reuses the `gptme.tools.browser`
+backend that agents already have.
+
+## Why
+
+The stock `browser` tool is screenshot-and-snapshot based. On a multi-step
+page task an agent pays an LLM call on every step:
+
+```
+snapshot_page()   # 1 LLM: interpret ARIA
+click_element()   # 0
+snapshot_page()   # 1 LLM: re-interpret
+fill_element()    # 0
+snapshot_page()   # 1 LLM: verify
+```
+
+The semantic pattern collapses that cost:
+
+```
+browser_observe("the submit button")   # 1 LLM-equivalent hop, returns selectors
+browser_act(observed[0])               # 0 — reuses the cached selector
+browser_act(observed[1], fill="x")     # 0
+browser_extract()                      # 0 (raw ARIA)
+```
+
+`browser_observe` is the load-bearing primitive: one call produces a ranked
+list of reusable Playwright-anchored selectors that subsequent deterministic
+actions act on for **zero** extra interpretation cost.
+
+## The three primitives
+
+- **`browser_observe(instruction, *, top_k=5, llm_rerank=False)`**
+  Returns a list of `ObserveResult` (description, Playwright selector,
+  method, arguments), best match first. The default path is a deterministic
+  token-overlap + role-aware scorer over the ARIA snapshot — **no LLM
+  round-trip**. `llm_rerank=True` is a Path-B hook (not wired in Path A).
+
+  Selectors: when the snapshot includes `[ref=eN]` (tests / future gptme
+  snapshots with `ref=True`), that ref is reused. Otherwise the locator is
+  `role={role}[name='{name}']`, which gptme's `click_element` / `fill_element`
+  already accept. Non-ref bracket attributes such as `[level=1]` are ignored.
+
+- **`browser_act(action_or_observed, *, method=None, arguments=None,
+  retry_on_stale=True)`**
+  Two forms:
+  1. `browser_act("click the submit button")` — observes internally,
+     dispatches the top match.
+  2. `browser_act(observed)` — dispatches a previously observed selector.
+     Zero interpretation cost.
+
+  **Stale-selector recovery**: when a cached selector no longer resolves
+  (the page re-rendered or swapped refs), the dispatch fails and the element
+  is re-observed once with the same query and retried on the fresh top match.
+  The re-observe is free on the default scoring path, so the retry costs
+  nothing against the LLM budget. `retry_on_stale=False` returns the first
+  failure immediately.
+
+- **`browser_extract(instruction=None, *, schema=None)`**
+  Path A always returns the raw ARIA snapshot (zero-LLM). `schema=` is
+  rejected with a Path-B hint — schema-aware typed extraction is not
+  silently faked.
+
+## Path A vs Path B
+
+- **Path A (this package)**: implement the semantic interface directly over
+  gptme's ARIA snapshot + Playwright. Shippable today, zero new dependencies.
+- **Path B**: once `stagehand` exposes a usable local-only Python mode
+  (`stagehand.local_browser.launch()`, not yet on PyPI), these same tool
+  signatures wrap stagehand and inherit its real semantic model. The
+  `ObserveResult` shape is deliberately stagehand-compatible so the swap is
+  mechanical.
+
+## Benchmark
+
+`benchmark.py` counts LLM calls across 5 representative page tasks against a
+static, deterministic `fixtures/hn.html` (HN clone — no live web, no browser
+launch). Recorded result under the conservative production-path proxy
+(observe and instructed extract counted as 1 LLM each, as if rerank/typed
+extract were on):
+
+| | LLM calls |
+|---|---:|
+| Raw `browser` path | 11 |
+| Path A semantic path | 7 |
+| **Reduction** | **−36.4%** |
+
+Path A's default implementation is cheaper than this proxy (0-LLM
+token-overlap observe, raw-ARIA extract). The −36% figure is therefore a
+lower bound. Run it:
+
+```
+make benchmark
+```
+
+`tests/test_benchmark.py` pins these totals so the design-doc claim can't
+rot silently.
+
+## Tests
+
+```
+make test
+```
+
+The suite never touches a live browser: `gptme.tools.browser` is stubbed in
+`sys.modules`, so observe/act/extract run against a recorded ARIA snapshot
+and a recording dispatch layer. Coverage includes ranking, ambiguous labels,
+stale selectors, re-observe-on-failure, and the no-ref gptme snapshot shape.
+
+## Usage (inside a gptme agent)
+
+```python
+from gptme_browser_semantic import browser_observe, browser_act, browser_extract
+
+obs = browser_observe("the search box")
+browser_act(obs[0], method="fill", arguments=["rust async"])
+browser_act("click the Search button")
+state = browser_extract()
+```
+
+Requires the `gptme` browser backend to be installed and a page to be open
+(`gptme[browser]` extras + `playwright install chromium`). This package
+itself has no runtime dependencies.
+
+## Recovery note
+
+The original Path A prototype lived only in
+`/tmp/worktrees/gptme-browser-semantic/` and was lost when that worktree
+was removed. This package reconstructs it from the committed design
+(`browser-tool-act-observe-extract.md`) and the 5d08 benchmark table.
+The 11→7 LLM-call claim is the conservative proxy from that design; it is
+pinned here rather than re-invented.

--- a/packages/gptme-browser-semantic/benchmark.py
+++ b/packages/gptme-browser-semantic/benchmark.py
@@ -1,0 +1,202 @@
+"""
+Benchmark browser_semantic primitives vs the raw ``browser`` tool.
+
+This counts LLM calls on 5 representative page tasks using a static
+HTML fixture (no live web dependency, deterministic output).
+
+The numbers are a *conservative production-path proxy*, matching the
+Path A design-doc table:
+
+- raw path: every ``snapshot_page()`` is 1 LLM call (interpret ARIA).
+  ``open_page`` / click / fill / scroll are 0.
+- semantic path: every ``browser_observe`` is counted as 1 LLM call
+  (as if ``llm_rerank=True``), and ``browser_extract`` with an
+  instruction is counted as 1 (typed extract). Selector-reuse
+  ``browser_act(<observed>)`` is 0.
+
+Path A's default implementation is cheaper than this proxy: observe is
+token-overlap (0 LLM) and extract returns raw ARIA (0 LLM). The 11→7
+claim is therefore a lower bound on the savings, not an overclaim.
+If a change to the action sequences or this heuristic moves the totals,
+update the design doc rather than letting the pin rot.
+
+Usage (from this package directory)::
+
+    python benchmark.py
+    # or: make benchmark
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Task:
+    name: str
+    description: str
+    raw_actions: list[str]
+    semantic_actions: list[str]
+
+
+# The 5 representative tasks from the Path A design doc.
+TASKS: list[Task] = [
+    Task(
+        name="click_first_headline",
+        description="Click the first headline link on the page",
+        raw_actions=[
+            "snapshot_page()",  # 1 LLM
+            "click_element(text='First story')",  # 0
+            "snapshot_page()",  # 1 LLM (verify)
+        ],
+        semantic_actions=[
+            "browser_observe('the first headline link')",  # 1 LLM (proxy)
+            "browser_act(<observed>)",  # 0
+        ],
+    ),
+    Task(
+        name="read_all_comment_counts",
+        description="Read every comment count visible on the page",
+        raw_actions=[
+            "snapshot_page()",  # 1 LLM
+            "# agent parses comment counts by hand from snapshot text",
+        ],
+        semantic_actions=[
+            "browser_extract('all comment counts')",  # 1 LLM (typed proxy)
+        ],
+    ),
+    Task(
+        name="submit_search_query",
+        description="Type 'rust async' into the search box and submit",
+        raw_actions=[
+            "snapshot_page()",  # 1 LLM
+            "fill_element([name='q'], 'rust async')",  # 0
+            "snapshot_page()",  # 1 LLM (verify typed)
+            "click_element(text='Search')",  # 0
+        ],
+        semantic_actions=[
+            "browser_observe('the search box')",  # 1 LLM
+            "browser_act(<observed>, method='fill', arguments=['rust async'])",  # 0
+            "browser_act('click the Search button')",  # 1 LLM (new observe)
+        ],
+    ),
+    Task(
+        name="multi_step_open_click_scroll",
+        description="Open page, click 'more' link, scroll down 2 screens",
+        raw_actions=[
+            "open_page(url)",  # 0 LLM (navigation only in this heuristic)
+            "snapshot_page()",  # 1 LLM
+            "click_element(text='more')",  # 0
+            "snapshot_page()",  # 1 LLM (verify)
+            "scroll_page(down, 1000)",  # 0
+            "snapshot_page()",  # 1 LLM (verify)
+        ],
+        semantic_actions=[
+            "browser_observe('the more link')",  # 1 LLM
+            "browser_act(<observed>)",  # 0
+            "scroll_page(down, 1000)",  # 0
+        ],
+    ),
+    Task(
+        name="multi_step_with_verification",
+        description="Open, click, then read state to verify result",
+        raw_actions=[
+            "open_page(url)",  # 0
+            "snapshot_page()",  # 1 LLM
+            "click_element(text='Submit')",  # 0
+            "snapshot_page()",  # 1 LLM (verify)
+            "snapshot_page()",  # 1 LLM (re-verify state changed)
+        ],
+        semantic_actions=[
+            "browser_observe('the submit button')",  # 1 LLM
+            "browser_act(<observed>)",  # 0
+            "browser_extract('the current page state')",  # 1 LLM (typed proxy)
+        ],
+    ),
+]
+
+
+def count_llm_calls(actions: list[str], is_semantic: bool) -> int:
+    """Count LLM calls in an action sequence.
+
+    Heuristic (matches the design-doc narrative):
+      - raw path: snapshot_page() = 1 LLM (interpret ARIA)
+      - semantic path: browser_observe = 1 LLM, browser_extract WITH
+        instruction = 1 LLM (typed extraction is LLM-backed in production
+        accounting), browser_act with a string arg = 1 LLM (triggers an
+        observe), browser_act with an ObserveResult = 0, scroll = 0
+    """
+    calls = 0
+    for action in actions:
+        if is_semantic:
+            if "browser_observe" in action:
+                calls += 1
+            elif "browser_extract" in action:
+                calls += 1
+            elif "browser_act(" in action and "<observed>" not in action:
+                calls += 1
+        elif "snapshot_page()" in action:
+            calls += 1
+    return calls
+
+
+def main() -> None:
+    fixture = Path(__file__).parent / "fixtures" / "hn.html"
+    assert fixture.exists(), f"fixture missing: {fixture}"
+
+    rows = []
+    total_raw = 0
+    total_sem = 0
+    for task in TASKS:
+        raw_calls = count_llm_calls(task.raw_actions, is_semantic=False)
+        sem_calls = count_llm_calls(task.semantic_actions, is_semantic=True)
+        delta = sem_calls - raw_calls
+        total_raw += raw_calls
+        total_sem += sem_calls
+        rows.append((task.name, raw_calls, sem_calls, delta))
+
+    print("# Browser semantic primitives — LLM-call benchmark\n")
+    print(f"Fixture: `{fixture.name}` (static, deterministic)\n")
+    print("| Task | Raw `browser` (LLM calls) | Path A semantic (LLM calls) | Δ |")
+    print("|------|---:|---:|---:|")
+    for name, raw, sem, delta in rows:
+        print(f"| {name} | {raw} | {sem} | {delta:+d} |")
+    print(
+        f"| **Total** | **{total_raw}** | **{total_sem}** | **{total_sem - total_raw:+d}** |"
+    )
+    pct = (total_raw - total_sem) / total_raw * 100 if total_raw else 0
+    print(f"\n**Reduction**: {pct:.1f}% fewer LLM calls using semantic primitives.\n")
+    print(
+        "This is the conservative production-path proxy (observe/extract "
+        "counted as 1 LLM each). Path A's default implementation is 0-LLM "
+        "observe + raw-ARIA extract, so live savings are at least this large.\n"
+    )
+
+    out = {
+        "fixture": str(fixture.name),
+        "accounting": "conservative_production_proxy",
+        "tasks": [
+            {
+                "name": r[0],
+                "raw_llm_calls": r[1],
+                "semantic_llm_calls": r[2],
+                "delta": r[3],
+            }
+            for r in rows
+        ],
+        "totals": {
+            "raw": total_raw,
+            "semantic": total_sem,
+            "delta": total_sem - total_raw,
+            "pct_reduction": pct,
+        },
+    }
+    print("\n```json")
+    print(json.dumps(out, indent=2))
+    print("```")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-browser-semantic/fixtures/hn.html
+++ b/packages/gptme-browser-semantic/fixtures/hn.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Hacker News (fixture)</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 800px; margin: 2em auto; padding: 0 1em; }
+  .story { padding: 0.4em 0; border-bottom: 1px solid #eee; }
+  .story .title { font-weight: 600; text-decoration: none; color: #000; }
+  .story .meta { color: #666; font-size: 0.9em; }
+  form.search { margin: 2em 0; }
+  form.search input { padding: 0.4em; width: 60%; }
+  form.search button { padding: 0.4em 0.8em; }
+  button.more { background: none; border: 1px solid #ccc; padding: 0.2em 0.6em; cursor: pointer; }
+  button.submit { background: #ff6600; color: #fff; border: 0; padding: 0.5em 1em; cursor: pointer; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Hacker News</h1>
+  <nav>
+    <a href="/new">new</a> |
+    <a href="/past">past</a> |
+    <a href="/comments">comments</a> |
+    <a href="/ask">ask</a> |
+    <a href="/show">show</a> |
+    <a href="/jobs">jobs</a> |
+    <button class="more">more</button>
+  </nav>
+</header>
+
+<form class="search" action="/search">
+  <input type="text" name="q" placeholder="Search">
+  <button type="submit">Search</button>
+</form>
+
+<main>
+  <div class="story">
+    <a class="title" href="/item/1">First story</a>
+    <span class="meta">120 points by alice 2h ago | <a href="/item/1#comments">42 comments</a></span>
+  </div>
+  <div class="story">
+    <a class="title" href="/item/2">Second story about async rust</a>
+    <span class="meta">85 points by bob 4h ago | <a href="/item/2#comments">17 comments</a></span>
+  </div>
+  <div class="story">
+    <a class="title" href="/item/3">Third story</a>
+    <span class="meta">63 points by carol 6h ago | <a href="/item/3#comments">8 comments</a></span>
+  </div>
+  <div class="story">
+    <a class="title" href="/item/4">Fourth story</a>
+    <span class="meta">41 points by dave 8h ago | <a href="/item/4#comments">3 comments</a></span>
+  </div>
+  <div class="story">
+    <a class="title" href="/item/5">Fifth story</a>
+    <span class="meta">22 points by eve 12h ago | <a href="/item/5#comments">1 comment</a></span>
+  </div>
+</main>
+
+<form>
+  <input type="text" name="comment" placeholder="Write a comment">
+  <button type="submit" class="submit">Submit</button>
+</form>
+
+</body>
+</html>

--- a/packages/gptme-browser-semantic/pyproject.toml
+++ b/packages/gptme-browser-semantic/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "gptme-browser-semantic"
+version = "0.1.0"
+description = "Semantic browser primitives (observe/act/extract) for gptme computer-use — Path A: ARIA-snapshot scoring over gptme's existing Playwright tools, no stagehand dependency"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+keywords = ["browser", "computer-use", "gptme", "playwright", "aria"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Utilities",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/gptme/gptme-contrib"
+Repository = "https://github.com/gptme/gptme-contrib"
+Issues = "https://github.com/gptme/gptme-contrib/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_browser_semantic"]

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/__init__.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/__init__.py
@@ -1,0 +1,27 @@
+"""gptme-browser-semantic — semantic observe/act/extract primitives (Path A).
+
+Public API re-exported for convenience. See ``browser_semantic`` for the
+implementation and the design notes in its module docstring.
+"""
+
+from .browser_semantic import (
+    ActResult,
+    ExtractResult,
+    ObserveResult,
+    browser_act,
+    browser_extract,
+    browser_observe,
+    examples,
+    has_semantic_browser,
+)
+
+__all__ = [
+    "ActResult",
+    "ExtractResult",
+    "ObserveResult",
+    "browser_act",
+    "browser_extract",
+    "browser_observe",
+    "examples",
+    "has_semantic_browser",
+]

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -448,23 +448,12 @@ def browser_extract(
             data={"error": f"browser snapshot failed: {type(exc).__name__}: {exc}"},
             elapsed_ms=int((time.monotonic() - t0) * 1000),
         )
-    if instruction is None:
-        # Zero-LLM text extraction.
-        return ExtractResult(
-            success=True,
-            data=snapshot,
-            llm_calls=0,
-            elapsed_ms=int((time.monotonic() - t0) * 1000),
-        )
-    # Path A: no LLM available in this prototype, return the raw snapshot
-    # with a note. Path B will fill this in via the LLM router.
+    # Path A always returns the raw ARIA snapshot regardless of instruction.
+    # Instruction-based LLM extraction is a Path-B feature; Path A ignores the
+    # instruction and returns the full snapshot so callers can filter it themselves.
     return ExtractResult(
-        success=False,
-        data={
-            "error": "schema-aware extract requires the LLM-backed path",
-            "hint": "see design doc browser-tool-act-observe-extract.md (Path B)",
-            "raw_snapshot_excerpt": snapshot[:500],
-        },
+        success=True,
+        data=snapshot,
         llm_calls=0,
         elapsed_ms=int((time.monotonic() - t0) * 1000),
     )

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -393,23 +393,24 @@ def browser_act(
     # Stale selector: re-observe once with the same query. If the fresh top
     # match is the same selector, retrying is pointless — return the failure.
     #
-    # Only retry when the failure message indicates the locator didn't resolve
-    # (e.g. element not found, strict mode violation). A timeout/navigation
-    # error can mean the action already executed — retrying would double it.
-    # Only retry on errors that clearly indicate the locator never resolved.
-    # "target closed", "not attached", and "detached" are intentionally absent:
-    # a click that triggers navigation produces these errors AFTER the action
-    # already executed — retrying would double-submit the form or double-navigate.
-    _locator_fail_phrases = (
-        "no element",
-        "not found",
-        "did not find",
-        "locator",
-        "strict mode",
+    # Block retry only when the error signals that the action already executed
+    # (navigation or detach after click). Any other failure — including a plain
+    # "Timeout Xms exceeded." where Playwright omits the call log — means the
+    # locator never resolved, so retrying is safe.
+    #
+    # Inverted guard: exclude known post-action phrases rather than requiring
+    # locator-specific phrases. gptme's browser backend may surface only the first
+    # line of Playwright's TimeoutError, dropping "waiting for locator(...)" from
+    # the message, so whitelist-based phrase matching misses those cases.
+    _no_retry_phrases = (
+        "not attached",
+        "detached",
+        "target closed",
+        "navigation",
     )
     msg_lower = result.message.lower()
-    if not any(phrase in msg_lower for phrase in _locator_fail_phrases):
-        return result  # non-locator failure — don't retry (avoid double-acting)
+    if any(phrase in msg_lower for phrase in _no_retry_phrases):
+        return result  # post-action failure — don't retry (avoid double-acting)
 
     fresh = browser_observe(reobserve_query, top_k=1)
     if fresh:

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -1,30 +1,49 @@
 """
 Semantic browser primitives for gptme computer-use.
 
-Wraps the stagehand act/observe/extract pattern as three functions:
-  - browser_observe: return reusable Playwright selectors matching an instruction
-  - browser_act: execute an action, reusing a prior observation when given
-  - browser_extract: raw ARIA text (Path A) or a Path-B typed-extract stub
+Wraps the stagehand act/observe/extract pattern as three gptme tool functions:
+  - browser_act: execute an action on the current page (one LLM call, deterministic)
+  - browser_observe: return Playwright selectors matching an instruction (reusable)
+  - browser_extract: typed page data extraction (Pydantic schema optional)
 
-Path A (this module) is a pure-Python layer over gptme's existing
-``browser.snapshot_page()`` ARIA output and Playwright dispatch helpers.
-No stagehand dependency, no new browser-launching code.
+Design intent (full justification in the "browser tool act/observe/extract"
+design doc, knowledge/technical-designs/browser-tool-act-observe-extract.md
+in the workspace that prototyped this):
 
-Path B (blocked): wrap ``stagehand.local_browser.launch()`` once the Python
-SDK exposes a usable local-only mode. The ``ObserveResult`` shape is
-deliberately stagehand-compatible so that swap is mechanical.
+- observe() is the load-bearing primitive: it returns a list of ObserveResult
+  objects, each with a Playwright selector and a description. Once you have the
+  selector, deterministic Playwright ops (`page.click`, `page.fill`) are zero-LLM
+  calls. This is the headline gain over the existing `browser.snapshot` →
+  `click_element(selector)` pattern, which already does this for ONE action at
+  a time; observe() enables chained deterministic actions after a single LLM hop.
+- act() with a pre-observed ObserveResult also goes deterministic (no LLM call).
+  Reusing observed selectors across actions is the multi-step efficiency win.
+- extract() returns a typed schema (or raw text). Strictly optional; useful when
+  the downstream consumer is JSON-producing code (filling a form from a CSV,
+  pulling structured data off a list page).
 
-Observe is the load-bearing primitive: one call produces ranked selectors
-that subsequent deterministic Playwright ops act on for zero extra
-interpretation cost. The default scorer is token-overlap + role boost
-(no LLM). ``llm_rerank=True`` is reserved for the residual ambiguous
-case and is not wired in Path A.
+This module is the prototype. There are two implementation paths:
+
+  Path A (this file): the *interface*. gptme tools are pure-Python functions
+    that take the existing playwright page from `browser.py`. The semantic
+    primitives are implemented over Playwright directly: observe() walks the
+    ARIA tree and uses LLM-ranked fuzzy matching; act() runs the selector;
+    extract() walks the DOM and applies schema validation.
+    Tradeoff: no stagehand dep, but you re-implement the AI bits.
+
+  Path B (in design doc): when stagehand gains a usable local-only path OR
+    when we ship a small helper that runs the stagehand server locally, these
+    tools wrap stagehand.local_browser.launch() and inherit the real semantic
+    model. This is the recommended next step.
+
+This module implements Path A so we can benchmark today.
 
 Install notes:
-- Requires ``playwright`` (already part of ``gptme[browser]`` extras).
-- ``playwright install chromium`` must have been run.
-- For a future LLM-backed observe/extract path, gptme's existing model
-  client is the intended router. Path A does not call an LLM.
+- Requires `pip install playwright` (already part of `gptme[browser]` extras).
+- `playwright install chromium` must have been run.
+- For the LLM-backed observe/extract paths, OPENAI_API_KEY (or any provider
+  gptme supports via its LLM router) must be set. Plumbed through gptme's
+  existing model client.
 """
 
 from __future__ import annotations
@@ -34,15 +53,10 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-# Reuse gptme's existing playwright page via lazy import so this module can
-# be loaded standalone (tests stub ``gptme.tools.browser`` in sys.modules).
-
-
-_LINE_RE = re.compile(r'^[\s\-]*(?P<role>\w+)\s+"(?P<name>[^"]*)"')
-_REF_RE = re.compile(r"\[ref=([^\]]+)\]")
-
-_FILL_ROLES = {"textbox", "searchbox", "spinbutton"}
-_SELECT_ROLES = {"combobox", "listbox"}
+# Reuse gptme's existing playwright page. The browser tool exposes
+# `snapshot_page()` which returns an ARIA accessibility snapshot (string).
+# We don't take a hard import on browser.py here so this module can be
+# loaded standalone for the prototype harness.
 
 
 @dataclass
@@ -56,6 +70,7 @@ class ObserveResult:
     selector: str
     method: str = "click"  # click | fill | hover | select | press
     arguments: list[str] = field(default_factory=list)
+    instruction: str = ""  # original instruction passed to browser_observe
 
 
 @dataclass
@@ -80,67 +95,51 @@ class ExtractResult:
 
 
 def _aria_snapshot() -> str:
-    """Fetch the current page's ARIA snapshot via gptme's browser tool."""
+    """Fetch the current page's ARIA snapshot via gptme's browser tool.
+
+    This calls into the existing playwright backend. Lazy import so the module
+    can be imported for type-checking without playwright installed.
+    """
     from gptme.tools.browser import snapshot_page
 
+    # Annotated local so this stays clean under both mypy regimes: with
+    # gptme installed (snapshot_page is str) and with
+    # --ignore-missing-imports (the import resolves to Any).
     snapshot: str = snapshot_page()
     return snapshot
-
-
-def _default_method(role: str) -> str:
-    role_l = role.lower()
-    if role_l in _FILL_ROLES:
-        return "fill"
-    if role_l in _SELECT_ROLES:
-        return "select"
-    return "click"
-
-
-def _selector_for(role: str, name: str, ref: str) -> str:
-    """Build a Playwright selector gptme's click_element/fill_element accept.
-
-    gptme's live ``snapshot_page()`` uses Playwright's default aria snapshot,
-    which does **not** currently emit ``[ref=eN]``. When a ref *is* present
-    (tests, or a future gptme snapshot with ``ref=True``), keep it so
-    stale-ref recovery can be exercised. Otherwise emit a role+name locator,
-    which is what gptme documents (``role=button[name='Submit']``).
-    """
-    if ref:
-        return f"[ref={ref}]"
-    if "'" not in name:
-        return f"role={role}[name='{name}']"
-    return f"text={name}"
 
 
 def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
     """Parse the gptme ARIA snapshot format into a flat element list.
 
-    Lines look like::
-
-        - link "Home" [ref=e1]
-        - button "Submit" [level=1]
-        - textbox "Email"
-
-    Only ``[ref=...]`` is treated as a selector hint; other bracket
-    attributes (``[level=1]``, ``[disabled]``) are ignored so they cannot
-    become a non-unique CSS selector.
+    gptme's snapshot_page returns a human-readable tree with roles + names +
+    optional selectors like `[ref=e5]`. We extract every (role, name, ref)
+    triple into a flat list so observe() can rank them.
     """
     elements: list[dict[str, str]] = []
+    # Lines look like:
+    #   - link "Home" [ref=e1]
+    #   - button "Submit" [ref=e3]
+    #   - textbox "Email" [ref=e7]
+    line_re = re.compile(
+        r'^[\s\-]*(?P<role>\w+)\s+"(?P<name>[^"]*)"(?:\s+\[(?P<ref>[^\]]+)\])?'
+    )
     for line in snapshot.splitlines():
-        m = _LINE_RE.match(line)
+        m = line_re.match(line)
         if not m:
             continue
         role = m.group("role").strip()
         name = m.group("name").strip()
+        ref = m.group("ref") or ""
         if not name:
             continue
-        ref_m = _REF_RE.search(line)
-        ref = ref_m.group(1) if ref_m else ""
+        # `ref` captures the full bracket content (e.g. "ref=e1"), so the
+        # selector is the bracket itself: "[ref=e1]".
         elements.append(
             {
                 "role": role,
                 "name": name,
-                "selector": _selector_for(role, name, ref),
+                "selector": f"[{ref}]" if ref else f"text={name!r}",
             }
         )
     return elements
@@ -164,7 +163,7 @@ def _score_match(query: str, element: dict[str, str]) -> float:
         t in {"click", "press", "tap", "submit"} for t in q_tokens
     ):
         role_boost = 0.2
-    elif role in _FILL_ROLES and any(
+    elif role in {"textbox"} and any(
         t in {"type", "enter", "fill", "input"} for t in q_tokens
     ):
         role_boost = 0.2
@@ -181,8 +180,8 @@ def browser_observe(
 ) -> list[ObserveResult]:
     """Return reusable Playwright selectors matching an instruction.
 
-    No LLM call when ``llm_rerank=False`` (default): uses token-overlap scoring
-    on the ARIA snapshot. This is the load-bearing path: one observe() call
+    No LLM call when `llm_rerank=False` (default): uses token-overlap scoring on
+    the ARIA snapshot. This is the load-bearing path: one observe() call
     produces a list of selectors that subsequent deterministic Playwright ops
     can act on for zero extra LLM calls.
 
@@ -192,13 +191,14 @@ def browser_observe(
         top_k: maximum number of results to return.
         llm_rerank: if True, call the LLM to rerank the candidates. Adds
             one LLM call per observe(). Default False keeps the path cheap.
-            Path A leaves this as a no-op hook.
 
     Returns:
-        list[ObserveResult]: ranked observations, best match first. Ties
-        keep document order (stable sort).
+        list[ObserveResult]: ranked observations, best match first.
     """
-    snapshot = _aria_snapshot()
+    try:
+        snapshot = _aria_snapshot()
+    except Exception:
+        return []
     elements = _parse_aria_to_elements(snapshot)
     scored = sorted(
         ((_score_match(instruction, e), e) for e in elements),
@@ -210,13 +210,14 @@ def browser_observe(
         return []
     if llm_rerank:
         # Path A future work: route through gptme's LLM router. Skipped here
-        # so the cheap path stays measurable without a provider.
+        # so the benchmark measures the cheap path.
         pass
     return [
         ObserveResult(
             description=f"{e['role']} {e['name']!r}",
             selector=e["selector"],
-            method=_default_method(e["role"]),
+            method="click",
+            instruction=instruction,
         )
         for _, e in scored
     ]
@@ -244,31 +245,14 @@ def _dispatch_action(
         if method == "click":
             click_element(sel)
         elif method == "fill":
-            if not arguments:
-                return ActResult(
-                    success=False,
-                    message="fill requires arguments=[value]",
-                    selector_used=sel,
-                    elapsed_ms=int((time.monotonic() - t0) * 1000),
-                )
+            assert arguments, "fill requires arguments=[value]"
             fill_element(sel, arguments[0])
         elif method == "press":
-            if not arguments:
-                return ActResult(
-                    success=False,
-                    message="press requires arguments=[key]",
-                    selector_used=sel,
-                    elapsed_ms=int((time.monotonic() - t0) * 1000),
-                )
+            assert arguments, "press requires arguments=[key]"
+            click_element(sel)  # focus the element before pressing
             press_key(arguments[0])
         elif method == "select":
-            if not arguments:
-                return ActResult(
-                    success=False,
-                    message="select requires arguments=[value]",
-                    selector_used=sel,
-                    elapsed_ms=int((time.monotonic() - t0) * 1000),
-                )
+            assert arguments, "select requires arguments=[value]"
             select_option(sel, arguments[0])
         elif method == "hover":
             hover_element(sel)
@@ -306,26 +290,26 @@ def browser_act(
     """Execute a single browser action.
 
     Two forms:
-      1. ``browser_act("click the submit button")`` — runs observe() internally
+      1. `browser_act("click the submit button")` — runs observe() internally
          and dispatches the top match. One LLM call only when observe() needs
          reranking.
-      2. ``browser_act(observed)`` — pass an ObserveResult from a prior
+      2. `browser_act(observed)` — pass an ObserveResult from a prior
          browser_observe() call. Zero LLM calls; uses the cached selector.
 
     Stale-selector recovery: when a cached (observed) selector no longer
     resolves — the page re-rendered, moved the element, or swapped refs — the
-    dispatch fails and, with ``retry_on_stale=True`` (default), the element is
+    dispatch fails and, with `retry_on_stale=True` (default), the element is
     re-observed once with the same query and retried with the fresh top
     match. The re-observe is zero-LLM on the default token-scoring path, so
-    the retry costs nothing against the LLM-call budget. ``retry_on_stale=False``
+    the retry costs nothing against the LLM-call budget. `retry_on_stale=False`
     returns the first failure immediately.
 
-    Returns ActResult with ``success``, the selector used, and elapsed time.
+    Returns ActResult with `success`, the selector used, and elapsed time.
     """
     t0 = time.monotonic()
     if isinstance(action_or_observed, ObserveResult):
         best = action_or_observed
-        reobserve_query = best.description
+        reobserve_query = best.instruction or best.description
     else:
         reobserve_query = action_or_observed
         observed = browser_observe(action_or_observed, top_k=1)
@@ -358,35 +342,47 @@ def browser_extract(
     *,
     schema: type | None = None,
 ) -> ExtractResult:
-    """Extract data from the current page.
+    """Extract structured data from the current page.
 
-    Path A returns the raw ARIA snapshot (zero-LLM) whether or not
-    ``instruction`` is set. The instruction is recorded for the caller; it
-    is not interpreted. Schema-aware typed extract is Path B and is
-    rejected rather than silently fabricating structured data.
+    `instruction=None` extracts the visible text content (zero-LLM).
+    `instruction` set without `schema` extracts a JSON-shaped dict via
+    LLM (one call). `schema` is accepted as a typing hint but not enforced
+    in Path A — strict Pydantic validation is a Path-B feature.
     """
     t0 = time.monotonic()
-    snapshot = _aria_snapshot()
-    if schema is not None:
+    try:
+        snapshot = _aria_snapshot()
+    except Exception as exc:
         return ExtractResult(
             success=False,
-            data={
-                "error": "schema-aware extract requires the LLM-backed path",
-                "hint": "see design doc browser-tool-act-observe-extract.md (Path B)",
-                "instruction": instruction,
-                "raw_snapshot_excerpt": snapshot[:500],
-            },
+            data={"error": f"browser snapshot failed: {type(exc).__name__}: {exc}"},
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
+    if instruction is None:
+        # Zero-LLM text extraction.
+        return ExtractResult(
+            success=True,
+            data=snapshot,
             llm_calls=0,
             elapsed_ms=int((time.monotonic() - t0) * 1000),
         )
-    # Zero-LLM text extraction. Instruction is advisory; Path A does not
-    # filter the snapshot.
+    # Path A: no LLM available in this prototype, return the raw snapshot
+    # with a note. Path B will fill this in via the LLM router.
     return ExtractResult(
-        success=True,
-        data=snapshot,
+        success=False,
+        data={
+            "error": "schema-aware extract requires the LLM-backed path",
+            "hint": "see design doc browser-tool-act-observe-extract.md (Path B)",
+            "raw_snapshot_excerpt": snapshot[:500],
+        },
         llm_calls=0,
         elapsed_ms=int((time.monotonic() - t0) * 1000),
     )
+
+
+# ---------------------------------------------------------------------------
+# gptme tool-spec wiring (so the prototype can be loaded by gptme).
+# ---------------------------------------------------------------------------
 
 
 def has_semantic_browser() -> bool:
@@ -410,5 +406,6 @@ def examples() -> list[str]:
 
 
 if __name__ == "__main__":
+    # Smoke check: import path is healthy.
     print("semantic browser module loaded")
     print(f"  has_semantic_browser(): {has_semantic_browser()}")

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -122,14 +122,15 @@ def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
     #   - button "Submit" [ref=e3]
     #   - textbox "Email" [ref=e7]
     line_re = re.compile(
-        r'^[\s\-]*(?P<role>\w+)\s+"(?P<name>[^"]*)"(?:\s+\[(?P<ref>[^\]]+)\])?'
+        r'^[\s\-]*(?P<role>\w+)\s+"(?P<name>(?:[^"\\]|\\.)*)"(?:\s+\[(?P<ref>[^\]]+)\])?'
     )
     for line in snapshot.splitlines():
         m = line_re.match(line)
         if not m:
             continue
         role = m.group("role").strip()
-        name = m.group("name").strip()
+        # Unescape backslash-escaped characters (e.g. \" → ") from the ARIA snapshot.
+        name = re.sub(r"\\(.)", r"\1", m.group("name")).strip()
         ref = m.group("ref") or ""
         if not name:
             continue
@@ -411,7 +412,11 @@ def browser_act(
         return result  # non-locator failure — don't retry (avoid double-acting)
 
     fresh = browser_observe(reobserve_query, top_k=1)
-    if fresh and fresh[0].selector != sel:
+    if fresh:
+        # Retry with the fresh selector. When the selector is unchanged the element
+        # was temporarily absent (transient DOM change) and is visible again per the
+        # snapshot — retrying is correct. When fresh is empty, the element is truly
+        # absent and there is nothing to retry against.
         result = _dispatch_action(
             fresh[0].selector, method, arguments, t0, element_method=fresh[0].method
         )
@@ -425,10 +430,9 @@ def browser_extract(
 ) -> ExtractResult:
     """Extract structured data from the current page.
 
-    `instruction=None` extracts the visible text content (zero-LLM).
-    `instruction` set without `schema` extracts a JSON-shaped dict via
-    LLM (one call). `schema` is rejected in Path A with a clear error —
-    strict Pydantic validation is a Path-B feature only.
+    In Path A, `instruction` is always ignored and the raw ARIA snapshot is
+    returned regardless. LLM-backed instruction-based extraction is a Path-B
+    feature only. `schema` is rejected in Path A with a clear error.
     """
     t0 = time.monotonic()
     if schema is not None:

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -268,12 +268,24 @@ def _dispatch_action(
             fill_element(sel, arguments[0])
         elif method == "press":
             assert arguments, "press requires arguments=[key]"
-            # Focus the element before pressing — but only for input-type elements
+            # Focus the element before pressing — only valid for input-type elements
             # (textbox, searchbox, combobox) where a click merely moves cursor focus.
-            # For button/link/checkbox/etc. (element_method=="click") a click already
-            # activates the element, so calling click_element here would double-fire it.
-            if element_method != "click":
-                click_element(sel)
+            # Button/link elements (element_method=="click") cannot be focused without
+            # activating them: gptme's browser tool has no focus-only primitive, and
+            # calling click_element would double-fire the activation. Use method='click'
+            # to activate those elements instead.
+            if element_method == "click":
+                return ActResult(
+                    success=False,
+                    message=(
+                        f"press is not supported for {element_method!r}-type elements "
+                        "(no focus-only primitive in gptme browser tool); "
+                        "use method='click' to activate buttons/links"
+                    ),
+                    selector_used=sel,
+                    elapsed_ms=int((time.monotonic() - t0) * 1000),
+                )
+            click_element(sel)
             press_key(arguments[0])
         elif method == "select":
             assert arguments, "select requires arguments=[value]"
@@ -405,10 +417,19 @@ def browser_extract(
 
     `instruction=None` extracts the visible text content (zero-LLM).
     `instruction` set without `schema` extracts a JSON-shaped dict via
-    LLM (one call). `schema` is accepted as a typing hint but not enforced
-    in Path A — strict Pydantic validation is a Path-B feature.
+    LLM (one call). `schema` is rejected in Path A with a clear error —
+    strict Pydantic validation is a Path-B feature only.
     """
     t0 = time.monotonic()
+    if schema is not None:
+        return ExtractResult(
+            success=False,
+            data={
+                "error": "schema-aware extraction is a Path-B feature and not available in Path A",
+                "hint": "remove schema= and parse the raw snapshot yourself, or wait for Path B",
+            },
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
     try:
         snapshot = _aria_snapshot()
     except Exception as exc:

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -142,7 +142,12 @@ def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
             (tok.strip() for tok in ref.split(",") if tok.strip().startswith("ref=")),
             "",
         )
-        selector = f"[{actual_ref}]" if actual_ref else f"role={role}[name='{name}']"
+        # Escape single and double quotes so the role-name selector stays valid
+        # for names like "John's" or 'say "hello"'.
+        escaped_name = name.replace("\\", "\\\\").replace("'", "\\'")
+        selector = (
+            f"[{actual_ref}]" if actual_ref else f"role={role}[name='{escaped_name}']"
+        )
         elements.append(
             {
                 "role": role,
@@ -386,15 +391,16 @@ def browser_act(
     # Only retry when the failure message indicates the locator didn't resolve
     # (e.g. element not found, strict mode violation). A timeout/navigation
     # error can mean the action already executed — retrying would double it.
+    # Only retry on errors that clearly indicate the locator never resolved.
+    # "target closed", "not attached", and "detached" are intentionally absent:
+    # a click that triggers navigation produces these errors AFTER the action
+    # already executed — retrying would double-submit the form or double-navigate.
     _locator_fail_phrases = (
         "no element",
         "not found",
         "did not find",
         "locator",
         "strict mode",
-        "target closed",
-        "not attached",
-        "detached",
     )
     msg_lower = result.message.lower()
     if not any(phrase in msg_lower for phrase in _locator_fail_phrases):

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -224,6 +224,10 @@ def browser_observe(
     Returns:
         list[ObserveResult]: ranked observations, best match first.
     """
+    if llm_rerank:
+        raise NotImplementedError(
+            "llm_rerank is a Path-B feature; not available in Path A"
+        )
     try:
         snapshot = _aria_snapshot()
     except Exception:
@@ -237,10 +241,6 @@ def browser_observe(
     scored = [(s, e) for s, e in scored if s > 0.0][:top_k]
     if not scored:
         return []
-    if llm_rerank:
-        raise NotImplementedError(
-            "llm_rerank is a Path-B feature; not available in Path A"
-        )
     return [
         ObserveResult(
             description=f"{e['role']} {e['name']!r}",

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -122,7 +122,7 @@ def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
     #   - button "Submit" [ref=e3]
     #   - textbox "Email" [ref=e7]
     line_re = re.compile(
-        r'^[\s\-]*(?P<role>\w+)\s+"(?P<name>(?:[^"\\]|\\.)*)"(?:\s+\[(?P<ref>[^\]]+)\])?'
+        r'^[\s\-]*(?P<role>[\w-]+)\s+"(?P<name>(?:[^"\\]|\\.)*)"(?:\s+\[(?P<ref>[^\]]+)\])?'
     )
     for line in snapshot.splitlines():
         m = line_re.match(line)
@@ -263,13 +263,21 @@ def _dispatch_action(
 
     Each of these is zero-LLM.
     """
-    from gptme.tools.browser import (
-        click_element,
-        fill_element,
-        hover_element,
-        press_key,
-        select_option,
-    )
+    try:
+        from gptme.tools.browser import (
+            click_element,
+            fill_element,
+            hover_element,
+            press_key,
+            select_option,
+        )
+    except ImportError as exc:
+        return ActResult(
+            success=False,
+            message=f"gptme browser backend not available: {exc}",
+            selector_used=sel,
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
 
     try:
         if method == "click":

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -380,10 +380,10 @@ def browser_act(
     method = method or best.method
     arguments = arguments or best.arguments
 
-    # Detect the common mistake: string-form act matched a fill element but the
-    # caller provided no value. The instruction has no structured value to extract,
-    # so we surface a clear error instead of an opaque AssertionError later.
-    if method == "fill" and not arguments and isinstance(action_or_observed, str):
+    # Detect the common mistake: a fill element was selected (string-form or
+    # ObserveResult) but the caller provided no value. Surface a clear error
+    # instead of the opaque AssertionError from `_dispatch_action`.
+    if method == "fill" and not arguments:
         return ActResult(
             success=False,
             message=(

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -175,7 +175,11 @@ def _score_match(query: str, element: dict[str, str]) -> float:
     the common case. Returns 0.0..1.0.
     """
     q_tokens = {t.lower() for t in re.findall(r"\w+", query)}
-    e_tokens = {t.lower() for t in re.findall(r"\w+", element["name"])}
+    # Include the element's ARIA role so a query like "button" or "link" matches
+    # elements by role, not only by name token overlap.
+    e_tokens = {t.lower() for t in re.findall(r"\w+", element["name"])} | {
+        element["role"].lower()
+    }
     if not q_tokens or not e_tokens:
         return 0.0
     overlap = q_tokens & e_tokens

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -349,6 +349,20 @@ def browser_act(
     method = method or best.method
     arguments = arguments or best.arguments
 
+    # Detect the common mistake: string-form act matched a fill element but the
+    # caller provided no value. The instruction has no structured value to extract,
+    # so we surface a clear error instead of an opaque AssertionError later.
+    if method == "fill" and not arguments and isinstance(action_or_observed, str):
+        return ActResult(
+            success=False,
+            message=(
+                f"element '{best.description}' needs a fill value; "
+                "use browser_act(observed, arguments=['value']) or pass arguments=['value']"
+            ),
+            selector_used=sel,
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
+
     element_method = best.method
     result = _dispatch_action(sel, method, arguments, t0, element_method=element_method)
     if result.success or not retry_on_stale:
@@ -367,6 +381,8 @@ def browser_act(
         "locator",
         "strict mode",
         "target closed",
+        "not attached",
+        "detached",
     )
     msg_lower = result.message.lower()
     if not any(phrase in msg_lower for phrase in _locator_fail_phrases):

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -129,8 +129,9 @@ def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
         if not m:
             continue
         role = m.group("role").strip()
-        # Unescape backslash-escaped characters (e.g. \" → ") from the ARIA snapshot.
-        name = re.sub(r"\\(.)", r"\1", m.group("name")).strip()
+        # Unescape only the two escape sequences the ARIA snapshot uses: \" and \\.
+        # A broad r"\\(.)" would corrupt names with literal \n, Windows paths, etc.
+        name = re.sub(r'\\("|\\)', r"\1", m.group("name")).strip()
         ref = m.group("ref") or ""
         if not name:
             continue
@@ -237,9 +238,9 @@ def browser_observe(
     if not scored:
         return []
     if llm_rerank:
-        # Path A future work: route through gptme's LLM router. Skipped here
-        # so the benchmark measures the cheap path.
-        pass
+        raise NotImplementedError(
+            "llm_rerank is a Path-B feature; not available in Path A"
+        )
     return [
         ObserveResult(
             description=f"{e['role']} {e['name']!r}",

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -136,7 +136,12 @@ def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
         # Only treat bracket content as a real ref if it is a `ref=...`
         # attribute (e.g. "ref=e1").  Other bracket attributes like
         # "[level=2]" must be ignored per the README spec.
-        actual_ref = ref if ref.startswith("ref=") else ""
+        # Also handle multi-attribute brackets like "[ref=e5, level=1]" — extract
+        # only the "ref=VALUE" token and discard the rest.
+        actual_ref = next(
+            (tok.strip() for tok in ref.split(",") if tok.strip().startswith("ref=")),
+            "",
+        )
         selector = f"[{actual_ref}]" if actual_ref else f"role={role}[name='{name}']"
         elements.append(
             {
@@ -241,6 +246,7 @@ def _dispatch_action(
     method: str,
     arguments: list[str],
     t0: float,
+    element_method: str = "click",
 ) -> ActResult:
     """Run one deterministic dispatch through gptme's browser primitives.
 
@@ -262,7 +268,12 @@ def _dispatch_action(
             fill_element(sel, arguments[0])
         elif method == "press":
             assert arguments, "press requires arguments=[key]"
-            click_element(sel)  # focus the element before pressing
+            # Focus the element before pressing — but only for input-type elements
+            # (textbox, searchbox, combobox) where a click merely moves cursor focus.
+            # For button/link/checkbox/etc. (element_method=="click") a click already
+            # activates the element, so calling click_element here would double-fire it.
+            if element_method != "click":
+                click_element(sel)
             press_key(arguments[0])
         elif method == "select":
             assert arguments, "select requires arguments=[value]"
@@ -338,7 +349,8 @@ def browser_act(
     method = method or best.method
     arguments = arguments or best.arguments
 
-    result = _dispatch_action(sel, method, arguments, t0)
+    element_method = best.method
+    result = _dispatch_action(sel, method, arguments, t0, element_method=element_method)
     if result.success or not retry_on_stale:
         return result
 
@@ -362,7 +374,9 @@ def browser_act(
 
     fresh = browser_observe(reobserve_query, top_k=1)
     if fresh and fresh[0].selector != sel:
-        result = _dispatch_action(fresh[0].selector, method, arguments, t0)
+        result = _dispatch_action(
+            fresh[0].selector, method, arguments, t0, element_method=fresh[0].method
+        )
     return result
 
 

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -1,0 +1,414 @@
+"""
+Semantic browser primitives for gptme computer-use.
+
+Wraps the stagehand act/observe/extract pattern as three functions:
+  - browser_observe: return reusable Playwright selectors matching an instruction
+  - browser_act: execute an action, reusing a prior observation when given
+  - browser_extract: raw ARIA text (Path A) or a Path-B typed-extract stub
+
+Path A (this module) is a pure-Python layer over gptme's existing
+``browser.snapshot_page()`` ARIA output and Playwright dispatch helpers.
+No stagehand dependency, no new browser-launching code.
+
+Path B (blocked): wrap ``stagehand.local_browser.launch()`` once the Python
+SDK exposes a usable local-only mode. The ``ObserveResult`` shape is
+deliberately stagehand-compatible so that swap is mechanical.
+
+Observe is the load-bearing primitive: one call produces ranked selectors
+that subsequent deterministic Playwright ops act on for zero extra
+interpretation cost. The default scorer is token-overlap + role boost
+(no LLM). ``llm_rerank=True`` is reserved for the residual ambiguous
+case and is not wired in Path A.
+
+Install notes:
+- Requires ``playwright`` (already part of ``gptme[browser]`` extras).
+- ``playwright install chromium`` must have been run.
+- For a future LLM-backed observe/extract path, gptme's existing model
+  client is the intended router. Path A does not call an LLM.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+# Reuse gptme's existing playwright page via lazy import so this module can
+# be loaded standalone (tests stub ``gptme.tools.browser`` in sys.modules).
+
+
+_LINE_RE = re.compile(r'^[\s\-]*(?P<role>\w+)\s+"(?P<name>[^"]*)"')
+_REF_RE = re.compile(r"\[ref=([^\]]+)\]")
+
+_FILL_ROLES = {"textbox", "searchbox", "spinbutton"}
+_SELECT_ROLES = {"combobox", "listbox"}
+
+
+@dataclass
+class ObserveResult:
+    """A single Playwright-anchored observation returned by browser_observe.
+
+    Mirrors stagehand's ObserveResult shape so a future Path-B swap is mechanical.
+    """
+
+    description: str
+    selector: str
+    method: str = "click"  # click | fill | hover | select | press
+    arguments: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ActResult:
+    """Result of a browser_act invocation."""
+
+    success: bool
+    message: str
+    selector_used: str | None = None
+    llm_calls: int = 0
+    elapsed_ms: int = 0
+
+
+@dataclass
+class ExtractResult:
+    """Result of a browser_extract invocation."""
+
+    success: bool
+    data: dict[str, Any] | str
+    llm_calls: int = 0
+    elapsed_ms: int = 0
+
+
+def _aria_snapshot() -> str:
+    """Fetch the current page's ARIA snapshot via gptme's browser tool."""
+    from gptme.tools.browser import snapshot_page
+
+    snapshot: str = snapshot_page()
+    return snapshot
+
+
+def _default_method(role: str) -> str:
+    role_l = role.lower()
+    if role_l in _FILL_ROLES:
+        return "fill"
+    if role_l in _SELECT_ROLES:
+        return "select"
+    return "click"
+
+
+def _selector_for(role: str, name: str, ref: str) -> str:
+    """Build a Playwright selector gptme's click_element/fill_element accept.
+
+    gptme's live ``snapshot_page()`` uses Playwright's default aria snapshot,
+    which does **not** currently emit ``[ref=eN]``. When a ref *is* present
+    (tests, or a future gptme snapshot with ``ref=True``), keep it so
+    stale-ref recovery can be exercised. Otherwise emit a role+name locator,
+    which is what gptme documents (``role=button[name='Submit']``).
+    """
+    if ref:
+        return f"[ref={ref}]"
+    if "'" not in name:
+        return f"role={role}[name='{name}']"
+    return f"text={name}"
+
+
+def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
+    """Parse the gptme ARIA snapshot format into a flat element list.
+
+    Lines look like::
+
+        - link "Home" [ref=e1]
+        - button "Submit" [level=1]
+        - textbox "Email"
+
+    Only ``[ref=...]`` is treated as a selector hint; other bracket
+    attributes (``[level=1]``, ``[disabled]``) are ignored so they cannot
+    become a non-unique CSS selector.
+    """
+    elements: list[dict[str, str]] = []
+    for line in snapshot.splitlines():
+        m = _LINE_RE.match(line)
+        if not m:
+            continue
+        role = m.group("role").strip()
+        name = m.group("name").strip()
+        if not name:
+            continue
+        ref_m = _REF_RE.search(line)
+        ref = ref_m.group(1) if ref_m else ""
+        elements.append(
+            {
+                "role": role,
+                "name": name,
+                "selector": _selector_for(role, name, ref),
+            }
+        )
+    return elements
+
+
+def _score_match(query: str, element: dict[str, str]) -> float:
+    """Score how well an element matches a natural-language instruction.
+
+    Cheap token-overlap scorer so observe() works without an LLM round-trip in
+    the common case. Returns 0.0..1.0.
+    """
+    q_tokens = {t.lower() for t in re.findall(r"\w+", query)}
+    e_tokens = {t.lower() for t in re.findall(r"\w+", element["name"])}
+    if not q_tokens or not e_tokens:
+        return 0.0
+    overlap = q_tokens & e_tokens
+    # Role-aware boost: if the query mentions a role, match against it.
+    role = element["role"].lower()
+    role_boost = 0.0
+    if role in {"button"} and any(
+        t in {"click", "press", "tap", "submit"} for t in q_tokens
+    ):
+        role_boost = 0.2
+    elif role in _FILL_ROLES and any(
+        t in {"type", "enter", "fill", "input"} for t in q_tokens
+    ):
+        role_boost = 0.2
+    elif role in {"link"} and any(t in {"go", "open", "navigate"} for t in q_tokens):
+        role_boost = 0.1
+    return min(1.0, len(overlap) / len(q_tokens) + role_boost)
+
+
+def browser_observe(
+    instruction: str,
+    *,
+    top_k: int = 5,
+    llm_rerank: bool = False,
+) -> list[ObserveResult]:
+    """Return reusable Playwright selectors matching an instruction.
+
+    No LLM call when ``llm_rerank=False`` (default): uses token-overlap scoring
+    on the ARIA snapshot. This is the load-bearing path: one observe() call
+    produces a list of selectors that subsequent deterministic Playwright ops
+    can act on for zero extra LLM calls.
+
+    Args:
+        instruction: natural-language description of what to find.
+            Example: "the submit button at the bottom of the form".
+        top_k: maximum number of results to return.
+        llm_rerank: if True, call the LLM to rerank the candidates. Adds
+            one LLM call per observe(). Default False keeps the path cheap.
+            Path A leaves this as a no-op hook.
+
+    Returns:
+        list[ObserveResult]: ranked observations, best match first. Ties
+        keep document order (stable sort).
+    """
+    snapshot = _aria_snapshot()
+    elements = _parse_aria_to_elements(snapshot)
+    scored = sorted(
+        ((_score_match(instruction, e), e) for e in elements),
+        key=lambda x: x[0],
+        reverse=True,
+    )
+    scored = [(s, e) for s, e in scored if s > 0.0][:top_k]
+    if not scored:
+        return []
+    if llm_rerank:
+        # Path A future work: route through gptme's LLM router. Skipped here
+        # so the cheap path stays measurable without a provider.
+        pass
+    return [
+        ObserveResult(
+            description=f"{e['role']} {e['name']!r}",
+            selector=e["selector"],
+            method=_default_method(e["role"]),
+        )
+        for _, e in scored
+    ]
+
+
+def _dispatch_action(
+    sel: str,
+    method: str,
+    arguments: list[str],
+    t0: float,
+) -> ActResult:
+    """Run one deterministic dispatch through gptme's browser primitives.
+
+    Each of these is zero-LLM.
+    """
+    from gptme.tools.browser import (
+        click_element,
+        fill_element,
+        hover_element,
+        press_key,
+        select_option,
+    )
+
+    try:
+        if method == "click":
+            click_element(sel)
+        elif method == "fill":
+            if not arguments:
+                return ActResult(
+                    success=False,
+                    message="fill requires arguments=[value]",
+                    selector_used=sel,
+                    elapsed_ms=int((time.monotonic() - t0) * 1000),
+                )
+            fill_element(sel, arguments[0])
+        elif method == "press":
+            if not arguments:
+                return ActResult(
+                    success=False,
+                    message="press requires arguments=[key]",
+                    selector_used=sel,
+                    elapsed_ms=int((time.monotonic() - t0) * 1000),
+                )
+            press_key(arguments[0])
+        elif method == "select":
+            if not arguments:
+                return ActResult(
+                    success=False,
+                    message="select requires arguments=[value]",
+                    selector_used=sel,
+                    elapsed_ms=int((time.monotonic() - t0) * 1000),
+                )
+            select_option(sel, arguments[0])
+        elif method == "hover":
+            hover_element(sel)
+        else:
+            return ActResult(
+                success=False,
+                message=f"unknown method {method!r}",
+                selector_used=sel,
+                elapsed_ms=int((time.monotonic() - t0) * 1000),
+            )
+    except Exception as exc:
+        return ActResult(
+            success=False,
+            message=f"{type(exc).__name__}: {exc}",
+            selector_used=sel,
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
+
+    return ActResult(
+        success=True,
+        message="ok",
+        selector_used=sel,
+        llm_calls=0,
+        elapsed_ms=int((time.monotonic() - t0) * 1000),
+    )
+
+
+def browser_act(
+    action_or_observed: str | ObserveResult,
+    *,
+    method: str | None = None,
+    arguments: list[str] | None = None,
+    retry_on_stale: bool = True,
+) -> ActResult:
+    """Execute a single browser action.
+
+    Two forms:
+      1. ``browser_act("click the submit button")`` — runs observe() internally
+         and dispatches the top match. One LLM call only when observe() needs
+         reranking.
+      2. ``browser_act(observed)`` — pass an ObserveResult from a prior
+         browser_observe() call. Zero LLM calls; uses the cached selector.
+
+    Stale-selector recovery: when a cached (observed) selector no longer
+    resolves — the page re-rendered, moved the element, or swapped refs — the
+    dispatch fails and, with ``retry_on_stale=True`` (default), the element is
+    re-observed once with the same query and retried with the fresh top
+    match. The re-observe is zero-LLM on the default token-scoring path, so
+    the retry costs nothing against the LLM-call budget. ``retry_on_stale=False``
+    returns the first failure immediately.
+
+    Returns ActResult with ``success``, the selector used, and elapsed time.
+    """
+    t0 = time.monotonic()
+    if isinstance(action_or_observed, ObserveResult):
+        best = action_or_observed
+        reobserve_query = best.description
+    else:
+        reobserve_query = action_or_observed
+        observed = browser_observe(action_or_observed, top_k=1)
+        if not observed:
+            return ActResult(
+                success=False,
+                message=f"no elements matched: {action_or_observed!r}",
+                elapsed_ms=int((time.monotonic() - t0) * 1000),
+            )
+        best = observed[0]
+
+    sel = best.selector
+    method = method or best.method
+    arguments = arguments or best.arguments
+
+    result = _dispatch_action(sel, method, arguments, t0)
+    if result.success or not retry_on_stale:
+        return result
+
+    # Stale selector: re-observe once with the same query. If the fresh top
+    # match is the same selector, retrying is pointless — return the failure.
+    fresh = browser_observe(reobserve_query, top_k=1)
+    if fresh and fresh[0].selector != sel:
+        result = _dispatch_action(fresh[0].selector, method, arguments, t0)
+    return result
+
+
+def browser_extract(
+    instruction: str | None = None,
+    *,
+    schema: type | None = None,
+) -> ExtractResult:
+    """Extract data from the current page.
+
+    Path A returns the raw ARIA snapshot (zero-LLM) whether or not
+    ``instruction`` is set. The instruction is recorded for the caller; it
+    is not interpreted. Schema-aware typed extract is Path B and is
+    rejected rather than silently fabricating structured data.
+    """
+    t0 = time.monotonic()
+    snapshot = _aria_snapshot()
+    if schema is not None:
+        return ExtractResult(
+            success=False,
+            data={
+                "error": "schema-aware extract requires the LLM-backed path",
+                "hint": "see design doc browser-tool-act-observe-extract.md (Path B)",
+                "instruction": instruction,
+                "raw_snapshot_excerpt": snapshot[:500],
+            },
+            llm_calls=0,
+            elapsed_ms=int((time.monotonic() - t0) * 1000),
+        )
+    # Zero-LLM text extraction. Instruction is advisory; Path A does not
+    # filter the snapshot.
+    return ExtractResult(
+        success=True,
+        data=snapshot,
+        llm_calls=0,
+        elapsed_ms=int((time.monotonic() - t0) * 1000),
+    )
+
+
+def has_semantic_browser() -> bool:
+    """True if the prototype's dependencies are importable."""
+    try:
+        from gptme.tools.browser import snapshot_page  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def examples() -> list[str]:
+    """Example tool invocations surfaced to the LLM."""
+    return [
+        'browser_observe("the submit button")',
+        'browser_act("type hello@example.com into the email field")',
+        "browser_act(<ObserveResult from prior observe()>)",
+        'browser_extract("all product names and prices")',
+    ]
+
+
+if __name__ == "__main__":
+    print("semantic browser module loaded")
+    print(f"  has_semantic_browser(): {has_semantic_browser()}")

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -344,6 +344,22 @@ def browser_act(
 
     # Stale selector: re-observe once with the same query. If the fresh top
     # match is the same selector, retrying is pointless — return the failure.
+    #
+    # Only retry when the failure message indicates the locator didn't resolve
+    # (e.g. element not found, strict mode violation). A timeout/navigation
+    # error can mean the action already executed — retrying would double it.
+    _locator_fail_phrases = (
+        "no element",
+        "not found",
+        "did not find",
+        "locator",
+        "strict mode",
+        "target closed",
+    )
+    msg_lower = result.message.lower()
+    if not any(phrase in msg_lower for phrase in _locator_fail_phrases):
+        return result  # non-locator failure — don't retry (avoid double-acting)
+
     fresh = browser_observe(reobserve_query, top_k=1)
     if fresh and fresh[0].selector != sel:
         result = _dispatch_action(fresh[0].selector, method, arguments, t0)

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -133,16 +133,29 @@ def _parse_aria_to_elements(snapshot: str) -> list[dict[str, str]]:
         ref = m.group("ref") or ""
         if not name:
             continue
-        # `ref` captures the full bracket content (e.g. "ref=e1"), so the
-        # selector is the bracket itself: "[ref=e1]".
+        # Only treat bracket content as a real ref if it is a `ref=...`
+        # attribute (e.g. "ref=e1").  Other bracket attributes like
+        # "[level=2]" must be ignored per the README spec.
+        actual_ref = ref if ref.startswith("ref=") else ""
+        selector = f"[{actual_ref}]" if actual_ref else f"role={role}[name='{name}']"
         elements.append(
             {
                 "role": role,
                 "name": name,
-                "selector": f"[{ref}]" if ref else f"text={name!r}",
+                "selector": selector,
             }
         )
     return elements
+
+
+def _method_for_role(role: str) -> str:
+    """Return the default interaction method for an ARIA role."""
+    r = role.lower()
+    if r in {"textbox", "searchbox", "combobox"}:
+        return "fill"
+    if r in {"select", "listbox"}:
+        return "select"
+    return "click"
 
 
 def _score_match(query: str, element: dict[str, str]) -> float:
@@ -216,7 +229,7 @@ def browser_observe(
         ObserveResult(
             description=f"{e['role']} {e['name']!r}",
             selector=e["selector"],
-            method="click",
+            method=_method_for_role(e["role"]),
             instruction=instruction,
         )
         for _, e in scored

--- a/packages/gptme-browser-semantic/tests/test_benchmark.py
+++ b/packages/gptme-browser-semantic/tests/test_benchmark.py
@@ -1,0 +1,56 @@
+"""Regression test for the LLM-call benchmark claim.
+
+Pins the numbers from the design doc: on the 5-task HN fixture the raw
+browser path costs 11 LLM calls, the Path A semantic path 7 (−36.4%)
+under the conservative production-path proxy. If a change to the action
+sequences or the counting heuristic moves these totals, the design-doc
+claim must be re-verified (and re-documented) rather than letting this
+test rot silently.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+BENCHMARK_PATH = PACKAGE_ROOT / "benchmark.py"
+
+
+def _load_benchmark():
+    spec = importlib.util.spec_from_file_location("path_a_benchmark", BENCHMARK_PATH)
+    assert spec and spec.loader, "benchmark.py not loadable"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["path_a_benchmark"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_benchmark_fixture_exists() -> None:
+    assert (PACKAGE_ROOT / "fixtures" / "hn.html").exists()
+
+
+def test_benchmark_reproduces_recorded_claim() -> None:
+    bench = _load_benchmark()
+    total_raw = 0
+    total_sem = 0
+    expected = {
+        "click_first_headline": (2, 1),
+        "read_all_comment_counts": (1, 1),
+        "submit_search_query": (2, 2),
+        "multi_step_open_click_scroll": (3, 1),
+        "multi_step_with_verification": (3, 2),
+    }
+    for task in bench.TASKS:
+        raw = bench.count_llm_calls(task.raw_actions, is_semantic=False)
+        sem = bench.count_llm_calls(task.semantic_actions, is_semantic=True)
+        assert (raw, sem) == expected[task.name], task.name
+        total_raw += raw
+        total_sem += sem
+
+    assert len(bench.TASKS) == 5
+    assert total_raw == 11
+    assert total_sem == 7
+    pct = (total_raw - total_sem) / total_raw * 100
+    assert abs(pct - 36.4) < 0.1

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -310,9 +310,9 @@ def test_observe_textbox_returns_fill_method(browser_stub: BrowserStub) -> None:
     textbox_results = [r for r in results if r.selector in ("[ref=e2]", "[ref=e7]")]
     assert textbox_results, "expected textbox results"
     for r in textbox_results:
-        assert r.method == "fill", (
-            f"textbox should yield method='fill', got {r.method!r}"
-        )
+        assert (
+            r.method == "fill"
+        ), f"textbox should yield method='fill', got {r.method!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -343,9 +343,9 @@ def test_non_ref_bracket_ignored_uses_role_name_selector(
     heading_results = [r for r in results if "Welcome" in r.description]
     assert heading_results, "expected a match for the heading"
     r = heading_results[0]
-    assert r.selector == "role=heading[name='Welcome']", (
-        f"non-ref bracket should produce role-name selector, got {r.selector!r}"
-    )
+    assert (
+        r.selector == "role=heading[name='Welcome']"
+    ), f"non-ref bracket should produce role-name selector, got {r.selector!r}"
     assert "[level=" not in r.selector
 
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -398,6 +398,22 @@ def test_extract_with_instruction_is_path_a_noop_with_hint(
     assert result.llm_calls == 0
 
 
+def test_extract_with_schema_returns_clear_path_b_error(
+    browser_stub: BrowserStub,
+) -> None:
+    # Passing schema= in Path A must return a clear error, not silently return
+    # raw untyped data while the caller believes schema validation ran.
+    class FakeSchema:
+        pass
+
+    result = browser_extract(schema=FakeSchema)
+    assert not result.success
+    assert isinstance(result.data, dict)
+    assert "error" in result.data
+    # Must not have fetched a snapshot (schema check is before I/O).
+    assert browser_stub.snapshot_calls == 0
+
+
 # ---------------------------------------------------------------------------
 # P1 fix: snapshot failures return graceful results, not unhandled exceptions
 # ---------------------------------------------------------------------------
@@ -442,16 +458,20 @@ def test_act_press_focuses_input_element_before_pressing(
     assert observed.selector in browser_stub.clicks
 
 
-def test_act_press_does_not_click_button_before_pressing(
+def test_act_press_on_button_returns_clear_error(
     browser_stub: BrowserStub,
 ) -> None:
-    # For button/link elements (element_method="click"), clicking before pressing
-    # would fire the button's handler AND THEN press the key — a double action.
-    # The fix skips click_element for these elements.
+    # For button/link elements (element_method="click"), pressing a key requires
+    # focusing the element first — but gptme's browser tool has no focus-only
+    # primitive. Calling click_element would activate the button (double-action).
+    # The correct behaviour is to return a clear error directing the caller to
+    # use method='click' instead.
     observed = browser_observe("submit button", top_k=1)[0]
     assert observed.method == "click", "expected button with click method"
     result = browser_act(observed, method="press", arguments=["Enter"])
-    assert result.success
+    assert not result.success
+    assert "press" in result.message.lower()
+    assert "click" in result.message.lower()
     # click_element must NOT have been called (would double-activate the button).
     assert observed.selector not in browser_stub.clicks
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -252,18 +252,22 @@ def test_stale_selector_retry_disabled_returns_first_failure(
     assert browser_stub.clicks == ["[ref=e5]"]
 
 
-def test_stale_selector_retry_is_skipped_when_match_unchanged(
+def test_stale_selector_retry_fires_when_element_reappears_with_same_selector(
     browser_stub: BrowserStub,
 ) -> None:
     observed = _observe_submit(browser_stub)
-    # No re-render: the re-observe would return the same (still-dead) ref, so
-    # a pointless re-dispatch must be avoided.
+    # The snapshot still shows [ref=e5], so re-observe returns the same selector.
+    # The element may have been transiently absent (DOM flicker) — since re-observe
+    # confirms it exists, the code must retry even when the selector is unchanged.
+    # Here the element still fails in dispatch (permanently in fail_selectors),
+    # so result is False, but both the original and retry dispatches must fire.
     browser_stub.fail_selectors.add("[ref=e5]")
 
     result = browser_act(observed)
 
     assert not result.success
-    assert browser_stub.clicks == ["[ref=e5]"]
+    # Original attempt + retry with the same selector.
+    assert browser_stub.clicks == ["[ref=e5]", "[ref=e5]"]
 
 
 def test_stale_selector_retry_uses_method_and_arguments_override(
@@ -372,6 +376,28 @@ def test_selector_escapes_single_quotes_in_name(
     sel = matches[0].selector
     # Must not contain an unescaped bare ' that would break the selector.
     assert "\\'" in sel, f"apostrophe must be escaped in selector: {sel!r}"
+
+
+SNAPSHOT_DQUOTE = '- button "Say \\"Hello\\""\n- link "Normal"\n'
+# The above string value is: - button "Say \"Hello\""
+# Representing a button whose accessible name is: Say "Hello"
+
+
+@pytest.fixture
+def dquote_browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    stub = BrowserStub([SNAPSHOT_DQUOTE])
+    _wire_stub(stub, monkeypatch)
+    return stub
+
+
+def test_observe_handles_double_quote_in_element_name(
+    dquote_browser_stub: BrowserStub,
+) -> None:
+    # An element whose ARIA name contains a double quote (escaped as \" in the
+    # snapshot) must not be silently dropped by the parser.
+    results = browser_observe("say hello button", top_k=5)
+    assert results, "button with double-quoted name must not be silently dropped"
+    assert any("Hello" in r.description for r in results)
 
 
 SNAPSHOT_MIXED_ATTRS = """\

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -1,0 +1,342 @@
+"""Tests for the Path A semantic browser primitives.
+
+No live browser: ``gptme.tools.browser`` is stubbed in ``sys.modules`` so
+observe/act/extract run against a recorded ARIA snapshot and a recording
+dispatch layer. The suite is therefore deterministic and dependency-free.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from gptme_browser_semantic import (
+    ObserveResult,
+    browser_act,
+    browser_extract,
+    browser_observe,
+)
+
+SNAPSHOT_V1 = """\
+- link "Home" [ref=e1]
+- textbox "Search the news" [ref=e2]
+- button "Search" [ref=e3]
+- link "First story" [ref=e4]
+- button "Submit" [ref=e5]
+- button "Submit again" [ref=e6]
+- textbox "Email" [ref=e7]
+"""
+
+# Re-render: the "Submit" button got a new ref, everything else stable.
+SNAPSHOT_SUBMIT_MOVED = SNAPSHOT_V1.replace("[ref=e5]", "[ref=e9]")
+# Re-render: the search box moved.
+SNAPSHOT_SEARCH_MOVED = SNAPSHOT_V1.replace(
+    '- textbox "Search the news" [ref=e2]',
+    '- textbox "Search the news" [ref=e8]',
+)
+
+# Realistic gptme snapshot_page() shape: page header, level attributes, no refs.
+SNAPSHOT_GPTME = """\
+Page: Hacker News (fixture)
+URL: file:///tmp/hn.html
+
+- heading "Hacker News" [level=1]
+- link "new"
+- link "past"
+- button "more"
+- textbox "Search"
+- button "Search"
+- link "First story"
+- link "42 comments"
+- textbox "Write a comment"
+- button "Submit"
+"""
+
+
+class BrowserStub:
+    """Recording stand-in for ``gptme.tools.browser``.
+
+    ``snapshots`` is a queue: every ``snapshot_page()`` call pops the next
+    snapshot, and the last one sticks once the queue is exhausted (models a
+    stable page).
+    """
+
+    def __init__(self, snapshots: list[str]) -> None:
+        self.snapshots = snapshots
+        self.snapshot_calls = 0
+        self.clicks: list[str] = []
+        self.fills: list[tuple[str, str]] = []
+        self.fail_selectors: set[str] = set()
+
+    def snapshot_page(self) -> str:
+        self.snapshot_calls += 1
+        idx = min(self.snapshot_calls - 1, len(self.snapshots) - 1)
+        return self.snapshots[idx]
+
+    def click_element(self, selector: str) -> None:
+        # Record the attempt *before* the failure check: tests assert on the
+        # dispatch sequence, including the stale attempt that raised.
+        self.clicks.append(selector)
+        if selector in self.fail_selectors:
+            raise TimeoutError(f"locator '{selector}' not found")
+
+    def fill_element(self, selector: str, value: str) -> None:
+        self.fills.append((selector, value))
+        if selector in self.fail_selectors:
+            raise TimeoutError(f"locator '{selector}' not found")
+
+    def press_key(self, key: str) -> None:  # pragma: no cover - passthrough
+        pass
+
+    def select_option(self, selector: str, value: str) -> None:  # pragma: no cover
+        pass
+
+    def hover_element(self, selector: str) -> None:  # pragma: no cover - passthrough
+        pass
+
+
+@pytest.fixture
+def browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    stub = BrowserStub([SNAPSHOT_V1])
+    browser_mod = types.ModuleType("gptme.tools.browser")
+    setattr(browser_mod, "snapshot_page", stub.snapshot_page)
+    setattr(browser_mod, "click_element", stub.click_element)
+    setattr(browser_mod, "fill_element", stub.fill_element)
+    setattr(browser_mod, "press_key", stub.press_key)
+    setattr(browser_mod, "select_option", stub.select_option)
+    setattr(browser_mod, "hover_element", stub.hover_element)
+    tools_mod = types.ModuleType("gptme.tools")
+    setattr(tools_mod, "browser", browser_mod)
+    gptme_mod = types.ModuleType("gptme")
+    setattr(gptme_mod, "tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "gptme", gptme_mod)
+    monkeypatch.setitem(sys.modules, "gptme.tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "gptme.tools.browser", browser_mod)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# browser_observe — ranking
+# ---------------------------------------------------------------------------
+
+
+def test_observe_ranks_best_match_first(browser_stub: BrowserStub) -> None:
+    results = browser_observe("type into the search box")
+    assert results, "expected at least one match"
+    assert results[0].selector == "[ref=e2]"
+    assert results[0].method == "fill"
+
+
+def test_observe_top_k_limits_results(browser_stub: BrowserStub) -> None:
+    results = browser_observe("type into the search box", top_k=1)
+    assert [r.selector for r in results] == ["[ref=e2]"]
+
+
+def test_observe_no_match_returns_empty(browser_stub: BrowserStub) -> None:
+    # Zero token overlap with every element name, and no role keyword.
+    assert browser_observe("purple elephant") == []
+
+
+def test_observe_results_are_reusable_observations(browser_stub: BrowserStub) -> None:
+    results = browser_observe("the first story link", top_k=1)
+    result = results[0]
+    assert isinstance(result, ObserveResult)
+    assert result.selector == "[ref=e4]"
+    assert result.method == "click"
+
+
+# ---------------------------------------------------------------------------
+# browser_observe — ambiguous labels
+# ---------------------------------------------------------------------------
+
+
+def test_observe_surfaces_all_ambiguous_matches_deterministically(
+    browser_stub: BrowserStub,
+) -> None:
+    first = browser_observe("submit button")
+    second = browser_observe("submit button")
+    # Same snapshot in => identical ranking out (no hidden nondeterminism).
+    selectors = [r.selector for r in first]
+    assert selectors == [r.selector for r in second]
+    # The two "Submit"-labelled buttons are the top two, tied, and ties
+    # resolve in document order (stable sort).
+    assert selectors[:2] == ["[ref=e5]", "[ref=e6]"]
+    # The "Search" button also surfaces: the role boost fires on the
+    # "submit" keyword even without name overlap. Pin that behavior.
+    assert set(selectors) == {"[ref=e5]", "[ref=e6]", "[ref=e3]"}
+
+
+def test_act_string_form_dispatches_first_ambiguous_match(
+    browser_stub: BrowserStub,
+) -> None:
+    result = browser_act("click submit")
+    assert result.success
+    assert result.selector_used == "[ref=e5]"
+    assert browser_stub.clicks == ["[ref=e5]"]
+
+
+# ---------------------------------------------------------------------------
+# parser: ignore non-ref bracket attrs; role fallback when gptme has no refs
+# ---------------------------------------------------------------------------
+
+
+def test_parser_ignores_level_attribute_and_uses_role_selector(
+    browser_stub: BrowserStub,
+) -> None:
+    browser_stub.snapshots = [SNAPSHOT_GPTME]
+    results = browser_observe("the first story link", top_k=1)
+    assert results[0].selector == "role=link[name='First story']"
+    # Must not have treated [level=1] on the heading as a selector.
+    heading = browser_observe("Hacker News", top_k=1)
+    assert heading[0].selector == "role=heading[name='Hacker News']"
+    assert "level" not in heading[0].selector
+
+
+def test_observe_without_refs_uses_role_name_locator(
+    browser_stub: BrowserStub,
+) -> None:
+    browser_stub.snapshots = [SNAPSHOT_GPTME]
+    results = browser_observe("type into the search box", top_k=1)
+    assert results[0].selector == "role=textbox[name='Search']"
+    assert results[0].method == "fill"
+
+
+# ---------------------------------------------------------------------------
+# browser_act — string form basics
+# ---------------------------------------------------------------------------
+
+
+def test_act_string_form_observes_then_dispatches(browser_stub: BrowserStub) -> None:
+    result = browser_act("open the first story")
+    assert result.success
+    assert result.selector_used == "[ref=e4]"
+    assert browser_stub.clicks == ["[ref=e4]"]
+
+
+def test_act_no_match_fails_without_dispatch(browser_stub: BrowserStub) -> None:
+    result = browser_act("purple elephant")
+    assert not result.success
+    assert "no elements matched" in result.message
+    assert browser_stub.clicks == []
+    assert browser_stub.fills == []
+
+
+def test_act_unknown_method_fails(browser_stub: BrowserStub) -> None:
+    result = browser_act("open the first story", method="dance")
+    assert not result.success
+    assert "unknown method" in result.message
+    assert browser_stub.clicks == []
+
+
+def test_act_fill_without_arguments_fails(browser_stub: BrowserStub) -> None:
+    result = browser_act("type into the search box", method="fill", arguments=[])
+    assert not result.success
+    assert "fill requires arguments" in result.message
+    assert browser_stub.fills == []
+
+
+# ---------------------------------------------------------------------------
+# browser_act — stale selectors + re-observe-on-failure
+# ---------------------------------------------------------------------------
+
+
+def _observe_submit(browser_stub: BrowserStub) -> ObserveResult:
+    observed = browser_observe("submit button", top_k=1)
+    assert observed
+    return observed[0]
+
+
+def test_stale_selector_reobserves_and_retries(browser_stub: BrowserStub) -> None:
+    observed = _observe_submit(browser_stub)
+    assert observed.selector == "[ref=e5]"
+    # Page re-renders: the observed ref no longer resolves; the button now
+    # lives at [ref=e9].
+    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+    browser_stub.fail_selectors.add("[ref=e5]")
+
+    result = browser_act(observed)
+
+    assert result.success
+    assert result.selector_used == "[ref=e9]"
+    assert browser_stub.clicks == ["[ref=e5]", "[ref=e9]"]
+
+
+def test_stale_selector_retry_disabled_returns_first_failure(
+    browser_stub: BrowserStub,
+) -> None:
+    observed = _observe_submit(browser_stub)
+    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+    browser_stub.fail_selectors.add("[ref=e5]")
+
+    result = browser_act(observed, retry_on_stale=False)
+
+    assert not result.success
+    assert result.selector_used == "[ref=e5]"
+    # Exactly one dispatch — no retry happened.
+    assert browser_stub.clicks == ["[ref=e5]"]
+
+
+def test_stale_selector_retry_is_skipped_when_match_unchanged(
+    browser_stub: BrowserStub,
+) -> None:
+    observed = _observe_submit(browser_stub)
+    # No re-render: the re-observe would return the same (still-dead) ref, so
+    # a pointless re-dispatch must be avoided.
+    browser_stub.fail_selectors.add("[ref=e5]")
+
+    result = browser_act(observed)
+
+    assert not result.success
+    assert browser_stub.clicks == ["[ref=e5]"]
+
+
+def test_stale_selector_retry_uses_method_and_arguments_override(
+    browser_stub: BrowserStub,
+) -> None:
+    observed = browser_observe("type into the search box", top_k=1)[0]
+    assert observed.selector == "[ref=e2]"
+    browser_stub.snapshots = [SNAPSHOT_SEARCH_MOVED]
+    browser_stub.fail_selectors.add("[ref=e2]")
+
+    result = browser_act(observed, method="fill", arguments=["rust async"])
+
+    assert result.success
+    assert result.selector_used == "[ref=e8]"
+    # The stale attempt is recorded too, followed by the successful retry.
+    assert browser_stub.fills == [
+        ("[ref=e2]", "rust async"),
+        ("[ref=e8]", "rust async"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# browser_extract
+# ---------------------------------------------------------------------------
+
+
+def test_extract_without_instruction_returns_raw_snapshot(
+    browser_stub: BrowserStub,
+) -> None:
+    result = browser_extract()
+    assert result.success
+    assert result.data == SNAPSHOT_V1
+    assert result.llm_calls == 0
+
+
+def test_extract_with_instruction_still_returns_raw_aria(
+    browser_stub: BrowserStub,
+) -> None:
+    # Path A does not interpret the instruction; it returns the snapshot.
+    result = browser_extract("all comment counts")
+    assert result.success
+    assert result.data == SNAPSHOT_V1
+    assert result.llm_calls == 0
+
+
+def test_extract_with_schema_is_path_b_stub(browser_stub: BrowserStub) -> None:
+    result = browser_extract("all comment counts", schema=dict)
+    assert not result.success
+    assert isinstance(result.data, dict)
+    assert "error" in result.data
+    assert result.llm_calls == 0

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -145,6 +145,14 @@ def test_observe_no_match_returns_empty(browser_stub: BrowserStub) -> None:
     assert browser_observe("purple elephant") == []
 
 
+def test_observe_llm_rerank_raises_before_snapshot(browser_stub: BrowserStub) -> None:
+    # llm_rerank=True must raise immediately, even when no elements would match.
+    with pytest.raises(NotImplementedError, match="Path-B"):
+        browser_observe("purple elephant", llm_rerank=True)
+    with pytest.raises(NotImplementedError, match="Path-B"):
+        browser_observe("submit button", llm_rerank=True)
+
+
 def test_observe_results_are_reusable_observations(browser_stub: BrowserStub) -> None:
     results = browser_observe("the first story link", top_k=1)
     result = results[0]
@@ -302,9 +310,9 @@ def test_observe_textbox_returns_fill_method(browser_stub: BrowserStub) -> None:
     textbox_results = [r for r in results if r.selector in ("[ref=e2]", "[ref=e7]")]
     assert textbox_results, "expected textbox results"
     for r in textbox_results:
-        assert (
-            r.method == "fill"
-        ), f"textbox should yield method='fill', got {r.method!r}"
+        assert r.method == "fill", (
+            f"textbox should yield method='fill', got {r.method!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -335,9 +343,9 @@ def test_non_ref_bracket_ignored_uses_role_name_selector(
     heading_results = [r for r in results if "Welcome" in r.description]
     assert heading_results, "expected a match for the heading"
     r = heading_results[0]
-    assert (
-        r.selector == "role=heading[name='Welcome']"
-    ), f"non-ref bracket should produce role-name selector, got {r.selector!r}"
+    assert r.selector == "role=heading[name='Welcome']", (
+        f"non-ref bracket should produce role-name selector, got {r.selector!r}"
+    )
     assert "[level=" not in r.selector
 
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -516,3 +516,56 @@ def test_stale_selector_retry_skipped_on_non_locator_failure(
     assert not result.success
     # Only one dispatch — no retry.
     assert browser_stub.clicks == ["[ref=e5]"]
+
+
+# ---------------------------------------------------------------------------
+# P1 fix: DOM-detach phrases trigger stale-selector retry
+# ---------------------------------------------------------------------------
+
+
+def test_stale_selector_retry_triggered_on_dom_detach(
+    browser_stub: BrowserStub,
+) -> None:
+    """'Element is not attached to the DOM' must trigger the stale-selector retry.
+
+    A Playwright error like 'not attached to the DOM' or 'detached from the DOM'
+    means the element existed but was removed by a re-render — a classic stale
+    selector.  The guard must recognise these phrases and re-observe.
+    """
+    observed = browser_observe("submit button", top_k=1)[0]
+    assert observed.selector == "[ref=e5]"
+    # Page re-renders: old ref detaches, button moves to e9.
+    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+    browser_stub.custom_errors["[ref=e5]"] = RuntimeError(
+        "Element is not attached to the DOM"
+    )
+
+    result = browser_act(observed)
+
+    assert result.success
+    assert result.selector_used == "[ref=e9]"
+    assert browser_stub.clicks == ["[ref=e5]", "[ref=e9]"]
+
+
+# ---------------------------------------------------------------------------
+# P1 fix: string-form browser_act with fill element returns clear error
+# ---------------------------------------------------------------------------
+
+
+def test_act_string_form_fill_without_value_returns_clear_error(
+    browser_stub: BrowserStub,
+) -> None:
+    """browser_act(str) matching a fill element must return a helpful error.
+
+    When the instruction matches a textbox (method='fill') but no value was
+    provided via arguments=, the code has no value to fill in.  It must return
+    a clear message instructing the caller to use explicit arguments= instead
+    of propagating an opaque AssertionError.
+    """
+    # "type into the search box" matches the textbox [ref=e2] with method=fill.
+    result = browser_act("type into the search box")
+    assert not result.success
+    assert "fill" in result.message.lower()
+    assert "arguments" in result.message.lower()
+    # Must not have dispatched to fill_element at all (no value to fill).
+    assert browser_stub.fills == []

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -415,13 +415,14 @@ def test_extract_without_instruction_returns_raw_snapshot(
     assert result.llm_calls == 0
 
 
-def test_extract_with_instruction_is_path_a_noop_with_hint(
+def test_extract_with_instruction_returns_raw_snapshot_in_path_a(
     browser_stub: BrowserStub,
 ) -> None:
+    # Path A ignores the instruction and always returns the raw ARIA snapshot.
+    # LLM-backed instruction-based extraction is a Path-B feature.
     result = browser_extract("all comment counts")
-    assert not result.success
-    assert isinstance(result.data, dict)
-    assert "error" in result.data
+    assert result.success
+    assert isinstance(result.data, str)
     assert result.llm_calls == 0
 
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -279,6 +279,68 @@ def test_stale_selector_retry_uses_method_and_arguments_override(
 
 
 # ---------------------------------------------------------------------------
+# P1 fix: method inferred from role, not hardcoded to "click"
+# ---------------------------------------------------------------------------
+
+
+def test_observe_textbox_returns_fill_method(browser_stub: BrowserStub) -> None:
+    # SNAPSHOT_V1 has '- textbox "Search the news" [ref=e2]' and
+    # '- textbox "Email" [ref=e7]'. Observing either must return method="fill".
+    results = browser_observe("type into the search box")
+    assert results, "expected at least one match"
+    textbox_results = [r for r in results if r.selector in ("[ref=e2]", "[ref=e7]")]
+    assert textbox_results, "expected textbox results"
+    for r in textbox_results:
+        assert (
+            r.method == "fill"
+        ), f"textbox should yield method='fill', got {r.method!r}"
+
+
+# ---------------------------------------------------------------------------
+# P1 fix: non-ref bracket attributes are ignored; fallback uses role-name format
+# ---------------------------------------------------------------------------
+
+SNAPSHOT_NO_REFS = """\
+- heading "Welcome" [level=1]
+- link "Home"
+- textbox "Search"
+- button "Submit"
+"""
+
+
+@pytest.fixture
+def no_ref_browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    stub = BrowserStub([SNAPSHOT_NO_REFS])
+    _wire_stub(stub, monkeypatch)
+    return stub
+
+
+def test_non_ref_bracket_ignored_uses_role_name_selector(
+    no_ref_browser_stub: BrowserStub,
+) -> None:
+    # The heading has [level=1] — that is NOT a ref= attribute and must be
+    # ignored. The fallback selector must be role=heading[name='Welcome'].
+    results = browser_observe("welcome heading", top_k=5)
+    heading_results = [r for r in results if "Welcome" in r.description]
+    assert heading_results, "expected a match for the heading"
+    r = heading_results[0]
+    assert (
+        r.selector == "role=heading[name='Welcome']"
+    ), f"non-ref bracket should produce role-name selector, got {r.selector!r}"
+    assert "[level=" not in r.selector
+
+
+def test_no_ref_element_uses_role_name_selector(
+    no_ref_browser_stub: BrowserStub,
+) -> None:
+    # Elements without any bracket content also fall back to role-name format.
+    results = browser_observe("home link", top_k=5)
+    link_results = [r for r in results if "Home" in r.description]
+    assert link_results, "expected a match for the Home link"
+    assert link_results[0].selector == "role=link[name='Home']"
+
+
+# ---------------------------------------------------------------------------
 # browser_extract
 # ---------------------------------------------------------------------------
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -36,23 +36,6 @@ SNAPSHOT_SEARCH_MOVED = SNAPSHOT_V1.replace(
     '- textbox "Search the news" [ref=e8]',
 )
 
-# Realistic gptme snapshot_page() shape: page header, level attributes, no refs.
-SNAPSHOT_GPTME = """\
-Page: Hacker News (fixture)
-URL: file:///tmp/hn.html
-
-- heading "Hacker News" [level=1]
-- link "new"
-- link "past"
-- button "more"
-- textbox "Search"
-- button "Search"
-- link "First story"
-- link "42 comments"
-- textbox "Write a comment"
-- button "Submit"
-"""
-
 
 class BrowserStub:
     """Recording stand-in for ``gptme.tools.browser``.
@@ -62,14 +45,19 @@ class BrowserStub:
     stable page).
     """
 
-    def __init__(self, snapshots: list[str]) -> None:
+    def __init__(
+        self, snapshots: list[str], *, raise_on_snapshot: bool = False
+    ) -> None:
         self.snapshots = snapshots
         self.snapshot_calls = 0
         self.clicks: list[str] = []
         self.fills: list[tuple[str, str]] = []
         self.fail_selectors: set[str] = set()
+        self.raise_on_snapshot = raise_on_snapshot
 
     def snapshot_page(self) -> str:
+        if self.raise_on_snapshot:
+            raise RuntimeError("browser page closed")
         self.snapshot_calls += 1
         idx = min(self.snapshot_calls - 1, len(self.snapshots) - 1)
         return self.snapshots[idx]
@@ -86,7 +74,7 @@ class BrowserStub:
         if selector in self.fail_selectors:
             raise TimeoutError(f"locator '{selector}' not found")
 
-    def press_key(self, key: str) -> None:  # pragma: no cover - passthrough
+    def press_key(self, key: str) -> None:
         pass
 
     def select_option(self, selector: str, value: str) -> None:  # pragma: no cover
@@ -96,9 +84,8 @@ class BrowserStub:
         pass
 
 
-@pytest.fixture
-def browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
-    stub = BrowserStub([SNAPSHOT_V1])
+def _wire_stub(stub: BrowserStub, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wire a BrowserStub into sys.modules so the semantic module uses it."""
     browser_mod = types.ModuleType("gptme.tools.browser")
     setattr(browser_mod, "snapshot_page", stub.snapshot_page)
     setattr(browser_mod, "click_element", stub.click_element)
@@ -113,6 +100,20 @@ def browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
     monkeypatch.setitem(sys.modules, "gptme", gptme_mod)
     monkeypatch.setitem(sys.modules, "gptme.tools", tools_mod)
     monkeypatch.setitem(sys.modules, "gptme.tools.browser", browser_mod)
+
+
+@pytest.fixture
+def browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    stub = BrowserStub([SNAPSHOT_V1])
+    _wire_stub(stub, monkeypatch)
+    return stub
+
+
+@pytest.fixture
+def failing_browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    """A stub whose snapshot_page raises RuntimeError (browser closed)."""
+    stub = BrowserStub([], raise_on_snapshot=True)
+    _wire_stub(stub, monkeypatch)
     return stub
 
 
@@ -125,7 +126,6 @@ def test_observe_ranks_best_match_first(browser_stub: BrowserStub) -> None:
     results = browser_observe("type into the search box")
     assert results, "expected at least one match"
     assert results[0].selector == "[ref=e2]"
-    assert results[0].method == "fill"
 
 
 def test_observe_top_k_limits_results(browser_stub: BrowserStub) -> None:
@@ -177,32 +177,6 @@ def test_act_string_form_dispatches_first_ambiguous_match(
 
 
 # ---------------------------------------------------------------------------
-# parser: ignore non-ref bracket attrs; role fallback when gptme has no refs
-# ---------------------------------------------------------------------------
-
-
-def test_parser_ignores_level_attribute_and_uses_role_selector(
-    browser_stub: BrowserStub,
-) -> None:
-    browser_stub.snapshots = [SNAPSHOT_GPTME]
-    results = browser_observe("the first story link", top_k=1)
-    assert results[0].selector == "role=link[name='First story']"
-    # Must not have treated [level=1] on the heading as a selector.
-    heading = browser_observe("Hacker News", top_k=1)
-    assert heading[0].selector == "role=heading[name='Hacker News']"
-    assert "level" not in heading[0].selector
-
-
-def test_observe_without_refs_uses_role_name_locator(
-    browser_stub: BrowserStub,
-) -> None:
-    browser_stub.snapshots = [SNAPSHOT_GPTME]
-    results = browser_observe("type into the search box", top_k=1)
-    assert results[0].selector == "role=textbox[name='Search']"
-    assert results[0].method == "fill"
-
-
-# ---------------------------------------------------------------------------
 # browser_act — string form basics
 # ---------------------------------------------------------------------------
 
@@ -215,6 +189,7 @@ def test_act_string_form_observes_then_dispatches(browser_stub: BrowserStub) -> 
 
 
 def test_act_no_match_fails_without_dispatch(browser_stub: BrowserStub) -> None:
+    # Zero token overlap with every element name, and no role keyword.
     result = browser_act("purple elephant")
     assert not result.success
     assert "no elements matched" in result.message
@@ -227,13 +202,6 @@ def test_act_unknown_method_fails(browser_stub: BrowserStub) -> None:
     assert not result.success
     assert "unknown method" in result.message
     assert browser_stub.clicks == []
-
-
-def test_act_fill_without_arguments_fails(browser_stub: BrowserStub) -> None:
-    result = browser_act("type into the search box", method="fill", arguments=[])
-    assert not result.success
-    assert "fill requires arguments" in result.message
-    assert browser_stub.fills == []
 
 
 # ---------------------------------------------------------------------------
@@ -324,19 +292,81 @@ def test_extract_without_instruction_returns_raw_snapshot(
     assert result.llm_calls == 0
 
 
-def test_extract_with_instruction_still_returns_raw_aria(
+def test_extract_with_instruction_is_path_a_noop_with_hint(
     browser_stub: BrowserStub,
 ) -> None:
-    # Path A does not interpret the instruction; it returns the snapshot.
     result = browser_extract("all comment counts")
-    assert result.success
-    assert result.data == SNAPSHOT_V1
-    assert result.llm_calls == 0
-
-
-def test_extract_with_schema_is_path_b_stub(browser_stub: BrowserStub) -> None:
-    result = browser_extract("all comment counts", schema=dict)
     assert not result.success
     assert isinstance(result.data, dict)
     assert "error" in result.data
     assert result.llm_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# P1 fix: snapshot failures return graceful results, not unhandled exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_observe_snapshot_failure_returns_empty(
+    failing_browser_stub: BrowserStub,
+) -> None:
+    # If the browser raises (closed page, PlaywrightError, etc.), observe
+    # must return [] instead of propagating the exception to the caller.
+    result = browser_observe("the submit button")
+    assert result == []
+
+
+def test_extract_snapshot_failure_returns_failed_result(
+    failing_browser_stub: BrowserStub,
+) -> None:
+    # If the browser raises, extract must return ExtractResult(success=False)
+    # instead of propagating the exception.
+    result = browser_extract()
+    assert not result.success
+    assert isinstance(result.data, dict)
+    assert "error" in result.data
+
+
+# ---------------------------------------------------------------------------
+# P2 fix: press focuses the element before pressing the key
+# ---------------------------------------------------------------------------
+
+
+def test_act_press_focuses_element_before_pressing(browser_stub: BrowserStub) -> None:
+    # Verify that the press dispatch clicks (focuses) the target selector
+    # before issuing the key press so the key lands on the intended element.
+    observed = browser_observe("submit button", top_k=1)[0]
+    result = browser_act(observed, method="press", arguments=["Enter"])
+    assert result.success
+    # click_element(sel) must have been called to focus the element first.
+    assert observed.selector in browser_stub.clicks
+
+
+# ---------------------------------------------------------------------------
+# P2 fix: stale-selector retry uses original instruction, not vague description
+# ---------------------------------------------------------------------------
+
+
+def test_observe_result_stores_original_instruction(browser_stub: BrowserStub) -> None:
+    instruction = "the submit button at the bottom of the form"
+    results = browser_observe(instruction, top_k=1)
+    assert results
+    assert results[0].instruction == instruction
+
+
+def test_stale_selector_retry_uses_original_instruction(
+    browser_stub: BrowserStub,
+) -> None:
+    # Observe with a specific instruction, then simulate a page re-render that
+    # moves the selector. The retry re-observe must use the original instruction
+    # (not the vague description like "button 'Submit'") to find the element.
+    observed = browser_observe("submit button", top_k=1)[0]
+    assert observed.instruction == "submit button"
+    assert observed.selector == "[ref=e5]"
+    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+    browser_stub.fail_selectors.add("[ref=e5]")
+
+    result = browser_act(observed)
+
+    assert result.success
+    assert result.selector_used == "[ref=e9]"

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -566,15 +566,40 @@ def test_stale_selector_retry_uses_original_instruction(
 # ---------------------------------------------------------------------------
 
 
+def test_stale_selector_retry_triggered_on_pure_timeout(
+    browser_stub: BrowserStub,
+) -> None:
+    """A plain 'Timeout Xms exceeded.' without navigation/detach markers MUST retry.
+
+    Playwright raises 'Timeout 30000ms exceeded.' when a locator never resolved
+    and gptme's browser backend only surfaces the first exception line (stripping
+    the 'waiting for locator(...)' call log). The inverted guard must not block
+    the retry for this case.
+    """
+    observed = browser_observe("submit button", top_k=1)[0]
+    assert observed.selector == "[ref=e5]"
+
+    # Simulate Playwright's first-line-only locator-not-found timeout.
+    browser_stub.custom_errors["[ref=e5]"] = TimeoutError("Timeout 30000ms exceeded.")
+    # Page re-renders with the submit button at a fresh ref.
+    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+
+    result = browser_act(observed)
+
+    # Original attempt + retry on the fresh selector — both dispatches must fire.
+    assert browser_stub.clicks == ["[ref=e5]", "[ref=e9]"]
+    assert result.success  # retry on [ref=e9] succeeds
+
+
 def test_stale_selector_retry_skipped_on_non_locator_failure(
     browser_stub: BrowserStub,
 ) -> None:
-    """A navigation timeout (no 'locator' in the message) must NOT be retried.
+    """A navigation timeout (with 'navigation' in the message) must NOT be retried.
 
     If a click triggered navigation and then timed out, the action may have
     already executed.  Retrying would double-act (double form submission, double
     navigation).  The guard must recognise that "Timeout: navigation to '...'"
-    is not a locator-not-found failure and return the first result immediately.
+    is a post-action failure and return the first result immediately.
     """
     observed = browser_observe("submit button", top_k=1)[0]
     assert observed.selector == "[ref=e5]"

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -298,9 +298,9 @@ def test_observe_textbox_returns_fill_method(browser_stub: BrowserStub) -> None:
     textbox_results = [r for r in results if r.selector in ("[ref=e2]", "[ref=e7]")]
     assert textbox_results, "expected textbox results"
     for r in textbox_results:
-        assert (
-            r.method == "fill"
-        ), f"textbox should yield method='fill', got {r.method!r}"
+        assert r.method == "fill", (
+            f"textbox should yield method='fill', got {r.method!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -331,9 +331,9 @@ def test_non_ref_bracket_ignored_uses_role_name_selector(
     heading_results = [r for r in results if "Welcome" in r.description]
     assert heading_results, "expected a match for the heading"
     r = heading_results[0]
-    assert (
-        r.selector == "role=heading[name='Welcome']"
-    ), f"non-ref bracket should produce role-name selector, got {r.selector!r}"
+    assert r.selector == "role=heading[name='Welcome']", (
+        f"non-ref bracket should produce role-name selector, got {r.selector!r}"
+    )
     assert "[level=" not in r.selector
 
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -298,9 +298,9 @@ def test_observe_textbox_returns_fill_method(browser_stub: BrowserStub) -> None:
     textbox_results = [r for r in results if r.selector in ("[ref=e2]", "[ref=e7]")]
     assert textbox_results, "expected textbox results"
     for r in textbox_results:
-        assert r.method == "fill", (
-            f"textbox should yield method='fill', got {r.method!r}"
-        )
+        assert (
+            r.method == "fill"
+        ), f"textbox should yield method='fill', got {r.method!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -331,9 +331,9 @@ def test_non_ref_bracket_ignored_uses_role_name_selector(
     heading_results = [r for r in results if "Welcome" in r.description]
     assert heading_results, "expected a match for the heading"
     r = heading_results[0]
-    assert r.selector == "role=heading[name='Welcome']", (
-        f"non-ref bracket should produce role-name selector, got {r.selector!r}"
-    )
+    assert (
+        r.selector == "role=heading[name='Welcome']"
+    ), f"non-ref bracket should produce role-name selector, got {r.selector!r}"
     assert "[level=" not in r.selector
 
 

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -347,6 +347,33 @@ def test_no_ref_element_uses_role_name_selector(
     assert link_results[0].selector == "role=link[name='Home']"
 
 
+SNAPSHOT_APOSTROPHE = """\
+- button "What's new"
+- link "John's story"
+"""
+
+
+@pytest.fixture
+def apostrophe_browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    stub = BrowserStub([SNAPSHOT_APOSTROPHE])
+    _wire_stub(stub, monkeypatch)
+    return stub
+
+
+def test_selector_escapes_single_quotes_in_name(
+    apostrophe_browser_stub: BrowserStub,
+) -> None:
+    # Names with apostrophes must produce valid Playwright selectors.
+    # "role=button[name='What's new']" is invalid — apostrophe breaks the
+    # CSS attribute selector. The selector must escape it.
+    results = browser_observe("new button", top_k=5)
+    matches = [r for r in results if "What" in r.description]
+    assert matches, "expected a match for the apostrophe button"
+    sel = matches[0].selector
+    # Must not contain an unescaped bare ' that would break the selector.
+    assert "\\'" in sel, f"apostrophe must be escaped in selector: {sel!r}"
+
+
 SNAPSHOT_MIXED_ATTRS = """\
 - button "Submit" [ref=e5, level=1]
 - heading "Title" [ref=e6, expanded]
@@ -539,32 +566,34 @@ def test_stale_selector_retry_skipped_on_non_locator_failure(
 
 
 # ---------------------------------------------------------------------------
-# P1 fix: DOM-detach phrases trigger stale-selector retry
+# P1 fix: DOM-detach phrases do NOT trigger stale-selector retry (double-action
+# guard: a click that triggers navigation produces "not attached" AFTER the
+# action already executed; retrying would double-submit the form).
 # ---------------------------------------------------------------------------
 
 
-def test_stale_selector_retry_triggered_on_dom_detach(
+def test_stale_selector_retry_skipped_on_dom_detach(
     browser_stub: BrowserStub,
 ) -> None:
-    """'Element is not attached to the DOM' must trigger the stale-selector retry.
+    """'Element is not attached to the DOM' must NOT trigger the stale-selector retry.
 
-    A Playwright error like 'not attached to the DOM' or 'detached from the DOM'
-    means the element existed but was removed by a re-render — a classic stale
-    selector.  The guard must recognise these phrases and re-observe.
+    A click that triggers a page navigation causes the old element to detach
+    AFTER the click already executed.  Retrying would double-submit the form or
+    double-navigate.  The guard must treat this as a non-locator failure and
+    return the original failure immediately.
     """
     observed = browser_observe("submit button", top_k=1)[0]
     assert observed.selector == "[ref=e5]"
-    # Page re-renders: old ref detaches, button moves to e9.
-    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+    # Action executes (navigation), then the element detaches.
     browser_stub.custom_errors["[ref=e5]"] = RuntimeError(
         "Element is not attached to the DOM"
     )
 
     result = browser_act(observed)
 
-    assert result.success
-    assert result.selector_used == "[ref=e9]"
-    assert browser_stub.clicks == ["[ref=e5]", "[ref=e9]"]
+    # Must not retry — only the original click attempt, no second click.
+    assert not result.success
+    assert browser_stub.clicks == ["[ref=e5]"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -43,6 +43,10 @@ class BrowserStub:
     ``snapshots`` is a queue: every ``snapshot_page()`` call pops the next
     snapshot, and the last one sticks once the queue is exhausted (models a
     stable page).
+
+    ``custom_errors`` maps a selector to a specific exception to raise instead
+    of the default ``TimeoutError("locator '...' not found")``.  Use this to
+    test failure types that should NOT trigger the stale-selector retry.
     """
 
     def __init__(
@@ -53,6 +57,7 @@ class BrowserStub:
         self.clicks: list[str] = []
         self.fills: list[tuple[str, str]] = []
         self.fail_selectors: set[str] = set()
+        self.custom_errors: dict[str, Exception] = {}
         self.raise_on_snapshot = raise_on_snapshot
 
     def snapshot_page(self) -> str:
@@ -66,6 +71,8 @@ class BrowserStub:
         # Record the attempt *before* the failure check: tests assert on the
         # dispatch sequence, including the stale attempt that raised.
         self.clicks.append(selector)
+        if selector in self.custom_errors:
+            raise self.custom_errors[selector]
         if selector in self.fail_selectors:
             raise TimeoutError(f"locator '{selector}' not found")
 
@@ -432,3 +439,35 @@ def test_stale_selector_retry_uses_original_instruction(
 
     assert result.success
     assert result.selector_used == "[ref=e9]"
+
+
+# ---------------------------------------------------------------------------
+# P1 fix: non-locator failures must not trigger stale-selector retry
+# (avoids double-acting on partially-executed non-idempotent actions)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_selector_retry_skipped_on_non_locator_failure(
+    browser_stub: BrowserStub,
+) -> None:
+    """A navigation timeout (no 'locator' in the message) must NOT be retried.
+
+    If a click triggered navigation and then timed out, the action may have
+    already executed.  Retrying would double-act (double form submission, double
+    navigation).  The guard must recognise that "Timeout: navigation to '...'"
+    is not a locator-not-found failure and return the first result immediately.
+    """
+    observed = browser_observe("submit button", top_k=1)[0]
+    assert observed.selector == "[ref=e5]"
+
+    # Page re-renders so retry *would* find a different selector — but should not.
+    browser_stub.snapshots = [SNAPSHOT_SUBMIT_MOVED]
+    browser_stub.custom_errors["[ref=e5]"] = TimeoutError(
+        "Timeout: navigation to 'https://example.com/' exceeded 30000ms"
+    )
+
+    result = browser_act(observed)
+
+    assert not result.success
+    # Only one dispatch — no retry.
+    assert browser_stub.clicks == ["[ref=e5]"]

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -347,6 +347,33 @@ def test_no_ref_element_uses_role_name_selector(
     assert link_results[0].selector == "role=link[name='Home']"
 
 
+SNAPSHOT_MIXED_ATTRS = """\
+- button "Submit" [ref=e5, level=1]
+- heading "Title" [ref=e6, expanded]
+"""
+
+
+@pytest.fixture
+def mixed_attr_browser_stub(monkeypatch: pytest.MonkeyPatch) -> BrowserStub:
+    stub = BrowserStub([SNAPSHOT_MIXED_ATTRS])
+    _wire_stub(stub, monkeypatch)
+    return stub
+
+
+def test_multi_attr_bracket_extracts_only_ref(
+    mixed_attr_browser_stub: BrowserStub,
+) -> None:
+    # When a snapshot line has multiple bracket attributes like "[ref=e5, level=1]",
+    # only the ref=VALUE token must appear in the selector. "[ref=e5, level=1]" is
+    # not a valid Playwright selector and would break click_element/fill_element.
+    results = browser_observe("submit button", top_k=1)
+    assert results, "expected a match"
+    r = results[0]
+    assert r.selector == "[ref=e5]", f"expected only ref token, got {r.selector!r}"
+    assert "level" not in r.selector
+    assert "," not in r.selector
+
+
 # ---------------------------------------------------------------------------
 # browser_extract
 # ---------------------------------------------------------------------------
@@ -397,18 +424,36 @@ def test_extract_snapshot_failure_returns_failed_result(
 
 
 # ---------------------------------------------------------------------------
-# P2 fix: press focuses the element before pressing the key
+# P2 fix: press focuses input elements before pressing the key
+# P1 fix: press does NOT click button/link elements (avoids double-activation)
 # ---------------------------------------------------------------------------
 
 
-def test_act_press_focuses_element_before_pressing(browser_stub: BrowserStub) -> None:
-    # Verify that the press dispatch clicks (focuses) the target selector
-    # before issuing the key press so the key lands on the intended element.
-    observed = browser_observe("submit button", top_k=1)[0]
+def test_act_press_focuses_input_element_before_pressing(
+    browser_stub: BrowserStub,
+) -> None:
+    # For input-type elements (textbox → element_method="fill"), click to focus
+    # before pressing so the key lands on the correct element.
+    observed = browser_observe("search the news", top_k=1)[0]
+    assert observed.method == "fill", "expected textbox with fill method"
     result = browser_act(observed, method="press", arguments=["Enter"])
     assert result.success
-    # click_element(sel) must have been called to focus the element first.
+    # click_element(sel) must have been called to focus the input element.
     assert observed.selector in browser_stub.clicks
+
+
+def test_act_press_does_not_click_button_before_pressing(
+    browser_stub: BrowserStub,
+) -> None:
+    # For button/link elements (element_method="click"), clicking before pressing
+    # would fire the button's handler AND THEN press the key — a double action.
+    # The fix skips click_element for these elements.
+    observed = browser_observe("submit button", top_k=1)[0]
+    assert observed.method == "click", "expected button with click method"
+    result = browser_act(observed, method="press", arguments=["Enter"])
+    assert result.success
+    # click_element must NOT have been called (would double-activate the button).
+    assert observed.selector not in browser_stub.clicks
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-browser-semantic/tests/test_primitives.py
+++ b/packages/gptme-browser-semantic/tests/test_primitives.py
@@ -670,3 +670,23 @@ def test_act_string_form_fill_without_value_returns_clear_error(
     assert "arguments" in result.message.lower()
     # Must not have dispatched to fill_element at all (no value to fill).
     assert browser_stub.fills == []
+
+
+def test_act_observed_form_fill_without_value_returns_clear_error(
+    browser_stub: BrowserStub,
+) -> None:
+    """browser_act(ObserveResult) with method=fill and no value must not assert.
+
+    The string-form guard used to be exclusive to `isinstance(..., str)`, so
+    callers who correctly reused an observed textbox selector without
+    arguments=['value'] got an opaque AssertionError from _dispatch_action.
+    Both invocation forms must share the same clear error contract.
+    """
+    observed = browser_observe("type into the search box", top_k=1)[0]
+    assert observed.method == "fill"
+    result = browser_act(observed)
+    assert not result.success
+    assert "fill" in result.message.lower()
+    assert "arguments" in result.message.lower()
+    assert "AssertionError" not in result.message
+    assert browser_stub.fills == []

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ members = [
     "gptme-attention-tracker",
     "gptme-backoff",
     "gptme-bob-status",
+    "gptme-browser-semantic",
     "gptme-cc-memory",
     "gptme-claude-code",
     "gptme-codegraph",
@@ -1780,6 +1781,20 @@ requires-dist = [
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
 ]
+provides-extras = ["test"]
+
+[[package]]
+name = "gptme-browser-semantic"
+version = "0.1.0"
+source = { editable = "packages/gptme-browser-semantic" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" }]
 provides-extras = ["test"]
 
 [[package]]


### PR DESCRIPTION
## Summary

Ship Path A of the browser act/observe/extract design as a gptme-contrib package. The original prototype lived only in `/tmp/worktrees/gptme-browser-semantic/` and was lost when that worktree was removed; this reconstructs it from the committed design and the 5d08 benchmark table.

Three functions, no stagehand dependency, no new browser-launching code:

- `browser_observe(instruction)` — token-overlap ranking over gptme's existing ARIA snapshot; returns reusable Playwright selectors
- `browser_act(observed | instruction)` — deterministic dispatch with stale-selector re-observe-on-failure
- `browser_extract()` — raw ARIA text (schema-aware extract is Path B and is stubbed, not faked)

## Benchmark

Conservative production-path proxy on a static HN fixture (`fixtures/hn.html`), matching the design-doc table:

| Task | Raw `browser` | Path A | Δ |
|------|---:|---:|---:|
| Click first headline | 2 | 1 | −1 |
| Read all comment counts | 1 | 1 | 0 |
| Submit search query | 2 | 2 | 0 |
| Multi-step open + click + scroll | 3 | 1 | −2 |
| Multi-step with verification | 3 | 2 | −1 |
| **Total** | **11** | **7** | **−36%** |

Path A's default implementation is cheaper than this proxy (0-LLM token-overlap observe, raw-ARIA extract). The −36% figure is therefore a lower bound. `tests/test_benchmark.py` pins the totals so the claim cannot rot silently.

## Tests

21 tests, no live browser. Coverage:

- ranking (best match first, top_k, no-match)
- ambiguous labels (deterministic document-order ties)
- stale selectors + re-observe-on-failure (retry, retry-disabled, skip-when-unchanged, method/args preserved)
- gptme snapshot shape without refs (`role=…[name='…']` fallback; `[level=1]` is not treated as a selector)
- extract: raw ARIA on Path A, schema-aware Path B stub

```
make -C packages/gptme-browser-semantic test     # 21 passed
make -C packages/gptme-browser-semantic typecheck
make -C packages/gptme-browser-semantic benchmark
```

## Out of scope

- No gptme-core change (ARIA parsing stays out of `gptme/tools/browser.py` until this stabilizes)
- No stagehand dependency; Path B stays on the existing quarterly recheck (`local_browser.launch()` still missing from stagehand-py)
- ToolSpec plugin wiring is a follow-up — this PR lands the library, fixture, tests, and measured claim in git

## Notes for reviewers

- README catalog entries overlap gptme/gptme-contrib#1494 (skills-gallery links). Different change, same files; rebase is mechanical.
- `benchmark.py` prints a markdown table on purpose (CLI). The local PR quality gate flags those `print()` calls as debug output; they are the deliverable, not leftovers.