### PR TITLE
feat(precommit): add config-driven root-structure validator

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,3 +10,16 @@
   pass_filenames: false
   always_run: true
   additional_dependencies: []
+
+- id: validate-root-structure
+  name: Check root directory structure (config-driven)
+  description: >
+    Config-driven variant of ``check-root-structure``. Reads the allowlist from
+    a per-repo YAML file (default ``root-structure-allowlist.yaml``) instead of
+    repeated ``--allow`` args, so consuming repos own a data file rather than a
+    copy of the checker. Requires PyYAML in the hook environment.
+  entry: scripts/precommit/validators/validate_root_structure_yaml.py
+  language: script
+  pass_filenames: false
+  always_run: true
+  additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,9 +17,9 @@
     Config-driven variant of ``check-root-structure``. Reads the allowlist from
     a per-repo YAML file (default ``root-structure-allowlist.yaml``) instead of
     repeated ``--allow`` args, so consuming repos own a data file rather than a
-    copy of the checker. Requires PyYAML in the hook environment.
+    copy of the checker.
   entry: scripts/precommit/validators/validate_root_structure_yaml.py
-  language: script
+  language: python
   pass_filenames: false
   always_run: true
-  additional_dependencies: []
+  additional_dependencies: [PyYAML]

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,7 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 warn_return_any = True
 strict_optional = True
-mypy_path = scripts:scripts/precommit
+mypy_path = scripts:scripts/precommit:scripts/precommit/validators
 
 # Explicitly ignore imports without stubs
 [mypy.plugins.django.*]

--- a/scripts/precommit/validators/validate_root_structure_yaml.py
+++ b/scripts/precommit/validators/validate_root_structure_yaml.py
@@ -97,7 +97,7 @@ def load_allowlist(config_path: Path) -> "frozenset[str] | None":
         return None
 
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8", errors="surrogateescape") as f:
             data = yaml.safe_load(f)
 
         if not isinstance(data, dict) or "allowed_entries" not in data:

--- a/scripts/precommit/validators/validate_root_structure_yaml.py
+++ b/scripts/precommit/validators/validate_root_structure_yaml.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Enforce allowed set of top-level files and directories via YAML config file.
+
+This validator reads an allowlist from a YAML config file (default:
+`root-structure-allowlist.yaml` in the repo root) and rejects any tracked
+top-level entries not on that list. The allowlist approach scales across
+multiple repos without code duplication.
+
+Each repo using this validator owns a `root-structure-allowlist.yaml` file
+listing its permitted top-level entries, one per line.
+
+Usage (from repo root):
+    python3 gptme-contrib/scripts/precommit/validators/validate_root_structure_yaml.py
+
+Or with a custom config path:
+    python3 gptme-contrib/scripts/precommit/validators/validate_root_structure_yaml.py \\
+      --config my-root-allowlist.yaml
+
+As a pre-commit hook in .pre-commit-config.yaml:
+    - repo: https://github.com/gptme/gptme-contrib
+      rev: <SHA or tag>
+      hooks:
+      - id: validate-root-structure
+        name: Check root directory structure
+        entry: python3 scripts/precommit/validators/validate_root_structure_yaml.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        args:
+          - --config=root-structure-allowlist.yaml
+
+Config file format (YAML, one entry per line):
+    ---
+    allowed_entries:
+      - .github
+      - .gitignore
+      - README.md
+      - src
+      - tests
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def get_repo_root() -> Path:
+    """Return the repository root via git rev-parse."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        check=True,
+    )
+    return Path(result.stdout.rstrip(b"\r\n").decode("utf-8", errors="surrogateescape"))
+
+
+def get_tracked_root_entries(repo_root: Path) -> set[str]:
+    """Return first path components of all files in the git index."""
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "-z"],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+    )
+    entries: set[str] = set()
+    for path in result.stdout.split(b"\0"):
+        if path:
+            entries.add(
+                path.split(b"/", maxsplit=1)[0].decode(
+                    "utf-8", errors="surrogateescape"
+                )
+            )
+    return entries
+
+
+def load_allowlist(config_path: Path) -> "frozenset[str] | None":
+    """Load allowed entries from YAML config file.
+
+    Expects a file with structure:
+        ---
+        allowed_entries:
+          - entry1
+          - entry2
+
+    Returns the allowed entries, or None if the config could not be loaded.
+    An empty-but-valid ``allowed_entries`` list returns an empty frozenset,
+    which is distinct from a load failure.
+    """
+    if not config_path.exists():
+        print(
+            f"validate-root-structure: config file not found: {config_path}",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict) or "allowed_entries" not in data:
+            print(
+                f"validate-root-structure: config file missing 'allowed_entries' key: {config_path}",
+                file=sys.stderr,
+            )
+            return None
+
+        entries = data["allowed_entries"]
+        if entries is None:
+            entries = []
+        if not isinstance(entries, list):
+            print(
+                f"validate-root-structure: 'allowed_entries' must be a list: {config_path}",
+                file=sys.stderr,
+            )
+            return None
+
+        return frozenset(str(entry) for entry in entries)
+    except yaml.YAMLError as e:
+        print(
+            f"validate-root-structure: failed to parse YAML config: {e}",
+            file=sys.stderr,
+        )
+        return None
+    except OSError as e:
+        print(
+            f"validate-root-structure: error reading config: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="root-structure-allowlist.yaml",
+        help="Path to YAML allowlist file (default: root-structure-allowlist.yaml in repo root)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        repo_root = get_repo_root()
+    except subprocess.CalledProcessError as error:
+        print(
+            f"validate-root-structure: unable to find git repo root: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve config path relative to repo root if not absolute
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = repo_root / config_path
+
+    allowed = load_allowlist(config_path)
+    if allowed is None:
+        # load_allowlist already explained what went wrong.
+        if not config_path.exists():
+            print(
+                f"If this is intentional, create {config_path} with allowed entries.",
+                file=sys.stderr,
+            )
+        return 1
+
+    try:
+        entries = get_tracked_root_entries(repo_root)
+    except subprocess.CalledProcessError as error:
+        print(
+            f"validate-root-structure: git ls-files failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    unexpected = entries - allowed
+    if not unexpected:
+        return 0
+
+    print("validate-root-structure: unexpected top-level entries found:")
+    for name in sorted(unexpected):
+        print(f"  {name}")
+    print()
+    print(
+        f"If this is intentional, add the entry to {config_path} and explain\n"
+        "the choice in your commit message."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/precommit/validators/validate_root_structure_yaml.py
+++ b/scripts/precommit/validators/validate_root_structure_yaml.py
@@ -142,7 +142,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     try:
         repo_root = get_repo_root()
-    except subprocess.CalledProcessError as error:
+    except (subprocess.CalledProcessError, OSError) as error:
         print(
             f"validate-root-structure: unable to find git repo root: {error}",
             file=sys.stderr,
@@ -166,7 +166,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     try:
         entries = get_tracked_root_entries(repo_root)
-    except subprocess.CalledProcessError as error:
+    except (subprocess.CalledProcessError, OSError) as error:
         print(
             f"validate-root-structure: git ls-files failed: {error}",
             file=sys.stderr,

--- a/scripts/precommit/validators/validate_root_structure_yaml.py
+++ b/scripts/precommit/validators/validate_root_structure_yaml.py
@@ -16,18 +16,12 @@ Or with a custom config path:
     python3 gptme-contrib/scripts/precommit/validators/validate_root_structure_yaml.py \\
       --config my-root-allowlist.yaml
 
-As a pre-commit hook in .pre-commit-config.yaml:
+As a pre-commit hook in .pre-commit-config.yaml (language and dependencies
+are declared in .pre-commit-hooks.yaml and do not need repeating here):
     - repo: https://github.com/gptme/gptme-contrib
       rev: <SHA or tag>
       hooks:
       - id: validate-root-structure
-        name: Check root directory structure
-        entry: python3 scripts/precommit/validators/validate_root_structure_yaml.py
-        language: system
-        pass_filenames: false
-        always_run: true
-        args:
-          - --config=root-structure-allowlist.yaml
 
 Config file format (YAML, one entry per line):
     ---

--- a/scripts/precommit/validators/validate_root_structure_yaml.py
+++ b/scripts/precommit/validators/validate_root_structure_yaml.py
@@ -112,7 +112,19 @@ def load_allowlist(config_path: Path) -> "frozenset[str] | None":
             )
             return None
 
-        return frozenset(str(entry) for entry in entries)
+        normalized: list[str] = []
+        for entry in entries:
+            if not isinstance(entry, str):
+                print(
+                    f"validate-root-structure: non-string entry in 'allowed_entries': {entry!r}",
+                    file=sys.stderr,
+                )
+                return None
+            # Normalize: strip leading ./ and trailing / so "src/" and "./src/" both match "src"
+            s = entry[2:] if entry.startswith("./") else entry
+            s = s.rstrip("/")
+            normalized.append(s)
+        return frozenset(normalized)
     except yaml.YAMLError as e:
         print(
             f"validate-root-structure: failed to parse YAML config: {e}",

--- a/scripts/precommit/validators/validate_root_structure_yaml.py
+++ b/scripts/precommit/validators/validate_root_structure_yaml.py
@@ -29,6 +29,7 @@ Config file format (YAML, one entry per line):
       - .github
       - .gitignore
       - README.md
+      - root-structure-allowlist.yaml  # the config file itself must be listed
       - src
       - tests
 """

--- a/tests/test_validate_root_structure_yaml.py
+++ b/tests/test_validate_root_structure_yaml.py
@@ -146,6 +146,42 @@ def test_get_repo_root_preserves_non_utf8_path_bytes():
     assert str(repo_root).encode("utf-8", errors="surrogateescape") == b"/tmp/repo-\xff"
 
 
+def test_allowlist_entries_with_trailing_slash_match(tmp_path):
+    """Allowlist entries written with a trailing slash match the normalized tracked entry."""
+    config = write_config(tmp_path, "allowed_entries:\n  - src/\n  - README.md\n")
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(
+            validator,
+            "get_tracked_root_entries",
+            return_value={"src", "README.md"},
+        ),
+    ):
+        assert validator.main(["--config", str(config)]) == 0
+
+
+def test_allowlist_entries_with_dot_slash_prefix_match(tmp_path):
+    """Allowlist entries written with a leading ./ match the normalized tracked entry."""
+    config = write_config(tmp_path, "allowed_entries:\n  - ./src\n  - README.md\n")
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(
+            validator,
+            "get_tracked_root_entries",
+            return_value={"src", "README.md"},
+        ),
+    ):
+        assert validator.main(["--config", str(config)]) == 0
+
+
+def test_non_string_entry_in_allowlist_fails(tmp_path, capsys):
+    """A non-string entry in allowed_entries exits 1 with a clear error."""
+    config = write_config(tmp_path, "allowed_entries:\n  - README.md\n  - [foo]\n")
+    with patch.object(validator, "get_repo_root", return_value=tmp_path):
+        assert validator.main(["--config", str(config)]) == 1
+    assert "non-string entry" in capsys.readouterr().err
+
+
 def test_get_tracked_root_entries_takes_first_path_component():
     """Nested paths collapse to their top-level entry."""
     with patch("subprocess.run") as run:

--- a/tests/test_validate_root_structure_yaml.py
+++ b/tests/test_validate_root_structure_yaml.py
@@ -100,6 +100,26 @@ def test_non_list_allowed_entries_fails(tmp_path, capsys):
     assert "must be a list" in capsys.readouterr().err
 
 
+def test_config_file_itself_must_be_in_allowlist(tmp_path, capsys):
+    """The config file lives at the repo root and must be listed in the allowlist.
+
+    Bootstrap requirement: when a consumer creates root-structure-allowlist.yaml,
+    that file becomes a tracked top-level entry. It must appear in allowed_entries
+    or the hook immediately reports it as unexpected.
+    """
+    config = write_config(tmp_path, "allowed_entries:\n  - README.md\n")
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(
+            validator,
+            "get_tracked_root_entries",
+            return_value={"README.md", "root-structure-allowlist.yaml"},
+        ),
+    ):
+        assert validator.main(["--config", str(config)]) == 1
+    assert "root-structure-allowlist.yaml" in capsys.readouterr().out
+
+
 def test_relative_config_resolves_against_repo_root(tmp_path):
     """A relative --config path is resolved from the repo root, not the cwd."""
     write_config(tmp_path, "allowed_entries:\n  - README.md\n")

--- a/tests/test_validate_root_structure_yaml.py
+++ b/tests/test_validate_root_structure_yaml.py
@@ -1,0 +1,134 @@
+"""Tests for the config-driven root structure validator."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "precommit" / "validators"))
+
+import validate_root_structure_yaml as validator  # noqa: E402
+
+
+def write_config(tmp_path: Path, body: str) -> Path:
+    config = tmp_path / "root-structure-allowlist.yaml"
+    config.write_text(body)
+    return config
+
+
+def test_allowed_entries_pass(tmp_path):
+    """Tracked entries that are a subset of the allowlist exit 0."""
+    config = write_config(
+        tmp_path,
+        "allowed_entries:\n  - README.md\n  - scripts\n  - tests\n",
+    )
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(
+            validator,
+            "get_tracked_root_entries",
+            return_value={"README.md", "scripts"},
+        ),
+    ):
+        assert validator.main(["--config", str(config)]) == 0
+
+
+def test_unexpected_entry_fails(tmp_path, capsys):
+    """An entry missing from the allowlist exits 1 and is named in the output."""
+    config = write_config(tmp_path, "allowed_entries:\n  - README.md\n")
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(
+            validator,
+            "get_tracked_root_entries",
+            return_value={"README.md", "stray_dir"},
+        ),
+    ):
+        assert validator.main(["--config", str(config)]) == 1
+    assert "stray_dir" in capsys.readouterr().out
+
+
+def test_missing_config_reports_creation_hint(tmp_path, capsys):
+    """A missing config file explains how to create one."""
+    missing = tmp_path / "root-structure-allowlist.yaml"
+    with patch.object(validator, "get_repo_root", return_value=tmp_path):
+        assert validator.main(["--config", str(missing)]) == 1
+    err = capsys.readouterr().err
+    assert "config file not found" in err
+    assert "If this is intentional, create" in err
+
+
+def test_empty_allowlist_is_not_reported_as_missing(tmp_path, capsys):
+    """A valid but empty allowlist rejects entries without the 'create it' hint.
+
+    Regression guard: conflating "load failed" with "loaded an empty list" made
+    a present-but-empty config print the missing-file hint.
+    """
+    config = write_config(tmp_path, "allowed_entries: []\n")
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(validator, "get_tracked_root_entries", return_value={"README.md"}),
+    ):
+        assert validator.main(["--config", str(config)]) == 1
+    captured = capsys.readouterr()
+    assert "README.md" in captured.out
+    assert "If this is intentional, create" not in captured.err
+
+
+def test_malformed_yaml_fails_cleanly(tmp_path, capsys):
+    """Unparseable YAML exits 1 with a parse error, not a traceback."""
+    config = write_config(tmp_path, "allowed_entries: [unclosed\n")
+    with patch.object(validator, "get_repo_root", return_value=tmp_path):
+        assert validator.main(["--config", str(config)]) == 1
+    assert "failed to parse YAML config" in capsys.readouterr().err
+
+
+def test_missing_allowed_entries_key_fails(tmp_path, capsys):
+    """A YAML file without the 'allowed_entries' key exits 1."""
+    config = write_config(tmp_path, "something_else:\n  - README.md\n")
+    with patch.object(validator, "get_repo_root", return_value=tmp_path):
+        assert validator.main(["--config", str(config)]) == 1
+    assert "missing 'allowed_entries' key" in capsys.readouterr().err
+
+
+def test_non_list_allowed_entries_fails(tmp_path, capsys):
+    """A scalar 'allowed_entries' value exits 1 rather than iterating a string."""
+    config = write_config(tmp_path, "allowed_entries: README.md\n")
+    with patch.object(validator, "get_repo_root", return_value=tmp_path):
+        assert validator.main(["--config", str(config)]) == 1
+    assert "must be a list" in capsys.readouterr().err
+
+
+def test_relative_config_resolves_against_repo_root(tmp_path):
+    """A relative --config path is resolved from the repo root, not the cwd."""
+    write_config(tmp_path, "allowed_entries:\n  - README.md\n")
+    with (
+        patch.object(validator, "get_repo_root", return_value=tmp_path),
+        patch.object(validator, "get_tracked_root_entries", return_value={"README.md"}),
+    ):
+        assert validator.main(["--config", "root-structure-allowlist.yaml"]) == 0
+
+
+def test_repo_root_failure_reports_cleanly(tmp_path, capsys):
+    """main() fails cleanly when git cannot resolve a repository root."""
+    error = subprocess.CalledProcessError(128, ["git", "rev-parse", "--show-toplevel"])
+    with patch.object(validator, "get_repo_root", side_effect=error):
+        assert validator.main([]) == 1
+    assert "unable to find git repo root" in capsys.readouterr().err
+
+
+def test_get_repo_root_preserves_non_utf8_path_bytes():
+    """Repository paths round-trip undecodable bytes via surrogateescape."""
+    with patch("subprocess.run") as run:
+        run.return_value.stdout = b"/tmp/repo-\xff\n"
+        repo_root = validator.get_repo_root()
+    assert str(repo_root).encode("utf-8", errors="surrogateescape") == b"/tmp/repo-\xff"
+
+
+def test_get_tracked_root_entries_takes_first_path_component():
+    """Nested paths collapse to their top-level entry."""
+    with patch("subprocess.run") as run:
+        run.return_value.stdout = b"README.md\0scripts/a/b.py\0tests/test_x.py\0"
+        entries = validator.get_tracked_root_entries(Path("/tmp/repo"))
+    assert entries == {"README.md", "scripts", "tests"}


### PR DESCRIPTION
Upstreams the shared root-structure validator that #1445 Phase 2 depends on.

## Why

`check_root_structure.py` takes its allowlist as repeated `--allow` args in each
consuming repo. That is fine for one repo and bad for four: gptme (#3580),
gptme-cloud (#867), and gptme-agent-template (#85) have each merged the guard in
hardcoded-args form, so the allowlists now drift independently — the same
accretion #1445 was opened about.

This adds `validate_root_structure_yaml.py`: identical logic, allowlist read from
a per-repo `root-structure-allowlist.yaml`. Consuming repos then own a **data
file**, not a copy of the checker.

The immediate trigger: gptme/gptme-agent-template#88 vendored a local copy of
this validator because it was not available here. Once this merges, that PR can
drop the copy and reference the shared hook instead.

## What

- `scripts/precommit/validators/validate_root_structure_yaml.py` — the validator.
  Reads root entries from the **git index** (`git ls-files`) rather than walking
  the filesystem, so gitignored scratch in a dirty worktree cannot affect the
  result and no `git check-ignore` subprocess-per-entry is needed.
- Hook id `validate-root-structure` in `.pre-commit-hooks.yaml`, so consumers wire
  one line. Requires PyYAML in the hook environment.
- `mypy_path` gains `scripts/precommit/validators` so validator tests can import
  their subject the same way `tests/test_check_root_structure.py` already does
  for `scripts/precommit`.
- 11 tests.

## Two bugs fixed relative to the draft this was extracted from

Both were found by writing the tests, and both are verified to fail against the
pre-fix version:

1. **A valid but empty `allowed_entries: []` exited 1 with no explanation.**
   `load_allowlist` returned an empty frozenset for both "load failed" and
   "loaded, empty", and the caller `if not allowed:` treated them alike — so it
   returned 1 *before* printing which entries were unexpected, and skipped the
   "create the config" hint too because the file did exist. Silent failure.
2. **A scalar `allowed_entries: README.md` was iterated as a string**, making the
   allowlist a set of individual characters (`{R, E, A, D, M, ., m, d}`) instead
   of raising a config error.

`load_allowlist` now returns `None` on load failure and a frozenset on success
(possibly empty), and rejects a non-list `allowed_entries`.

## Verification

```
$ uv run --active python3 -m pytest tests/test_validate_root_structure_yaml.py tests/test_check_root_structure.py -q
26 passed
```

`prek run` clean on the changed files (ruff, ruff-format, mypy, jscpd, and the
rest of the hook set).

Regression evidence for the two bug fixes — the new tests run against the
unfixed validator:

```
FAILED test_empty_allowlist_is_not_reported_as_missing
FAILED test_non_list_allowed_entries_fails
2 failed, 9 passed
```

## Follow-up (not in this PR)

gptme-agent-template, gptme, and gptme-cloud each need a
`root-structure-allowlist.yaml` and a hook swap. Tracked in
`tasks/root-structure-validator-propagation.md`; gptme-agent-template#88 is the
first consumer.

ref: #1445