### PR TITLE
fix(community-plugins): git add docs/community_plugins.json (path mismatch)

### DIFF
--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -26,9 +26,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add community_plugins.json
+          git add docs/community_plugins.json
           if git diff --cached --quiet; then
-            echo "No changes to community_plugins.json"
+            echo "No changes to docs/community_plugins.json"
           else
             branch="automation/community-plugins"
             git checkout -B "$branch"


### PR DESCRIPTION
## Problem

The weekly `Update Community Plugins` workflow has been failing since 2026-08-24 with:

```
fatal: pathspec 'community_plugins.json' did not match any files
```

The fetch script (`scripts/fetch-community-plugins.py`) writes to `docs/community_plugins.json` (its `DEFAULT_OUTPUT`), but the `Commit if changed` step was doing `git add community_plugins.json` (repo root) — a path mismatch.

## Fix

Change `git add community_plugins.json` → `git add docs/community_plugins.json` in the workflow.