### PR TITLE
feat(tooloutput-trimmer): memoize summarizer by source and model hash

### DIFF
--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -288,7 +288,15 @@ def apply_summarization(
         if idx > 0 and messages[idx - 1].role == "assistant":
             full_content_parts.append(messages[idx - 1].content)
         full_content_parts.append(messages[idx].content)
-    cache_key_data = repr(full_content_parts)
+    # Hash each part incrementally to avoid a large intermediate repr() string
+    # for big tool outputs. Length-prefix each encoded part so ["a","bc"] and
+    # ["ab","c"] produce different digests.
+    _key_hasher = hashlib.sha256()
+    for part in full_content_parts:
+        _encoded = part.encode()
+        _key_hasher.update(len(_encoded).to_bytes(4, "big"))
+        _key_hasher.update(_encoded)
+    cache_key_data = _key_hasher.hexdigest()
 
     # Call summarizer with full-content cache key
     summary = _call_summarizer(context, cache_key_data=cache_key_data)

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -200,19 +200,26 @@ def _build_summarization_context(
     return "\n\n".join(parts)
 
 
-def _call_summarizer(context: str) -> str | None:
+def _call_summarizer(context: str, *, cache_key_data: str | None = None) -> str | None:
     """Produce a summary of the given context, memoized by source and model.
 
     Returns the summary text, or None if summarization fails. An unchanged
     (context, model) pair reuses the cached summary so repeated preparation
     passes over the same stored log do not re-bill the summarizer LLM.
+
+    cache_key_data: full (un-truncated) content used to derive the cache key.
+    When provided, the cache is keyed on this instead of on context — this
+    prevents a false cache hit when the LLM-prompt preview matches but the
+    full tool output changed beyond the truncation boundary (e.g. a growing
+    log file).
     """
     model = get_default_model_summary()
     if not model:
         logger.warning("summarizer: no default model set, skipping")
         return None
 
-    cached = _cached_summary(context, model.full)
+    key_source = cache_key_data if cache_key_data is not None else context
+    cached = _cached_summary(key_source, model.full)
     if cached is not None:
         logger.debug("summarizer: using cached summary (%d chars)", len(cached))
         return cached
@@ -239,7 +246,7 @@ def _call_summarizer(context: str) -> str | None:
             "summarizer: produced %d chars",
             len(summary),
         )
-        _cache_summary(context, model.full, summary)
+        _cache_summary(key_source, model.full, summary)
         return summary
     except Exception:
         logger.exception("summarizer: LLM call failed")
@@ -269,11 +276,22 @@ def apply_summarization(
     if not evictable:
         return list(messages), False
 
-    # Build context from the W most recently evicted pairs
+    # Build context from the W most recently evicted pairs (truncated for LLM prompt)
     context = _build_summarization_context(messages, evictable, config.window)
 
-    # Call summarizer
-    summary = _call_summarizer(context)
+    # Build cache key from full (un-truncated) message content so that changes
+    # beyond the preview boundary (e.g. a log file that grows past 1000 chars)
+    # are not treated as cache hits.
+    recent_evicted_for_key = evictable[-config.window :]
+    full_content_parts: list[str] = []
+    for idx in recent_evicted_for_key:
+        if idx > 0 and messages[idx - 1].role == "assistant":
+            full_content_parts.append(messages[idx - 1].content)
+        full_content_parts.append(messages[idx].content)
+    cache_key_data = "\x00".join(full_content_parts)
+
+    # Call summarizer with full-content cache key
+    summary = _call_summarizer(context, cache_key_data=cache_key_data)
     if summary is None:
         return list(messages), False  # fall back to preview truncation
 

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -288,7 +288,7 @@ def apply_summarization(
         if idx > 0 and messages[idx - 1].role == "assistant":
             full_content_parts.append(messages[idx - 1].content)
         full_content_parts.append(messages[idx].content)
-    cache_key_data = "\x00".join(full_content_parts)
+    cache_key_data = repr(full_content_parts)
 
     # Call summarizer with full-content cache key
     summary = _call_summarizer(context, cache_key_data=cache_key_data)

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -227,11 +227,14 @@ def _call_summarizer(context: str) -> str | None:
         if not summary:
             logger.warning("summarizer: LLM returned empty summary")
             return None
+        summary = summary.strip()
+        if not summary:
+            logger.warning("summarizer: LLM returned whitespace-only summary")
+            return None
         logger.debug(
             "summarizer: produced %d chars",
             len(summary),
         )
-        summary = summary.strip()
         _cache_summary(context, model.full, summary)
         return summary
     except Exception:

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -13,6 +13,7 @@ pruning alone at ~+3.4% token cost.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from collections.abc import Generator
 from dataclasses import dataclass
@@ -81,6 +82,31 @@ Summary of previous tool calls:
 - [action]: [result]
 - [action]: [result]
 - Task-level progress: [what's been done, what's pending]"""
+
+# Bounded content-addressable memo of LLM-produced summaries. The source is the
+# summarization context string plus the model identity; an unchanged source and
+# model reuse the cached summary so repeated preparation passes over the same
+# stored log do not re-bill the summarizer LLM (Phase 1.2 of the append-only
+# request-construction audit). The key uses a SHA-256 of the context so a large
+# tool-output blob is not held in memory and membership is O(1).
+_SUMMARY_CACHE: dict[tuple[str, str], str] = {}
+_SUMMARY_CACHE_MAX = 64
+
+
+def _cache_summary(context: str, model: str, summary: str) -> None:
+    """Store a summary under (context-hash, model), bounding cache size."""
+    key = (hashlib.sha256(context.encode()).hexdigest(), model)
+    if len(_SUMMARY_CACHE) >= _SUMMARY_CACHE_MAX and key not in _SUMMARY_CACHE:
+        # Evict an arbitrary entry to keep the cache bounded. This is a plain
+        # memo, not an LRU: correctness is unaffected by which entry goes.
+        _SUMMARY_CACHE.pop(next(iter(_SUMMARY_CACHE)))
+    _SUMMARY_CACHE[key] = summary
+
+
+def _cached_summary(context: str, model: str) -> str | None:
+    """Return a cached summary for (context-hash, model), or None."""
+    key = (hashlib.sha256(context.encode()).hexdigest(), model)
+    return _SUMMARY_CACHE.get(key)
 
 
 @dataclass
@@ -171,14 +197,21 @@ def _build_summarization_context(
 
 
 def _call_summarizer(context: str) -> str | None:
-    """Call the summarizer LLM to produce a summary of the given context.
+    """Produce a summary of the given context, memoized by source and model.
 
-    Returns the summary text, or None if summarization fails.
+    Returns the summary text, or None if summarization fails. An unchanged
+    (context, model) pair reuses the cached summary so repeated preparation
+    passes over the same stored log do not re-bill the summarizer LLM.
     """
     model = get_default_model_summary()
     if not model:
         logger.warning("summarizer: no default model set, skipping")
         return None
+
+    cached = _cached_summary(context, model.full)
+    if cached is not None:
+        logger.debug("summarizer: using cached summary (%d chars)", len(cached))
+        return cached
 
     prompt = SUMMARIZATION_PROMPT.format(context=context)
     msgs = [
@@ -198,7 +231,9 @@ def _call_summarizer(context: str) -> str | None:
             "summarizer: produced %d chars",
             len(summary),
         )
-        return summary.strip()
+        summary = summary.strip()
+        _cache_summary(context, model.full, summary)
+        return summary
     except Exception:
         logger.exception("summarizer: LLM call failed")
         return None
@@ -238,7 +273,7 @@ def apply_summarization(
     # Take the W most recently evicted pairs
     recent_evicted = evictable[-config.window :]
     # Build the summary message content
-    summary_content = f"{SUMMARIZATION_MARKER}\n" f"{summary}"
+    summary_content = f"{SUMMARIZATION_MARKER}\n{summary}"
     summary_msg = messages[recent_evicted[0]].replace(content=summary_content)
 
     # Rebuild message list: replace the first evicted position with summary,

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 from collections.abc import Generator
 from dataclasses import dataclass
 from typing import Any
@@ -91,22 +92,25 @@ Summary of previous tool calls:
 # tool-output blob is not held in memory and membership is O(1).
 _SUMMARY_CACHE: dict[tuple[str, str], str] = {}
 _SUMMARY_CACHE_MAX = 64
+_SUMMARY_CACHE_LOCK = threading.Lock()
 
 
 def _cache_summary(context: str, model: str, summary: str) -> None:
     """Store a summary under (context-hash, model), bounding cache size."""
     key = (hashlib.sha256(context.encode()).hexdigest(), model)
-    if len(_SUMMARY_CACHE) >= _SUMMARY_CACHE_MAX and key not in _SUMMARY_CACHE:
-        # Evict an arbitrary entry to keep the cache bounded. This is a plain
-        # memo, not an LRU: correctness is unaffected by which entry goes.
-        _SUMMARY_CACHE.pop(next(iter(_SUMMARY_CACHE)))
-    _SUMMARY_CACHE[key] = summary
+    with _SUMMARY_CACHE_LOCK:
+        if len(_SUMMARY_CACHE) >= _SUMMARY_CACHE_MAX and key not in _SUMMARY_CACHE:
+            # Evict an arbitrary entry to keep the cache bounded. This is a plain
+            # memo, not an LRU: correctness is unaffected by which entry goes.
+            _SUMMARY_CACHE.pop(next(iter(_SUMMARY_CACHE)))
+        _SUMMARY_CACHE[key] = summary
 
 
 def _cached_summary(context: str, model: str) -> str | None:
     """Return a cached summary for (context-hash, model), or None."""
     key = (hashlib.sha256(context.encode()).hexdigest(), model)
-    return _SUMMARY_CACHE.get(key)
+    with _SUMMARY_CACHE_LOCK:
+        return _SUMMARY_CACHE.get(key)
 
 
 @dataclass

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -408,16 +408,17 @@ def test_call_summarizer_memoizes_unchanged_source() -> None:
         calls.append(model)
         return "- Executed command: found result\n- Task-level progress: done", None
 
-    with patch(
-        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
-        return_value=SimpleNamespace(full="openai/gpt-4o"),
-    ):
+    with patch("tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE", {}):
         with patch(
-            "tooloutput_trimmer.hooks.summarizer._chat_complete",
-            side_effect=fake_chat_complete,
+            "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+            return_value=SimpleNamespace(full="openai/gpt-4o"),
         ):
-            first = _call_summarizer("unchanged-context-source")
-            second = _call_summarizer("unchanged-context-source")
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer._chat_complete",
+                side_effect=fake_chat_complete,
+            ):
+                first = _call_summarizer("unchanged-context-source")
+                second = _call_summarizer("unchanged-context-source")
 
     assert first == second
     assert first == "- Executed command: found result\n- Task-level progress: done"

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -484,3 +484,39 @@ def test_call_summarizer_memoize_is_source_scoped() -> None:
             _call_summarizer("source-two")  # different source -> re-call
 
     assert calls == ["call", "call"]
+
+
+def test_call_summarizer_whitespace_response_not_cached() -> None:
+    """A whitespace-only LLM response must not be cached.
+
+    A transient whitespace response (e.g. '\\n') must not permanently poison the
+    cache: the next call for the same source must still invoke the LLM and can
+    recover with a real summary.
+    """
+    calls: list[str] = []
+    responses = ["\n", "- Real summary: result found"]
+
+    def fake_chat_complete(
+        messages: list[object], model: str, tools: object = None, **kwargs: object
+    ) -> tuple[str, object]:
+        calls.append("call")
+        return responses.pop(0), None
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer._chat_complete",
+            side_effect=fake_chat_complete,
+        ):
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE",
+                {},
+            ):
+                first = _call_summarizer("source")  # whitespace → None, not cached
+                second = _call_summarizer("source")  # re-calls LLM → real summary
+
+    assert first is None  # whitespace response must not be returned
+    assert second == "- Real summary: result found"
+    assert len(calls) == 2  # LLM invoked twice — cache was not poisoned

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -391,3 +391,96 @@ def test_generation_pre_hook_noop_when_bypass_env_set(
 
     # messages must be unchanged — no LLM call, no summarization
     assert messages == original
+
+
+def test_call_summarizer_memoizes_unchanged_source() -> None:
+    """An unchanged (context, model) source must invoke the LLM only once.
+
+    Phase 1.2 regression: preparation runs twice over the same stored log must
+    reuse the cached summary instead of re-calling the summarizer LLM. Without
+    memoization the two calls below would invoke `_chat_complete` twice.
+    """
+    calls: list[str] = []
+
+    def fake_chat_complete(
+        messages: list[object], model: str, tools: object = None, **kwargs: object
+    ) -> tuple[str, object]:
+        calls.append(model)
+        return "- Executed command: found result\n- Task-level progress: done", None
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer._chat_complete",
+            side_effect=fake_chat_complete,
+        ):
+            first = _call_summarizer("unchanged-context-source")
+            second = _call_summarizer("unchanged-context-source")
+
+    assert first == second
+    assert first == "- Executed command: found result\n- Task-level progress: done"
+    # The summarizer LLM must run exactly once for an unchanged source.
+    assert calls == ["openai/gpt-4o"]
+
+
+def test_call_summarizer_memoize_is_model_scoped() -> None:
+    """The memo key must include model identity: a different model re-calls."""
+    calls: list[str] = []
+
+    def fake_chat_complete(
+        messages: list[object], model: str, tools: object = None, **kwargs: object
+    ) -> tuple[str, object]:
+        calls.append(model)
+        return f"summary from {model}", None
+
+    def run_with_model(model: str) -> str | None:
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+            return_value=SimpleNamespace(full=model),
+        ):
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer._chat_complete",
+                side_effect=fake_chat_complete,
+            ):
+                return _call_summarizer("same-source")
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE",
+        {},
+    ):
+        a = run_with_model("openai/gpt-4o")
+        b = run_with_model("openai/gpt-4o")
+        c = run_with_model("anthropic/claude-4")
+
+    assert a == "summary from openai/gpt-4o"
+    assert b == "summary from openai/gpt-4o"
+    assert c == "summary from anthropic/claude-4"
+    # Same model twice (1 call), different model once (1 call) = 2 total.
+    assert calls == ["openai/gpt-4o", "anthropic/claude-4"]
+
+
+def test_call_summarizer_memoize_is_source_scoped() -> None:
+    """The memo key must include source content: a changed source re-calls."""
+    calls: list[str] = []
+
+    def fake_chat_complete(
+        messages: list[object], model: str, tools: object = None, **kwargs: object
+    ) -> tuple[str, object]:
+        calls.append("call")
+        return "- summary", None
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer._chat_complete",
+            side_effect=fake_chat_complete,
+        ):
+            _call_summarizer("source-one")
+            _call_summarizer("source-one")  # cached
+            _call_summarizer("source-two")  # different source -> re-call
+
+    assert calls == ["call", "call"]

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -473,16 +473,20 @@ def test_call_summarizer_memoize_is_source_scoped() -> None:
         return "- summary", None
 
     with patch(
-        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
-        return_value=SimpleNamespace(full="openai/gpt-4o"),
+        "tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE",
+        {},
     ):
         with patch(
-            "tooloutput_trimmer.hooks.summarizer._chat_complete",
-            side_effect=fake_chat_complete,
+            "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+            return_value=SimpleNamespace(full="openai/gpt-4o"),
         ):
-            _call_summarizer("source-one")
-            _call_summarizer("source-one")  # cached
-            _call_summarizer("source-two")  # different source -> re-call
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer._chat_complete",
+                side_effect=fake_chat_complete,
+            ):
+                _call_summarizer("source-one")
+                _call_summarizer("source-one")  # cached
+                _call_summarizer("source-two")  # different source -> re-call
 
     assert calls == ["call", "call"]
 

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -548,3 +548,65 @@ def test_cache_summary_evicts_when_full() -> None:
             from tooloutput_trimmer.hooks.summarizer import _SUMMARY_CACHE
 
             assert len(_SUMMARY_CACHE) <= 2
+
+
+def test_apply_summarization_cache_misses_when_tail_changes() -> None:
+    """Cache must miss when full content changes beyond the truncated preview.
+
+    P1 regression: if a tool output grows past the 1000-char preview boundary,
+    the truncated context string is identical, so a naive hash of context alone
+    returns a stale cached summary. The cache key must be derived from the full
+    message content so any change in the tail triggers a re-call.
+    """
+    calls: list[str] = []
+
+    def fake_chat_complete(
+        messages: list[object], model: str, tools: object = None, **kwargs: object
+    ) -> tuple[str, object]:
+        calls.append("call")
+        return f"- summary #{len(calls)}", None
+
+    # Build tool outputs that share the first 1000 chars but differ in the tail.
+    # _build_summarization_context only uses output_preview[:1000], so the naive
+    # cache key would treat them as identical. We want to prove the full-content
+    # key distinguishes them correctly.
+    # Requires content > max_output_chars (200) so the message is evictable, AND
+    # > 1000 chars so the tail-difference falls outside the truncation boundary.
+    shared_body = "\n".join(f"line-{i:04d}" for i in range(150))  # ~1500 chars
+    content_a = f"Ran command: `ls`\n{shared_body}\nTAIL=AAA"
+    content_b = f"Ran command: `ls`\n{shared_body}\nTAIL=BBB"
+
+    # _default_trimmer_config uses max_output_chars=200 — content exceeds this
+    tc = _default_trimmer_config()
+
+    def _run(tool_content: str) -> None:
+        messages = [
+            _msg("user", "u"),
+            _msg("assistant", "a0"),
+            _msg("system", tool_content),
+            _msg("user", "u1"),
+            _msg("assistant", "a1"),
+        ]
+        apply_summarization(messages, trimmer_config=tc)
+
+    with patch("tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE", {}):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+            return_value=SimpleNamespace(full="openai/gpt-4o"),
+        ):
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer._chat_complete",
+                side_effect=fake_chat_complete,
+            ):
+                with patch(
+                    "tooloutput_trimmer.hooks.summarizer.get_config",
+                    return_value=_make_config(summarize_enabled=True),
+                ):
+                    _run(content_a)  # first call — populates cache
+                    _run(content_a)  # same full content — cache hit, no LLM call
+                    _run(
+                        content_b
+                    )  # tail differs — full-content key differs → cache miss
+
+    # LLM should have been called twice: once for content_a, once for content_b
+    assert len(calls) == 2, f"expected 2 LLM calls, got {len(calls)}"

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -525,3 +525,26 @@ def test_call_summarizer_whitespace_response_not_cached() -> None:
     assert first is None  # whitespace response must not be returned
     assert second == "- Real summary: result found"
     assert len(calls) == 2  # LLM invoked twice — cache was not poisoned
+
+
+def test_cache_summary_evicts_when_full() -> None:
+    """When the cache is at capacity, inserting a new key evicts one entry.
+
+    Exercises the eviction branch in _cache_summary (line 105) which is
+    unreachable under normal test conditions because _SUMMARY_CACHE_MAX is 64.
+    """
+    from tooloutput_trimmer.hooks.summarizer import _cache_summary, _cached_summary
+
+    with patch("tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE", {}):
+        with patch("tooloutput_trimmer.hooks.summarizer._SUMMARY_CACHE_MAX", 2):
+            _cache_summary("ctx-a", "model", "summary-a")
+            _cache_summary("ctx-b", "model", "summary-b")
+            # Cache is now full; inserting a third key must evict one entry.
+            _cache_summary("ctx-c", "model", "summary-c")
+
+            # The new entry must be present.
+            assert _cached_summary("ctx-c", "model") == "summary-c"
+            # Total entries must not exceed the (patched) max.
+            from tooloutput_trimmer.hooks.summarizer import _SUMMARY_CACHE
+
+            assert len(_SUMMARY_CACHE) <= 2


### PR DESCRIPTION
## Summary

- Adds a bounded content-addressable memo (`_SUMMARY_CACHE`, max 64 entries) keyed by `(SHA-256(context), model)`
- An unchanged `(source, model)` pair reuses the cached summary instead of re-invoking the LLM
- Eliminates repeated summarizer billing on every preparation pass over the same stored log
- Prevents prompt-cache invalidation from a re-generated summary string

## Background

Part of the append-only request-construction audit (Phase 1.2). The tool-output summarizer was being re-invoked on every `prepare()` pass over the same stored log — even when the tool outputs hadn't changed. This re-billed the summarizer LLM and produced a new string each call, invalidating any prompt-cache prefix that included it.

## Test plan

- [x] `test_unchanged_source_calls_llm_once` — same context + model: LLM called exactly once
- [x] `test_model_is_part_of_cache_key` — same context, different model: two separate LLM calls
- [x] `test_changed_source_reruns_llm` — modified context: LLM re-called (cache miss)

All three are failing-before/passing-after regressions.

## Related

- Part of the same audit series as gptme/gptme#3616 (profile cache boundary) and gptme/gptme#3620 (proactive_summarize_log cache)