### PR TITLE
feat(gptodo): add --skip-claimed flag to gptodo ready

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3383,7 +3383,7 @@ def _get_claimed_task_ids(repo_root: Path) -> set[str]:
             rows = conn.execute(
                 """SELECT task_id FROM work
                 WHERE task_id LIKE 'cascade:task:%'
-                  AND status IN ('claimed', 'completed')
+                  AND status = 'claimed'
                   AND expires_at >= datetime('now')
                   AND (? = '' OR claimer != ?)""",
                 (my_agent, my_agent),

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3384,8 +3384,8 @@ def _get_claimed_task_ids(repo_root: Path) -> set[str]:
                 """SELECT task_id FROM work
                 WHERE task_id LIKE 'cascade:task:%'
                   AND status = 'claimed'
-                  AND expires_at >= datetime('now')
-                  AND (? = '' OR claimer != ?)""",
+                  AND (expires_at IS NULL OR expires_at >= datetime('now'))
+                  AND (? = '' OR claimer IS NULL OR claimer != ?)""",
                 (my_agent, my_agent),
             ).fetchall()
     except Exception:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3350,6 +3350,39 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
     )
 
 
+def _get_claimed_task_ids(repo_root: Path) -> set[str]:
+    """Return task IDs actively claimed by another agent in the coordination DB.
+
+    Queries ``state/coordination/coord.db`` using stdlib sqlite3 — no coordination
+    package dependency.  Returns an empty set if the DB is absent or unreadable.
+    """
+    import sqlite3
+
+    db_path = repo_root / "state" / "coordination" / "coord.db"
+    if not db_path.exists():
+        return set()
+
+    prefix = "cascade:task:"
+    my_agent = (
+        os.environ.get("CASCADE_COORDINATION_AGENT") or os.environ.get("AGENT_ID") or ""
+    ).strip()
+
+    try:
+        with sqlite3.connect(str(db_path)) as conn:
+            rows = conn.execute(
+                """SELECT task_id FROM work
+                WHERE task_id LIKE 'cascade:task:%'
+                  AND status IN ('claimed', 'completed')
+                  AND expires_at >= datetime('now')
+                  AND (? = '' OR claimer != ?)""",
+                (my_agent, my_agent),
+            ).fetchall()
+    except Exception:
+        return set()
+
+    return {r[0][len(prefix) :] if r[0].startswith(prefix) else r[0] for r in rows}
+
+
 @cli.command("ready")
 @click.option(
     "--state",
@@ -3394,7 +3427,16 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
     default=None,
     help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
 )
-def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool):
+@click.option(
+    "--skip-claimed",
+    "skip_claimed",
+    is_flag=True,
+    help=(
+        "Skip tasks already claimed by another coordination session. "
+        "Reads state/coordination/coord.db; silently degrades if absent."
+    ),
+)
+def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool, skip_claimed):
     """List all ready (unblocked) tasks.
 
     Shows tasks that have no dependencies or whose dependencies are all completed.
@@ -3405,6 +3447,7 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
     Use --use-cache to also check URL-based 'requires' against cached issue states.
     Use --pool to filter by work pool; default hides non-default pools (e.g. frontier).
     Use --pool all to see every pool; --pool frontier for frontier only.
+    Use --skip-claimed to hide tasks claimed by a concurrent coordination session.
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -3511,6 +3554,22 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
             t.created,
         )
     )
+
+    # Filter out tasks claimed by another coordination session
+    if skip_claimed:
+        claimed = _get_claimed_task_ids(repo_root)
+        if claimed:
+            ready_tasks = [t for t in ready_tasks if t.name not in claimed]
+        if not ready_tasks:
+            if output_json:
+                print("No ready tasks found", file=sys.stderr)
+                print(json.dumps({"ready_tasks": [], "count": 0}, indent=2))
+                return
+            if output_jsonl:
+                print("No ready tasks found", file=sys.stderr)
+                return
+            console.print("[yellow]No ready tasks found (all claimed by concurrent sessions)![/]")
+            return
 
     # JSONL output - one task per line (compact for LLM consumption)
     if output_jsonl:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -246,9 +246,20 @@ def cli(verbose, tasks_dir):
     logging.basicConfig(level=log_level)
 
     # Set GPTODO_TASKS_DIR if provided via CLI
-    # This allows find_repo_root to pick it up
+    # This allows find_repo_root to pick it up.
+    # Restore the old value on context close to avoid leaking into subsequent
+    # in-process CliRunner calls in tests.
     if tasks_dir:
+        _old_tasks_dir = os.environ.get("GPTODO_TASKS_DIR")
         os.environ["GPTODO_TASKS_DIR"] = tasks_dir
+
+        def _restore_tasks_dir_env() -> None:
+            if _old_tasks_dir is None:
+                os.environ.pop("GPTODO_TASKS_DIR", None)
+            else:
+                os.environ["GPTODO_TASKS_DIR"] = _old_tasks_dir
+
+        click.get_current_context().call_on_close(_restore_tasks_dir_env)
 
 
 @cli.command("show")

--- a/packages/gptodo/tests/test_skip_claimed.py
+++ b/packages/gptodo/tests/test_skip_claimed.py
@@ -81,6 +81,40 @@ class TestGetClaimedTaskIds:
         )
         assert _get_claimed_task_ids(tmp_path) == set()
 
+    def test_includes_null_expiry_claims(self, tmp_path: Path) -> None:
+        """Claims with NULL expires_at are treated as non-expiring — still blocked."""
+        db_path = tmp_path / "state" / "coordination" / "coord.db"
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:no-expiry-task",
+                    "status": "claimed",
+                    "expires_at": None,  # type: ignore[arg-type]
+                }
+            ],
+        )
+        result = _get_claimed_task_ids(tmp_path)
+        assert "no-expiry-task" in result
+
+    def test_includes_null_claimer_claims(self, tmp_path: Path, monkeypatch) -> None:
+        """Claims with NULL claimer are blocked (unknown owner — treat as external)."""
+        monkeypatch.setenv("AGENT_ID", "me")
+        db_path = tmp_path / "state" / "coordination" / "coord.db"
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:unknown-claimer-task",
+                    "claimer": None,  # type: ignore[arg-type]
+                    "status": "claimed",
+                    "expires_at": "2099-01-01 00:00:00",
+                }
+            ],
+        )
+        result = _get_claimed_task_ids(tmp_path)
+        assert "unknown-claimer-task" in result
+
     def test_excludes_own_agent_claims(self, tmp_path: Path, monkeypatch) -> None:
         db_path = tmp_path / "state" / "coordination" / "coord.db"
         monkeypatch.setenv("AGENT_ID", "me")

--- a/packages/gptodo/tests/test_skip_claimed.py
+++ b/packages/gptodo/tests/test_skip_claimed.py
@@ -1,0 +1,177 @@
+"""Tests for gptodo ready --skip-claimed: filters out cascade-claimed tasks."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import _get_claimed_task_ids, cli
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    lines = ["---"]
+    for key, value in metadata.items():
+        lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+def write_coord_db(db_path: Path, claims: list[dict]) -> None:
+    """Write a minimal coordination DB with given claim rows."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS work (
+                task_id TEXT NOT NULL,
+                claimer TEXT,
+                status TEXT NOT NULL,
+                expires_at TEXT
+            )"""
+        )
+        for c in claims:
+            conn.execute(
+                "INSERT INTO work (task_id, claimer, status, expires_at) VALUES (?,?,?,?)",
+                (c["task_id"], c.get("claimer", "other-agent"), c["status"], c["expires_at"]),
+            )
+
+
+# ---------------------------------------------------------------------------
+# _get_claimed_task_ids unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetClaimedTaskIds:
+    def test_returns_empty_when_db_absent(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        assert _get_claimed_task_ids(repo) == set()
+
+    def test_strips_cascade_prefix(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "state" / "coordination" / "coord.db"
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:my-task",
+                    "status": "claimed",
+                    "expires_at": "2099-01-01 00:00:00",
+                }
+            ],
+        )
+        result = _get_claimed_task_ids(tmp_path)
+        assert result == {"my-task"}
+
+    def test_ignores_expired_claims(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "state" / "coordination" / "coord.db"
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:expired-task",
+                    "status": "claimed",
+                    "expires_at": "2000-01-01 00:00:00",  # past
+                }
+            ],
+        )
+        assert _get_claimed_task_ids(tmp_path) == set()
+
+    def test_excludes_own_agent_claims(self, tmp_path: Path, monkeypatch) -> None:
+        db_path = tmp_path / "state" / "coordination" / "coord.db"
+        monkeypatch.setenv("AGENT_ID", "me")
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:my-own-task",
+                    "claimer": "me",
+                    "status": "claimed",
+                    "expires_at": "2099-01-01 00:00:00",
+                }
+            ],
+        )
+        assert _get_claimed_task_ids(tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# gptodo ready --skip-claimed integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadySkipClaimed:
+    def _setup(self, tmp_path: Path) -> tuple[Path, Path]:
+        repo = tmp_path / "repo"
+        tasks_dir = repo / "tasks"
+        tasks_dir.mkdir(parents=True)
+        return repo, tasks_dir
+
+    def test_skip_claimed_hides_claimed_task(self, tmp_path: Path) -> None:
+        repo, tasks_dir = self._setup(tmp_path)
+        write_task(tasks_dir, "free-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(tasks_dir, "claimed-task", state="backlog", created="2026-01-01T00:00:00")
+        db_path = repo / "state" / "coordination" / "coord.db"
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:claimed-task",
+                    "status": "claimed",
+                    "expires_at": "2099-01-01 00:00:00",
+                }
+            ],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--tasks-dir", str(tasks_dir), "ready", "--skip-claimed", "--jsonl"]
+        )
+        assert result.exit_code == 0, result.output
+        names = [
+            json.loads(line)["name"] for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert "free-task" in names
+        assert "claimed-task" not in names
+
+    def test_without_flag_shows_claimed_task(self, tmp_path: Path) -> None:
+        repo, tasks_dir = self._setup(tmp_path)
+        write_task(tasks_dir, "free-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(tasks_dir, "claimed-task", state="backlog", created="2026-01-01T00:00:00")
+        db_path = repo / "state" / "coordination" / "coord.db"
+        write_coord_db(
+            db_path,
+            [
+                {
+                    "task_id": "cascade:task:claimed-task",
+                    "status": "claimed",
+                    "expires_at": "2099-01-01 00:00:00",
+                }
+            ],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--tasks-dir", str(tasks_dir), "ready", "--jsonl"])
+        assert result.exit_code == 0, result.output
+        names = [
+            json.loads(line)["name"] for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert "claimed-task" in names
+
+    def test_skip_claimed_degrades_without_db(self, tmp_path: Path) -> None:
+        repo, tasks_dir = self._setup(tmp_path)
+        write_task(tasks_dir, "my-task", state="backlog", created="2026-01-01T00:00:00")
+        # No coord DB exists
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--tasks-dir", str(tasks_dir), "ready", "--skip-claimed", "--jsonl"]
+        )
+        assert result.exit_code == 0, result.output
+        names = [
+            json.loads(line)["name"] for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert "my-task" in names


### PR DESCRIPTION
## Summary

Upstreams the cascade-claim filtering from the now-closed `ready-tasks.py` wrapper script (#1487).

- Adds `--skip-claimed` to `gptodo ready` that filters out tasks already held by another coordination session
- Reads `state/coordination/coord.db` directly via stdlib `sqlite3` — no dependency on the `coordination` package
- Gracefully degrades when the DB is absent (silent no-op, returns all tasks)
- Excludes own-agent claims via `CASCADE_COORDINATION_AGENT` / `AGENT_ID` env vars

## Why

When #1487 was closed, Erik asked: "Shouldn't this be `gptodo ready`?" The filtering logic was the only value-add beyond what `gptodo ready` already had. This PR adds it where it belongs.

## Test plan

- `TestGetClaimedTaskIds`: unit tests for the helper (absent DB, prefix stripping, expiry, own-claim exclusion)
- `TestReadySkipClaimed`: integration tests via CliRunner (hides claimed, shows without flag, degrades gracefully)

```
7 passed in 0.75s
```