### PR TITLE
fix(gptme-rag): make Indexer/ContextAssembler lazy imports

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/__init__.py
+++ b/packages/gptme-rag/src/gptme_rag/__init__.py
@@ -1,4 +1,3 @@
-from .indexing.indexer import Indexer
 from .lesson_matcher import (
     filter_by_session_category,
     keyword_to_regex,
@@ -13,7 +12,6 @@ from .observability import (
     log_injection,
     summarize_injections,
 )
-from .query.context_assembler import ContextAssembler
 
 __all__ = [
     "ContextAssembler",
@@ -29,3 +27,15 @@ __all__ = [
     "score_lessons",
     "summarize_injections",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "Indexer":
+        from .indexing.indexer import Indexer
+
+        return Indexer
+    if name == "ContextAssembler":
+        from .query.context_assembler import ContextAssembler
+
+        return ContextAssembler
+    raise AttributeError(f"module 'gptme_rag' has no attribute {name!r}")

--- a/packages/gptme-rag/src/gptme_rag/__init__.py
+++ b/packages/gptme-rag/src/gptme_rag/__init__.py
@@ -31,11 +31,27 @@ __all__ = [
 
 def __getattr__(name: str) -> object:
     if name == "Indexer":
-        from .indexing.indexer import Indexer
+        try:
+            from .indexing.indexer import Indexer
 
-        return Indexer
+            return Indexer
+        except ImportError as e:
+            raise AttributeError(
+                f"module 'gptme_rag' has no attribute {name!r} "
+                "(heavy deps not installed; install gptme-rag[full])"
+            ) from e
     if name == "ContextAssembler":
-        from .query.context_assembler import ContextAssembler
+        try:
+            from .query.context_assembler import ContextAssembler
 
-        return ContextAssembler
+            return ContextAssembler
+        except ImportError as e:
+            raise AttributeError(
+                f"module 'gptme_rag' has no attribute {name!r} "
+                "(heavy deps not installed; install gptme-rag[full])"
+            ) from e
     raise AttributeError(f"module 'gptme_rag' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/packages/gptme-rag/src/gptme_rag/__init__.py
+++ b/packages/gptme-rag/src/gptme_rag/__init__.py
@@ -13,6 +13,10 @@ from .observability import (
     summarize_injections,
 )
 
+# Note: Indexer and ContextAssembler are lazy-loaded via __getattr__ below.
+# They require the full install (gptme-rag[full]) with chromadb + sentence_transformers.
+# ``from gptme_rag import *`` will raise AttributeError for these names when the
+# heavy deps are absent; prefer explicit imports or hasattr() guards at call sites.
 __all__ = [
     "ContextAssembler",
     "IndexHealth",
@@ -34,6 +38,8 @@ def __getattr__(name: str) -> object:
         try:
             from .indexing.indexer import Indexer
 
+            # Cache in module namespace so subsequent accesses skip __getattr__.
+            globals()["Indexer"] = Indexer
             return Indexer
         except ImportError as e:
             raise AttributeError(
@@ -44,6 +50,8 @@ def __getattr__(name: str) -> object:
         try:
             from .query.context_assembler import ContextAssembler
 
+            # Cache in module namespace so subsequent accesses skip __getattr__.
+            globals()["ContextAssembler"] = ContextAssembler
             return ContextAssembler
         except ImportError as e:
             raise AttributeError(
@@ -54,4 +62,5 @@ def __getattr__(name: str) -> object:
 
 
 def __dir__() -> list[str]:
-    return __all__
+    # Include standard module attributes (from __dict__) plus lazy names from __all__.
+    return sorted(set(globals().keys()) | set(__all__))

--- a/packages/gptme-rag/tests/test_lazy_import.py
+++ b/packages/gptme-rag/tests/test_lazy_import.py
@@ -76,3 +76,46 @@ def test_unknown_attr_raises() -> None:
 
     with pytest.raises(AttributeError, match="gptme_rag"):
         _ = gptme_rag.NonExistentClass
+
+
+def test_missing_dep_raises_attribute_error_not_import_error() -> None:
+    """When a heavy dep is absent, __getattr__ must raise AttributeError, not ImportError.
+
+    hasattr() and getattr(..., default) only catch AttributeError.  If __getattr__
+    propagates ImportError, code that probes for optional Indexer will crash
+    instead of gracefully falling back.
+    """
+    import sys
+    from unittest.mock import patch
+
+    import gptme_rag
+    import pytest
+
+    # Evict any cached resolution of the indexer submodule.
+    for key in list(sys.modules):
+        if "gptme_rag.indexing" in key:
+            del sys.modules[key]
+
+    # Block the submodule as if chromadb were not installed (None → ImportError).
+    blocking = {
+        "gptme_rag.indexing": None,
+        "gptme_rag.indexing.indexer": None,
+    }
+    with patch.dict(sys.modules, blocking):
+        # hasattr must return False, not bubble up an ImportError.
+        assert not hasattr(gptme_rag, "Indexer")
+        # getattr with a default must return the default.
+        sentinel = object()
+        assert getattr(gptme_rag, "Indexer", sentinel) is sentinel
+        # Direct access must raise AttributeError (not ImportError).
+        with pytest.raises(AttributeError):
+            _ = gptme_rag.Indexer
+
+
+def test_dir_includes_lazy_names() -> None:
+    """Lazy names (Indexer, ContextAssembler) must appear in dir(gptme_rag)."""
+    import gptme_rag
+
+    d = dir(gptme_rag)
+    assert "Indexer" in d
+    assert "ContextAssembler" in d

--- a/packages/gptme-rag/tests/test_lazy_import.py
+++ b/packages/gptme-rag/tests/test_lazy_import.py
@@ -91,17 +91,11 @@ def test_missing_dep_raises_attribute_error_not_import_error() -> None:
     import gptme_rag
     import pytest
 
-    # Evict any cached resolution of the indexer submodule.
-    for key in list(sys.modules):
-        if "gptme_rag.indexing" in key:
-            del sys.modules[key]
-
-    # Block the submodule as if chromadb were not installed (None → ImportError).
-    blocking = {
-        "gptme_rag.indexing": None,
-        "gptme_rag.indexing.indexer": None,
-    }
-    with patch.dict(sys.modules, blocking):
+    # Block only the indexer submodule (None → ImportError).  Do NOT evict
+    # gptme_rag.indexing.* broadly — that clobbers gptme_rag.indexing.document,
+    # causing Document class-identity mismatches and pickling failures in sibling
+    # tests that share Document instances across the session.
+    with patch.dict(sys.modules, {"gptme_rag.indexing.indexer": None}):
         # hasattr must return False, not bubble up an ImportError.
         assert not hasattr(gptme_rag, "Indexer")
         # getattr with a default must return the default.

--- a/packages/gptme-rag/tests/test_lazy_import.py
+++ b/packages/gptme-rag/tests/test_lazy_import.py
@@ -63,6 +63,10 @@ def test_lazy_classes_in_all() -> None:
 
 def test_lazy_indexer_resolves() -> None:
     """gptme_rag.Indexer must resolve to the real class via __getattr__."""
+    import pytest
+
+    pytest.importorskip("chromadb", reason="heavy deps not installed")
+
     import gptme_rag
 
     cls = gptme_rag.Indexer
@@ -91,19 +95,27 @@ def test_missing_dep_raises_attribute_error_not_import_error() -> None:
     import gptme_rag
     import pytest
 
-    # Block only the indexer submodule (None → ImportError).  Do NOT evict
-    # gptme_rag.indexing.* broadly — that clobbers gptme_rag.indexing.document,
-    # causing Document class-identity mismatches and pickling failures in sibling
-    # tests that share Document instances across the session.
-    with patch.dict(sys.modules, {"gptme_rag.indexing.indexer": None}):
-        # hasattr must return False, not bubble up an ImportError.
-        assert not hasattr(gptme_rag, "Indexer")
-        # getattr with a default must return the default.
-        sentinel = object()
-        assert getattr(gptme_rag, "Indexer", sentinel) is sentinel
-        # Direct access must raise AttributeError (not ImportError).
-        with pytest.raises(AttributeError):
-            _ = gptme_rag.Indexer
+    # If a prior test already resolved and cached Indexer in the module namespace,
+    # clear it so __getattr__ is exercised rather than the cached value being returned.
+    cached = gptme_rag.__dict__.pop("Indexer", None)
+    try:
+        # Block only the indexer submodule (None → ImportError).  Do NOT evict
+        # gptme_rag.indexing.* broadly — that clobbers gptme_rag.indexing.document,
+        # causing Document class-identity mismatches and pickling failures in sibling
+        # tests that share Document instances across the session.
+        with patch.dict(sys.modules, {"gptme_rag.indexing.indexer": None}):
+            # hasattr must return False, not bubble up an ImportError.
+            assert not hasattr(gptme_rag, "Indexer")
+            # getattr with a default must return the default.
+            sentinel = object()
+            assert getattr(gptme_rag, "Indexer", sentinel) is sentinel
+            # Direct access must raise AttributeError (not ImportError).
+            with pytest.raises(AttributeError):
+                _ = gptme_rag.Indexer
+    finally:
+        # Restore cached value if it was present, so subsequent tests still work.
+        if cached is not None:
+            gptme_rag.__dict__["Indexer"] = cached
 
 
 def test_dir_includes_lazy_names() -> None:

--- a/packages/gptme-rag/tests/test_lazy_import.py
+++ b/packages/gptme-rag/tests/test_lazy_import.py
@@ -1,0 +1,66 @@
+"""Test that gptme_rag is importable without heavy deps (chromadb/sentence_transformers).
+
+Phase 3 prerequisite: match-lessons.py and similar hooks must be able to
+``import gptme_rag`` in the brain runtime without pulling in chromadb +
+torch (which adds several GB and ~10s to every prompt-submit hook invocation).
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def test_plain_import_does_not_pull_chromadb() -> None:
+    """``import gptme_rag`` must not import chromadb or sentence_transformers."""
+    # Remove any prior import so the test is isolated
+    mods_to_drop = [k for k in sys.modules if k.startswith("gptme_rag")]
+    for mod in mods_to_drop:
+        del sys.modules[mod]
+
+    import gptme_rag  # noqa: F401
+
+    heavy = [m for m in sys.modules if m in ("chromadb", "sentence_transformers")]
+    assert not heavy, f"Heavy deps imported after plain import: {heavy}"
+
+
+def test_lesson_matcher_functions_eagerly_importable() -> None:
+    """Lesson-matching surface must be importable without instantiating the dense backend."""
+    from gptme_rag import (
+        filter_by_session_category,
+        keyword_to_regex,
+        match_keyword,
+        scan_lessons,
+        score_lessons,
+    )
+
+    # Basic smoke-test: functions are callable
+    assert callable(scan_lessons)
+    assert callable(score_lessons)
+    assert callable(match_keyword)
+    assert callable(keyword_to_regex)
+    assert callable(filter_by_session_category)
+
+
+def test_lazy_classes_in_all() -> None:
+    """Indexer and ContextAssembler must remain in __all__ despite lazy import."""
+    import gptme_rag
+
+    assert "Indexer" in gptme_rag.__all__
+    assert "ContextAssembler" in gptme_rag.__all__
+
+
+def test_lazy_indexer_resolves() -> None:
+    """gptme_rag.Indexer must resolve to the real class via __getattr__."""
+    import gptme_rag
+
+    cls = gptme_rag.Indexer
+    assert cls.__name__ == "Indexer"
+
+
+def test_unknown_attr_raises() -> None:
+    """Unknown attributes must raise AttributeError, not silently return None."""
+    import gptme_rag
+    import pytest
+
+    with pytest.raises(AttributeError, match="gptme_rag"):
+        _ = gptme_rag.NonExistentClass

--- a/packages/gptme-rag/tests/test_lazy_import.py
+++ b/packages/gptme-rag/tests/test_lazy_import.py
@@ -12,15 +12,27 @@ import sys
 
 def test_plain_import_does_not_pull_chromadb() -> None:
     """``import gptme_rag`` must not import chromadb or sentence_transformers."""
-    # Remove any prior import so the test is isolated
-    mods_to_drop = [k for k in sys.modules if k.startswith("gptme_rag")]
-    for mod in mods_to_drop:
-        del sys.modules[mod]
+    _HEAVY = ("chromadb", "sentence_transformers")
 
-    import gptme_rag  # noqa: F401
+    # Snapshot and evict all gptme_rag submodules AND heavy deps so this test
+    # measures what a fresh process would see, not what prior tests already loaded.
+    saved: dict[str, object] = {}
+    for k in list(sys.modules):
+        if k.startswith("gptme_rag") or any(k == h or k.startswith(h + ".") for h in _HEAVY):
+            saved[k] = sys.modules.pop(k)
 
-    heavy = [m for m in sys.modules if m in ("chromadb", "sentence_transformers")]
-    assert not heavy, f"Heavy deps imported after plain import: {heavy}"
+    try:
+        import gptme_rag  # noqa: F401
+
+        heavy = [m for m in sys.modules if any(m == h or m.startswith(h + ".") for h in _HEAVY)]
+        assert not heavy, f"Heavy deps imported after plain import: {heavy}"
+    finally:
+        # Restore original module state so later tests are not affected by
+        # the transient eviction above.
+        for k in list(sys.modules):
+            if k.startswith("gptme_rag") or any(k == h or k.startswith(h + ".") for h in _HEAVY):
+                del sys.modules[k]
+        sys.modules.update(saved)
 
 
 def test_lesson_matcher_functions_eagerly_importable() -> None:


### PR DESCRIPTION
## Summary

- `import gptme_rag` previously pulled in chromadb + sentence_transformers eagerly via `Indexer` and `ContextAssembler`
- This blocked adoption in lightweight hook runtimes (match-lessons.py, prompt-submit hooks) where the dense backend is not needed
- Switches to module-level `__getattr__` so heavy deps load only when the caller actually uses `Indexer` or `ContextAssembler`
- `lesson_matcher` and `observability` functions remain eagerly importable

## Motivation

Phase 3 of the gptme-rag adoption plan (ErikBjare/bob) requires `match-lessons.py` to import from `gptme_rag` for BM25 scoring. The current eager import of chromadb + torch makes this unusable in the hook runtime (adds ~10s startup + GB of deps).

## Changes

- `gptme_rag/__init__.py`: remove two eager imports, add `__getattr__` with lazy loading
- `tests/test_lazy_import.py`: 5 tests verifying the no-heavy-deps guarantee and lazy resolution

## Test plan

- [x] `import gptme_rag` does not import chromadb (verified locally)
- [x] `gptme_rag.scan_lessons`, `score_lessons`, etc. importable without chromadb
- [x] `gptme_rag.Indexer` still resolves correctly via `__getattr__`
- [x] Unknown attributes raise `AttributeError`
- [ ] CI full test suite