### PR TITLE
fix(lessons): honor metadata.status in both lesson/skill matchers

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -165,6 +165,24 @@ def _clean_plain_scalar(raw: str) -> str:
     return re.split(r"\s+#", value, maxsplit=1)[0].strip()
 
 
+def effective_status(fm: dict) -> str:
+    """Resolve a lesson/skill lifecycle status from top-level or nested metadata.
+
+    The Agent Skills schema has no top-level ``status`` key, so a deprecated
+    ``SKILL.md`` can only record its lifecycle as ``metadata.status``. Treat
+    both locations as authoritative and let any non-active value win, so a
+    deprecation is never silently dropped because of where it was written.
+    """
+    candidates = [fm.get("status")]
+    metadata = fm.get("metadata")
+    if isinstance(metadata, dict):
+        candidates.append(metadata.get("status"))
+    for value in candidates:
+        if isinstance(value, str) and value.strip() and value.strip() != "active":
+            return value.strip()
+    return "active"
+
+
 def _extract_scalar_frontmatter_field(
     fm_str: str, field: str, *, allow_indented: bool = False
 ) -> str | None:
@@ -408,6 +426,16 @@ def extract_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     status = _extract_scalar_frontmatter_field(fm_str, "status")
     if status is not None:
         fm["status"] = status
+
+    # Agent Skills store lifecycle under ``metadata.status``; scope the lookup to
+    # the metadata block so an unrelated nested ``status:`` is not hoisted.
+    metadata_status_block = _extract_mapping_block(fm_str, "metadata")
+    if metadata_status_block:
+        nested_status = _extract_scalar_frontmatter_field(
+            metadata_status_block, "status", allow_indented=True
+        )
+        if nested_status is not None:
+            fm.setdefault("metadata", {})["status"] = nested_status
 
     for field in ("id", "name", "description", "when_to_use"):
         scalar_value = _extract_scalar_frontmatter_field(fm_str, field)
@@ -658,7 +686,9 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
 
     ``SKILL.md`` files are never deduplicated by name.
 
-    Lessons with ``status`` other than ``"active"`` are skipped.
+    Lessons with a ``status`` other than ``"active"`` are skipped, whether the
+    status is written top-level or as ``metadata.status`` (see
+    :func:`effective_status`).
     Lessons with no keywords, patterns, or skill name are skipped.
     """
     lessons: list[dict[str, Any]] = []
@@ -707,8 +737,7 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
 
             fm, body = extract_frontmatter(content)
 
-            status = fm.get("status", "active")
-            if status != "active":
+            if effective_status(fm) != "active":
                 continue
 
             match_data = fm.get("match", {})

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -178,8 +178,17 @@ def effective_status(fm: dict) -> str:
     if isinstance(metadata, dict):
         candidates.append(metadata.get("status"))
     for value in candidates:
-        if isinstance(value, str) and value.strip() and value.strip() != "active":
-            return value.strip()
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped and stripped != "active":
+                return stripped
+            continue
+        # Malformed non-string status (bool, list, int).  Fail closed: only the
+        # exact string "active" enables injection, so a `status: false` or
+        # `status: [deprecated]` typo cannot silently re-enable a deprecation.
+        return str(value)
     return "active"
 
 

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -199,10 +199,31 @@ def _extract_scalar_frontmatter_field(
     lines = fm_str.splitlines()
     indent = r"[ \t]*" if allow_indented else ""
     field_pattern = re.compile(rf"^{indent}{re.escape(field)}:\s*(.*)$")
+    # Detects any mapping key whose value is a block scalar indicator (| or >).
+    # Used to skip the body so a "field:" appearing inside a block value (e.g.
+    # "status: deprecated" in a "description: |" body) is not hoisted.
+    _block_key = re.compile(r"^([ \t]*)\S+:\s*[|>][ \t]*(?:#.*)?$")
+
+    skip_until_indent: int | None = None  # column of the active block scalar key
 
     for index, line in enumerate(lines):
+        # Skip lines inside another field's block scalar body.
+        if skip_until_indent is not None:
+            stripped = line.lstrip()
+            if not stripped:
+                continue  # blank lines may appear inside a block scalar
+            cur_indent = len(line) - len(stripped)
+            if cur_indent > skip_until_indent:
+                continue  # still inside block scalar content
+            skip_until_indent = None  # dedented — end of block scalar body
+
         match = field_pattern.match(line)
         if not match:
+            # Track block scalars introduced by other keys so their bodies are
+            # skipped on subsequent iterations.
+            bs_match = _block_key.match(line)
+            if bs_match:
+                skip_until_indent = len(bs_match.group(1))
             continue
         raw_value = match.group(1).strip()
         if raw_value and raw_value[0] in "|>":

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -1474,3 +1474,19 @@ class TestEffectiveStatus:
         fm, _ = extract_frontmatter(content)
 
         assert effective_status(fm) == "deprecated"
+
+    def test_regex_fallback_ignores_status_inside_description_block_scalar(self, monkeypatch):
+        """status: inside a description block scalar must not override metadata.status."""
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        content = (
+            "---\nname: skill\n"
+            "metadata:\n"
+            "  description: |\n"
+            "    status: deprecated\n"
+            "  status: active\n"
+            "---\n# Title\nBody.\n"
+        )
+
+        fm, _ = extract_frontmatter(content)
+
+        assert effective_status(fm) == "active"

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -1427,6 +1427,20 @@ class TestEffectiveStatus:
         assert effective_status({"metadata": "not-a-dict"}) == "active"
         assert effective_status({"metadata": ["a"]}) == "active"
 
+    def test_non_string_status_fails_closed(self):
+        """A malformed non-string status must NOT be treated as active.
+
+        PyYAML parses `status: false` as a bool and `status: [deprecated]` as a
+        list.  Only the exact string "active" may enable injection, otherwise a
+        typo silently re-enables a deprecated lesson/skill.
+        """
+        assert effective_status({"status": False}) != "active"
+        assert effective_status({"status": ["deprecated"]}) != "active"
+        assert effective_status({"metadata": {"status": False}}) != "active"
+        # An empty/whitespace status is "unset", not a deprecation.
+        assert effective_status({"status": ""}) == "active"
+        assert effective_status({"status": "  "}) == "active"
+
     def test_scan_lessons_skips_skill_with_only_nested_status(self, tmp_path: Path):
         skill_dir = tmp_path / "lifecycle-phase-index"
         skill_dir.mkdir()

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -11,6 +11,7 @@ from gptme_rag.lesson_matcher import (
     BM25_MIN_Z,
     _extract_list_frontmatter_field,
     BM25_STANDOUT_FRACTION,
+    effective_status,
     extract_frontmatter,
     filter_by_harness,
     filter_by_session_category,
@@ -1405,3 +1406,57 @@ class TestDescriptorStopwords:
             "template",
             "onboarding",
         }
+
+
+class TestEffectiveStatus:
+    """Agent Skills frontmatter has no top-level ``status``, so a deprecated
+    SKILL.md can only record its lifecycle as ``metadata.status``."""
+
+    def test_defaults_to_active(self):
+        assert effective_status({}) == "active"
+        assert effective_status({"status": "active"}) == "active"
+
+    def test_nested_metadata_status_is_honored(self):
+        assert effective_status({"metadata": {"status": "archived"}}) == "archived"
+
+    def test_stale_top_level_active_does_not_mask_nested_deprecation(self):
+        fm = {"status": "active", "metadata": {"status": "deprecated"}}
+        assert effective_status(fm) == "deprecated"
+
+    def test_non_dict_metadata_does_not_raise(self):
+        assert effective_status({"metadata": "not-a-dict"}) == "active"
+        assert effective_status({"metadata": ["a"]}) == "active"
+
+    def test_scan_lessons_skips_skill_with_only_nested_status(self, tmp_path: Path):
+        skill_dir = tmp_path / "lifecycle-phase-index"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: lifecycle-phase-index\n"
+            'description: "Route work through the lifecycle phases."\n'
+            "metadata:\n  status: deprecated\n---\n# Deprecated\n"
+        )
+
+        assert scan_lessons([tmp_path]) == []
+
+    def test_scan_lessons_keeps_skill_with_nested_active_status(self, tmp_path: Path):
+        skill_dir = tmp_path / "still-live"
+        skill_dir.mkdir()
+        skill_path = skill_dir / "SKILL.md"
+        skill_path.write_text(
+            "---\nname: still-live\n"
+            'description: "Do the live thing."\n'
+            "metadata:\n  status: active\n---\n# Live\n"
+        )
+
+        assert [lesson["path"] for lesson in scan_lessons([tmp_path])] == [str(skill_path)]
+
+    def test_regex_fallback_extracts_nested_metadata_status(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        content = (
+            "---\nname: skill\nstatus: active\n"
+            "metadata:\n  status: deprecated\n---\n# Title\nBody.\n"
+        )
+
+        fm, _ = extract_frontmatter(content)
+
+        assert effective_status(fm) == "deprecated"

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -508,8 +508,14 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
 
     # Any `status:` line (top-level or nested under `metadata:`) counts; a
     # non-active value wins so a nested deprecation is not masked by an earlier
-    # top-level `status: active`.
-    statuses = re.findall(r"status:\s*(\w+)", fm_str)
+    # top-level `status: active`.  Only consider real YAML key lines — filter
+    # comment lines (starting with #) first, then anchor to line starts, so a
+    # `status:` that appears inside a description value or a YAML comment is
+    # not mistaken for a lifecycle status.
+    fm_yaml_lines = "\n".join(
+        line for line in fm_str.splitlines() if not line.strip().startswith("#")
+    )
+    statuses = re.findall(r"^[^\S\n]*status:\s*(\w+)", fm_yaml_lines, re.MULTILINE)
     if statuses:
         non_active = [s for s in statuses if s != "active"]
         fm["status"] = non_active[0] if non_active else statuses[0]

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -529,7 +529,11 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
         line for line in fm_str.splitlines() if not line.strip().startswith("#")
     )
     # (1) Top-level: `^status:` with no leading whitespace.
-    top_statuses = re.findall(r"^status:\s*(\S+)", fm_no_comments, re.MULTILINE)
+    # Strip surrounding quotes so `status: "active"` equals `status: active`.
+    top_statuses = [
+        s.strip("\"'")
+        for s in re.findall(r"^status:\s*(\S+)", fm_no_comments, re.MULTILINE)
+    ]
     # (2) metadata.status: capture the indented body after `^metadata:` and
     # search for `status:` within it.  The capture stops at the first
     # non-indented line, so a `status:` in a sibling block scalar is not
@@ -541,9 +545,12 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
         re.MULTILINE,
     )
     if meta_m:
-        meta_statuses = re.findall(
-            r"^[ \t]+status:\s*(\S+)", meta_m.group(1), re.MULTILINE
-        )
+        meta_statuses = [
+            s.strip("\"'")
+            for s in re.findall(
+                r"^[ \t]+status:\s*(\S+)", meta_m.group(1), re.MULTILINE
+            )
+        ]
     all_statuses = top_statuses + meta_statuses
     if all_statuses:
         non_active = [s for s in all_statuses if s != "active"]

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -529,7 +529,7 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
         line for line in fm_str.splitlines() if not line.strip().startswith("#")
     )
     # (1) Top-level: `^status:` with no leading whitespace.
-    top_statuses = re.findall(r"^status:\s*(\w+)", fm_no_comments, re.MULTILINE)
+    top_statuses = re.findall(r"^status:\s*(\S+)", fm_no_comments, re.MULTILINE)
     # (2) metadata.status: capture the indented body after `^metadata:` and
     # search for `status:` within it.  The capture stops at the first
     # non-indented line, so a `status:` in a sibling block scalar is not
@@ -542,7 +542,7 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
     )
     if meta_m:
         meta_statuses = re.findall(
-            r"^[ \t]+status:\s*(\w+)", meta_m.group(1), re.MULTILINE
+            r"^[ \t]+status:\s*(\S+)", meta_m.group(1), re.MULTILINE
         )
     all_statuses = top_statuses + meta_statuses
     if all_statuses:

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -464,8 +464,17 @@ def effective_status(fm: dict) -> str:
     if isinstance(metadata, dict):
         candidates.append(metadata.get("status"))
     for value in candidates:
-        if isinstance(value, str) and value.strip() and value.strip() != "active":
-            return value.strip()
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped and stripped != "active":
+                return stripped
+            continue
+        # Malformed non-string status (bool, list, int).  Fail closed: only the
+        # exact string "active" enables injection, so a `status: false` or
+        # `status: [deprecated]` typo cannot silently re-enable a deprecation.
+        return str(value)
     return "active"
 
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -506,19 +506,39 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
     if keywords:
         fm["match"] = {"keywords": keywords}
 
-    # Any `status:` line (top-level or nested under `metadata:`) counts; a
-    # non-active value wins so a nested deprecation is not masked by an earlier
-    # top-level `status: active`.  Only consider real YAML key lines — filter
-    # comment lines (starting with #) first, then anchor to line starts, so a
-    # `status:` that appears inside a description value or a YAML comment is
-    # not mistaken for a lifecycle status.
-    fm_yaml_lines = "\n".join(
+    # Resolve lifecycle status without PyYAML.  Two independent lookups avoid
+    # false positives from block scalars (e.g. `description: |` whose
+    # continuation lines can contain `status: deprecated` with leading
+    # whitespace and would fool a single anchored-but-not-scoped regex):
+    #
+    # 1. Top-level `status:` — must start at column 0 (no leading whitespace).
+    # 2. `metadata.status` — only within the `metadata:` block's indented body.
+    #
+    # Comment lines are stripped first; the patterns never match them because
+    # the real guard is structural (column-0 vs. metadata-block scope).
+    fm_no_comments = "\n".join(
         line for line in fm_str.splitlines() if not line.strip().startswith("#")
     )
-    statuses = re.findall(r"^[^\S\n]*status:\s*(\w+)", fm_yaml_lines, re.MULTILINE)
-    if statuses:
-        non_active = [s for s in statuses if s != "active"]
-        fm["status"] = non_active[0] if non_active else statuses[0]
+    # (1) Top-level: `^status:` with no leading whitespace.
+    top_statuses = re.findall(r"^status:\s*(\w+)", fm_no_comments, re.MULTILINE)
+    # (2) metadata.status: capture the indented body after `^metadata:` and
+    # search for `status:` within it.  The capture stops at the first
+    # non-indented line, so a `status:` in a sibling block scalar is not
+    # mistakenly included.
+    meta_statuses: list[str] = []
+    meta_m = re.search(
+        r"^metadata:\s*\n((?:[ \t]+\S[^\n]*\n?)*)",
+        fm_no_comments,
+        re.MULTILINE,
+    )
+    if meta_m:
+        meta_statuses = re.findall(
+            r"^[ \t]+status:\s*(\w+)", meta_m.group(1), re.MULTILINE
+        )
+    all_statuses = top_statuses + meta_statuses
+    if all_statuses:
+        non_active = [s for s in all_statuses if s != "active"]
+        fm["status"] = non_active[0] if non_active else all_statuses[0]
 
     for field in ("name", "description", "when_to_use"):
         value = _extract_scalar_frontmatter_field(fm_str, field)

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -451,6 +451,24 @@ def _dedupe_strings(values: list[object]) -> list[str]:
     return deduped
 
 
+def effective_status(fm: dict) -> str:
+    """Resolve a lesson/skill lifecycle status from top-level or nested metadata.
+
+    The Agent Skills schema has no top-level ``status``, so a deprecated
+    SKILL.md can only record it as ``metadata.status``. Treat either location as
+    authoritative and let any non-active value win, so a deprecation is never
+    silently dropped.
+    """
+    candidates = [fm.get("status")]
+    metadata = fm.get("metadata")
+    if isinstance(metadata, dict):
+        candidates.append(metadata.get("status"))
+    for value in candidates:
+        if isinstance(value, str) and value.strip() and value.strip() != "active":
+            return value.strip()
+    return "active"
+
+
 def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
     """Extract YAML frontmatter and body from markdown."""
     if not content.startswith("---"):
@@ -488,9 +506,13 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
     if keywords:
         fm["match"] = {"keywords": keywords}
 
-    m = re.search(r"status:\s*(\w+)", fm_str)
-    if m:
-        fm["status"] = m.group(1)
+    # Any `status:` line (top-level or nested under `metadata:`) counts; a
+    # non-active value wins so a nested deprecation is not masked by an earlier
+    # top-level `status: active`.
+    statuses = re.findall(r"status:\s*(\w+)", fm_str)
+    if statuses:
+        non_active = [s for s in statuses if s != "active"]
+        fm["status"] = non_active[0] if non_active else statuses[0]
 
     for field in ("name", "description", "when_to_use"):
         value = _extract_scalar_frontmatter_field(fm_str, field)
@@ -635,8 +657,7 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
 
             fm, body = extract_frontmatter(content)
 
-            status = fm.get("status", "active")
-            if status != "active":
+            if effective_status(fm) != "active":
                 continue
 
             match_data = fm.get("match", {})

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1077,3 +1077,34 @@ def test_extract_frontmatter_regex_fallback_sees_nested_status(hook, monkeypatch
     )
 
     assert hook.effective_status(fm) == "deprecated"
+
+
+def test_extract_frontmatter_regex_fallback_ignores_status_in_comments(
+    hook, monkeypatch
+):
+    """The regex fallback must not pick up `status: deprecated` from YAML comments
+    or from a description field value — only real YAML key lines count."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # A comment containing `status: deprecated` must not override the real active status.
+    fm, _ = hook.extract_frontmatter(
+        "---\nstatus: active\n# status: deprecated\n---\n# Title\n"
+    )
+    assert (
+        hook.effective_status(fm) == "active"
+    ), "comment line must not override real status"
+
+    # A description value mentioning `status: deprecated` must not override active.
+    fm2, _ = hook.extract_frontmatter(
+        "---\nstatus: active\ndescription: Fix status: deprecated handling\n---\n# Title\n"
+    )
+    assert (
+        hook.effective_status(fm2) == "active"
+    ), "description text must not override real status"

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1060,6 +1060,20 @@ def test_effective_status_prefers_non_active_from_either_location(hook):
     assert hook.effective_status({"metadata": "not-a-dict"}) == "active"
 
 
+def test_effective_status_non_string_fails_closed(hook):
+    """Non-string status values must not be treated as active.
+
+    Mirrors the gptme-rag matcher: only the exact string "active" enables
+    injection, so `status: false` (bool) or `status: [deprecated]` (list) cannot
+    silently re-enable a deprecated lesson or skill.
+    """
+    assert hook.effective_status({"status": False}) != "active"
+    assert hook.effective_status({"status": ["deprecated"]}) != "active"
+    assert hook.effective_status({"metadata": {"status": False}}) != "active"
+    assert hook.effective_status({"status": ""}) == "active"
+    assert hook.effective_status({"status": "  "}) == "active"
+
+
 def test_extract_frontmatter_regex_fallback_sees_nested_status(hook, monkeypatch):
     """Without PyYAML the regex fallback must still see a nested deprecation,
     even when an earlier top-level `status: active` precedes it."""

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1158,3 +1158,35 @@ def test_extract_frontmatter_regex_fallback_ignores_status_in_block_scalar(
     assert (
         hook.effective_status(fm) == "active"
     ), "block scalar content must not override the real top-level status"
+
+
+def test_extract_frontmatter_regex_fallback_non_word_status_fails_closed(
+    hook, monkeypatch
+):
+    """Regex fallback: `status: [deprecated]` (list value) must not be treated as active.
+
+    The ``\\w+`` pattern only captures word characters, so ``[deprecated]`` was
+    silently dropped — leaving the status absent from fm and effective_status()
+    returning "active".  The fix uses ``\\S+`` to capture any non-whitespace value
+    so the list syntax reaches effective_status() as a non-active string.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    fm, _ = hook.extract_frontmatter("---\nstatus: [deprecated]\n---\n# Title\n")
+    assert (
+        hook.effective_status(fm) != "active"
+    ), "status: [deprecated] in regex fallback must not be treated as active"
+
+    fm2, _ = hook.extract_frontmatter(
+        "---\nmetadata:\n  status: [deprecated]\n---\n# Title\n"
+    )
+    assert (
+        hook.effective_status(fm2) != "active"
+    ), "metadata.status: [deprecated] in regex fallback must not be treated as active"

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1190,3 +1190,38 @@ def test_extract_frontmatter_regex_fallback_non_word_status_fails_closed(
     assert (
         hook.effective_status(fm2) != "active"
     ), "metadata.status: [deprecated] in regex fallback must not be treated as active"
+
+
+def test_extract_frontmatter_regex_fallback_quoted_active_not_dropped(
+    hook, monkeypatch
+):
+    """Regex fallback: ``status: "active"`` (quoted) must still inject the lesson.
+
+    ``\\S+`` captures surrounding quotes, so the raw captured value is ``"active"``
+    (with quotes) instead of ``active``.  Without quote-stripping the comparison
+    ``s != "active"`` evaluates true and the lesson is silently dropped — a
+    regression vs. the prior ``\\w+`` pattern which simply never matched quoted
+    values and left status absent (defaulting to active).
+
+    The fix strips ``"`` and ``'`` from captured values before comparison.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    fm, _ = hook.extract_frontmatter('---\nstatus: "active"\n---\n# Title\n')
+    assert (
+        hook.effective_status(fm) == "active"
+    ), 'status: "active" (quoted) must not be silently dropped by regex fallback'
+
+    fm2, _ = hook.extract_frontmatter(
+        "---\nmetadata:\n  status: 'active'\n---\n# Title\n"
+    )
+    assert (
+        hook.effective_status(fm2) == "active"
+    ), "metadata.status: 'active' (single-quoted) must not be silently dropped"

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1108,3 +1108,39 @@ def test_extract_frontmatter_regex_fallback_ignores_status_in_comments(
     assert (
         hook.effective_status(fm2) == "active"
     ), "description text must not override real status"
+
+
+def test_extract_frontmatter_regex_fallback_ignores_status_in_block_scalar(
+    hook, monkeypatch
+):
+    """The regex fallback must not be fooled by `status: deprecated` that appears
+    as a content line inside a YAML block scalar (e.g. `description: |`).
+
+    Block scalar content lines are indented, so `^[^\\S\\n]*status:` would match
+    them even though they are not YAML keys.  The fix scopes the indented lookup
+    to the `metadata:` block body only, so a block scalar sibling is invisible.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # A block scalar where the content happens to contain `status: deprecated`
+    # on its own line.  The lesson itself is `status: active`.
+    frontmatter = (
+        "---\n"
+        "status: active\n"
+        "description: |\n"
+        "  This lesson explains status: deprecated handling.\n"
+        "  status: deprecated lessons are skipped by the matcher.\n"
+        "---\n"
+        "# Title\n"
+    )
+    fm, _ = hook.extract_frontmatter(frontmatter)
+    assert (
+        hook.effective_status(fm) == "active"
+    ), "block scalar content must not override the real top-level status"

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1008,3 +1008,72 @@ def test_classify_lesson_present_manifest_missing_holdout_key_returns_unknown(ho
         "'unknown', not spuriously 'holdout'."
     )
     assert version == 2
+
+
+# --- metadata.status (Agent Skills lifecycle) ---
+
+
+def _write_skill_md(tmp_path: Path, name: str, frontmatter: str) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(f"---\n{frontmatter}---\n\n# {name}\n\nBody.\n")
+    return path
+
+
+def test_scan_lessons_skips_skill_with_only_nested_metadata_status(hook, tmp_path):
+    """Agent Skills frontmatter has no top-level `status`, so a deprecated skill
+    can only record it under `metadata.status`. It must still be filtered out."""
+    lessons_dir = tmp_path / "skills"
+    _write_skill_md(
+        lessons_dir,
+        "lifecycle-phase-index",
+        'name: lifecycle-phase-index\ndescription: "Route work through phases."\nmetadata:\n  status: deprecated\n',
+    )
+
+    assert hook.scan_lessons([lessons_dir]) == []
+
+
+def test_scan_lessons_keeps_skill_with_nested_active_status(hook, tmp_path):
+    lessons_dir = tmp_path / "skills"
+    path = _write_skill_md(
+        lessons_dir,
+        "still-live",
+        'name: still-live\ndescription: "Do the live thing."\nmetadata:\n  status: active\n',
+    )
+
+    assert [entry["path"] for entry in hook.scan_lessons([lessons_dir])] == [str(path)]
+
+
+def test_effective_status_prefers_non_active_from_either_location(hook):
+    assert hook.effective_status({}) == "active"
+    assert hook.effective_status({"status": "active"}) == "active"
+    assert hook.effective_status({"metadata": {"status": "archived"}}) == "archived"
+    # A stale top-level `active` must not mask a nested deprecation.
+    assert (
+        hook.effective_status(
+            {"status": "active", "metadata": {"status": "deprecated"}}
+        )
+        == "deprecated"
+    )
+    # Non-dict metadata must not raise.
+    assert hook.effective_status({"metadata": "not-a-dict"}) == "active"
+
+
+def test_extract_frontmatter_regex_fallback_sees_nested_status(hook, monkeypatch):
+    """Without PyYAML the regex fallback must still see a nested deprecation,
+    even when an earlier top-level `status: active` precedes it."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    fm, _ = hook.extract_frontmatter(
+        "---\nstatus: active\nmetadata:\n  status: deprecated\n---\n# Title\n"
+    )
+
+    assert hook.effective_status(fm) == "deprecated"


### PR DESCRIPTION
## Problem

The Agent Skills schema has no top-level `status` key, so a deprecated `SKILL.md` can only record its lifecycle as `metadata.status`. Both matchers resolved status with `fm.get("status", "active")`, which reads the **top level only** — the nested value was silently dropped, so a retired skill kept being injected.

Found during a Phase-3 recheck of `lifecycle-phase-index`: its 2026-08-12 deprecation did not stop injection, and unique-session fire rate went 16.5% → 33.8% after keyword narrowing.

## Fix

Both matchers now resolve status through a shared `effective_status(fm)`:

- `scripts/claude-code-hooks/match-lessons.py`
- `packages/gptme-rag/src/gptme_rag/lesson_matcher.py`

It reads top-level `status` **and** `metadata.status`, and any non-active value wins — so a stale top-level `status: active` cannot mask a nested deprecation.

Both no-PyYAML regex fallbacks were widened to see the nested key too:
- the hook scans every `status:` line and prefers a non-active one;
- gptme-rag scopes the lookup through the existing `_extract_mapping_block(fm_str, "metadata")`, so an unrelated nested `status:` is not hoisted.

## Scope

Only these two are *matchers* that gate injection. Checked and deliberately left alone: `gptme-lessons-extras/validate.py` (a validator, not a loader) and `gptme-lessons-mcp/mcp_server.py` (reads `lesson.metadata.status` off gptme's own parsed model).

## Tests

10 new tests across `tests/test_cc_match_lessons.py` and `packages/gptme-rag/tests/test_lesson_matcher.py`: metadata-only deprecation is filtered, a nested-`active` control still injects, precedence when both keys disagree, non-dict `metadata` does not raise, and the regex fallback sees the nested key.

**Verified RED before green** — restoring each unpatched source makes them fail (3 failures in the hook suite; `ImportError: cannot import name 'effective_status'` in the gptme-rag suite).

- `tests/test_cc_match_lessons.py` — 73 passed
- `packages/gptme-rag/tests/test_lesson_matcher.py` — 127 passed

## Impact today

Preventive, and worth saying plainly: an audit of every markdown file under `lessons/`, `skills/`, `gptme-contrib/lessons/` and `gptme-contrib/skills/` found exactly **one** file with a non-active `metadata.status` (`skills/lifecycle-phase-index/SKILL.md`), and it already carries a top-level `status: deprecated`. So nothing is leaking right now — this closes the hole for the *next* skill deprecation, which under the Agent Skills schema can only be written the nested way.

## Not covered

Claude Code's **native** skill matcher ignores this `status` field entirely and scores `description`. A deprecated skill whose description names its replacement skills stays a semantic magnet regardless of what this PR does. Tracked separately.
