### PR TITLE
fix(pm): give AI-review dispatch arms a false-positive disposition path

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -472,7 +472,8 @@ _AI_REVIEW_NEEDS_FIX_SECTIONS: dict[str, str] = {
         "```bash\n"
         "uv run python3 {pm_review_and_push}\n"
         "```\n"
-        "If it reports P0/P1 findings, fix them and re-run it; once clean it pushes."
+        "If it reports P0/P1 findings, fix them and re-run it; once clean it pushes.\n"
+        "\n" + _CLOSE_THE_LOOP
     ),
     "warnings": (
         "Warning: **This is an AI-reviewer dispatch, not Greptile.**"
@@ -495,7 +496,8 @@ _AI_REVIEW_NEEDS_IMPROVEMENT_SECTIONS: dict[str, str] = {
     "assessment": (
         "This PR scored 4/5 from our AI reviewer — minor issues."
         " Address them if quick; leave it untouched if trivial.\n"
-        "Do NOT re-trigger the reviewer just because you looked at it."
+        "Do NOT re-trigger the reviewer just because you looked at it.\n"
+        "\n" + _CLOSE_THE_LOOP
     ),
     "warnings": (
         "Warning: **Never push trivial changes just to chase 5/5.**\n"

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
@@ -18,6 +18,35 @@ uv run python3 /srv/agents/alice/workspace/scripts/github/pm-review-and-push.py
 ```
 If it reports P0/P1 findings, fix them and re-run it; once clean it pushes.
 
+**Closing the loop — required, and NOT the same thing as a PR comment.**
+
+An inline finding lives on a *review thread*. Posting to the PR conversation
+(`issues/7/comments`) does not touch it: the thread stays open, and the
+self-merge gate counts unresolved threads. Every finding you address needs a
+reply **on its own thread**, and then a resolution.
+
+- **Fixed in code** — reply on the thread with the fix SHA, then let the
+  reviewer resolve it. Re-running the review verifies the finding no longer
+  reproduces and resolves the thread itself; that is evidence-based and
+  stronger than resolving by hand.
+  ```bash
+  # root comment ids: gh api repos/ErikBjare/alice/pulls/7/comments --jq '.[] | {id, path, line}'
+  gh api repos/ErikBjare/alice/pulls/7/comments/COMMENT_ID/replies -f body="Fixed in SHA — ..."
+  ```
+- **False positive, won't-fix, or an accepted trade-off** — no code change will
+  ever settle it, so reply AND resolve in one step. A reasoned rejection with
+  code citations IS a resolution; it is not a reason to leave the thread open.
+  ```bash
+  python3 /srv/agents/alice/workspace/scripts/github/ai-review-dispose.py ErikBjare/alice 7 --list
+  python3 /srv/agents/alice/workspace/scripts/github/ai-review-dispose.py ErikBjare/alice 7 \
+      --fingerprint FP --reason rejected --reply-file /tmp/why.md
+  ```
+  It is idempotent (a second run is a no-op) and can only ever touch threads our
+  own reviewer opened — never a human's.
+
+⚠️ Never resolve a human's review thread. Burying a person's comment is far
+worse than leaving a thread open.
+
 Warning: **This is an AI-reviewer dispatch, not Greptile.** Do NOT trigger Greptile to clear it.
 The reviewer still runs automatically on the push the wrapper makes — no manual trigger needed or wanted.
 If you cannot fix the issues in this session, leave it for the next cycle.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
@@ -18,6 +18,35 @@ uv run python3 /home/bob/bob/scripts/github/pm-review-and-push.py
 ```
 If it reports P0/P1 findings, fix them and re-run it; once clean it pushes.
 
+**Closing the loop — required, and NOT the same thing as a PR comment.**
+
+An inline finding lives on a *review thread*. Posting to the PR conversation
+(`issues/1234/comments`) does not touch it: the thread stays open, and the
+self-merge gate counts unresolved threads. Every finding you address needs a
+reply **on its own thread**, and then a resolution.
+
+- **Fixed in code** — reply on the thread with the fix SHA, then let the
+  reviewer resolve it. Re-running the review verifies the finding no longer
+  reproduces and resolves the thread itself; that is evidence-based and
+  stronger than resolving by hand.
+  ```bash
+  # root comment ids: gh api repos/gptme/gptme-contrib/pulls/1234/comments --jq '.[] | {id, path, line}'
+  gh api repos/gptme/gptme-contrib/pulls/1234/comments/COMMENT_ID/replies -f body="Fixed in SHA — ..."
+  ```
+- **False positive, won't-fix, or an accepted trade-off** — no code change will
+  ever settle it, so reply AND resolve in one step. A reasoned rejection with
+  code citations IS a resolution; it is not a reason to leave the thread open.
+  ```bash
+  python3 /home/bob/bob/scripts/github/ai-review-dispose.py gptme/gptme-contrib 1234 --list
+  python3 /home/bob/bob/scripts/github/ai-review-dispose.py gptme/gptme-contrib 1234 \
+      --fingerprint FP --reason rejected --reply-file /tmp/why.md
+  ```
+  It is idempotent (a second run is a no-op) and can only ever touch threads our
+  own reviewer opened — never a human's.
+
+⚠️ Never resolve a human's review thread. Burying a person's comment is far
+worse than leaving a thread open.
+
 Warning: **This is an AI-reviewer dispatch, not Greptile.** Do NOT trigger Greptile to clear it.
 The reviewer still runs automatically on the push the wrapper makes — no manual trigger needed or wanted.
 If you cannot fix the issues in this session, leave it for the next cycle.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
@@ -10,6 +10,35 @@ gh api repos/ErikBjare/alice/pulls/7/comments \
 This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick; leave it untouched if trivial.
 Do NOT re-trigger the reviewer just because you looked at it.
 
+**Closing the loop — required, and NOT the same thing as a PR comment.**
+
+An inline finding lives on a *review thread*. Posting to the PR conversation
+(`issues/7/comments`) does not touch it: the thread stays open, and the
+self-merge gate counts unresolved threads. Every finding you address needs a
+reply **on its own thread**, and then a resolution.
+
+- **Fixed in code** — reply on the thread with the fix SHA, then let the
+  reviewer resolve it. Re-running the review verifies the finding no longer
+  reproduces and resolves the thread itself; that is evidence-based and
+  stronger than resolving by hand.
+  ```bash
+  # root comment ids: gh api repos/ErikBjare/alice/pulls/7/comments --jq '.[] | {id, path, line}'
+  gh api repos/ErikBjare/alice/pulls/7/comments/COMMENT_ID/replies -f body="Fixed in SHA — ..."
+  ```
+- **False positive, won't-fix, or an accepted trade-off** — no code change will
+  ever settle it, so reply AND resolve in one step. A reasoned rejection with
+  code citations IS a resolution; it is not a reason to leave the thread open.
+  ```bash
+  python3 /srv/agents/alice/workspace/scripts/github/ai-review-dispose.py ErikBjare/alice 7 --list
+  python3 /srv/agents/alice/workspace/scripts/github/ai-review-dispose.py ErikBjare/alice 7 \
+      --fingerprint FP --reason rejected --reply-file /tmp/why.md
+  ```
+  It is idempotent (a second run is a no-op) and can only ever touch threads our
+  own reviewer opened — never a human's.
+
+⚠️ Never resolve a human's review thread. Burying a person's comment is far
+worse than leaving a thread open.
+
 Warning: **Never push trivial changes just to chase 5/5.**
 If you do fix something, push via the in-band wrapper so the re-review happens in-session:
 ```bash

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
@@ -10,6 +10,35 @@ gh api repos/gptme/gptme-contrib/pulls/1234/comments \
 This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick; leave it untouched if trivial.
 Do NOT re-trigger the reviewer just because you looked at it.
 
+**Closing the loop — required, and NOT the same thing as a PR comment.**
+
+An inline finding lives on a *review thread*. Posting to the PR conversation
+(`issues/1234/comments`) does not touch it: the thread stays open, and the
+self-merge gate counts unresolved threads. Every finding you address needs a
+reply **on its own thread**, and then a resolution.
+
+- **Fixed in code** — reply on the thread with the fix SHA, then let the
+  reviewer resolve it. Re-running the review verifies the finding no longer
+  reproduces and resolves the thread itself; that is evidence-based and
+  stronger than resolving by hand.
+  ```bash
+  # root comment ids: gh api repos/gptme/gptme-contrib/pulls/1234/comments --jq '.[] | {id, path, line}'
+  gh api repos/gptme/gptme-contrib/pulls/1234/comments/COMMENT_ID/replies -f body="Fixed in SHA — ..."
+  ```
+- **False positive, won't-fix, or an accepted trade-off** — no code change will
+  ever settle it, so reply AND resolve in one step. A reasoned rejection with
+  code citations IS a resolution; it is not a reason to leave the thread open.
+  ```bash
+  python3 /home/bob/bob/scripts/github/ai-review-dispose.py gptme/gptme-contrib 1234 --list
+  python3 /home/bob/bob/scripts/github/ai-review-dispose.py gptme/gptme-contrib 1234 \
+      --fingerprint FP --reason rejected --reply-file /tmp/why.md
+  ```
+  It is idempotent (a second run is a no-op) and can only ever touch threads our
+  own reviewer opened — never a human's.
+
+⚠️ Never resolve a human's review thread. Burying a person's comment is far
+worse than leaving a thread open.
+
 Warning: **Never push trivial changes just to chase 5/5.**
 If you do fix something, push via the in-band wrapper so the re-review happens in-session:
 ```bash

--- a/packages/gptme-runloops/tests/test_prompt_templates.py
+++ b/packages/gptme-runloops/tests/test_prompt_templates.py
@@ -231,3 +231,38 @@ def test_local_fix_never_names_the_greptile_helper() -> None:
     cross = render_instruction(InstructionKind.CROSS_REPO_GREPTILE_REFRESH, ctx)
     assert "greptile-helper.sh" not in local
     assert f"greptile-helper.sh trigger {ctx.repo} {ctx.number}" in cross
+
+
+# --- Disposition path must exist on every AI-review arm ---
+#
+# Regression guard for the gptme/gptme#3615 loop (2026-08-26): the
+# `reviewer_needs_fix` arm told the worker to FIX and PUSH but gave it no way to
+# dispose of a finding it judged a false positive. The worker did the only thing
+# left — a top-level PR comment — which PM's `--require-inline-thread-reply`
+# delivery check correctly refuses to count. Two dispatches graded effect=none,
+# the retry budget burned down, and a stuck-PR escalation task was filed for a
+# PR whose findings had actually been adjudicated. A golden alone does not guard
+# this: goldens get regenerated. Assert the capability, not the bytes.
+
+_AI_REVIEW_KINDS = tuple(k for k in InstructionKind if k.value.startswith("ai_review"))
+
+
+@pytest.mark.parametrize("kind", _AI_REVIEW_KINDS, ids=lambda k: k.value)
+def test_ai_review_arms_offer_a_disposition_path(kind: InstructionKind) -> None:
+    """Every AI-review arm must name the reply-AND-resolve disposition tool."""
+    rendered = render_instruction(kind, CONTEXTS["bob"])
+    assert "ai-review-dispose.py" in rendered, (
+        f"{kind.value} gives a worker no way to dispose of a false-positive "
+        "finding; it will fall back to a top-level comment, which the PM "
+        "delivery check grades as no effect"
+    )
+
+
+@pytest.mark.parametrize("kind", _AI_REVIEW_KINDS, ids=lambda k: k.value)
+def test_ai_review_arms_warn_that_pr_comments_do_not_close_threads(
+    kind: InstructionKind,
+) -> None:
+    """The distinction that caused the loop must be stated, not implied."""
+    rendered = render_instruction(kind, CONTEXTS["bob"])
+    assert "does not touch it" in rendered
+    assert "Never resolve a human's review thread" in rendered


### PR DESCRIPTION
## Problem

The `reviewer_needs_fix` / `reviewer_needs_improvement` PM dispatch arms tell the worker to **fix the findings and push**. They give it no path for a finding it judges to be a **false positive**.

`_CLOSE_THE_LOOP` — reply on the inline thread, then resolve via `ai-review-dispose.py` — was already written, and is already used by the local-fix and Greptile arms. These two were the only AI-review arms that omitted it.

So a worker that *correctly* adjudicates a finding as a false positive does the only thing the prompt leaves it: posts a top-level PR comment. That hits `issues/{n}/comments`, a different API from the inline review thread. PM's `--require-inline-thread-reply` delivery check therefore refuses to count it, the dispatch grades `effect=none`, and the bounded ineffective-retry path burns the budget down to an escalation.

## Observed end-to-end

gptme/gptme#3615, 2026-08-26:

| dispatch | duration | exit | effect | outcome |
|---|---|---|---|---|
| 06:57 → 07:06 | 577s | 0 | `none` | `no_effect` |
| 07:18 → 07:23 | 295s | 0 | `none` | `no_effect` |

Both sessions ran to completion and posted a reasoned false-positive adjudication as a top-level comment. Both graded `effect=none`. Retry budget exhausted at 08:23, stuck-PR task filed — for a PR whose findings had in fact been handled. Two of its AI-review threads are **still open** on the now-merged PR.

Note this is neither of the known pm-stuck classes: not the ~25s exit-1 backend-auth fast-fail, and not oversized work (exit 124).

## Change

Append `_CLOSE_THE_LOOP` to the `assessment` of both AI-review section maps. `dispose_script` was already plumbed through `PromptContext` and `render_instruction`'s params, so this is purely a reuse of existing machinery — no new tool, no second implementation of "which threads are ours".

## Verification

- `1077 passed, 1 skipped` — full `gptme-runloops` suite
- 4 goldens regenerated (`ai_review_needs_fix` / `ai_review_needs_improvement` × bob/alice); no other golden moved
- **RED-verified**: reverting the source makes exactly the 4 new capability tests fail
- ruff check + ruff format clean at the pinned `v0.6.9`

Guarded by capability assertions (`ai-review-dispose.py` is named; the "a PR comment does not touch the thread" warning is present) rather than goldens alone — a golden that drifts just gets regenerated, which would silently re-open this hole.