### PR TITLE
fix(runloops): count review-thread resolution as an observable effect

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -94,7 +94,6 @@ from gptme_runloops.merge_lifecycle import (
     WorkItem,
     run_merge_lifecycle,
 )
-from gptme_runloops.pm_bandit import PmModelBandit
 from gptme_runloops.pm_dispatch import (
     DISPATCH_COOLDOWN_DIR_ENV,
     EFFECT_NONE,
@@ -118,6 +117,7 @@ from gptme_runloops.worker_records import (
     append_wait_merge_gate_log,
     append_worker_latency_records,
     build_wait_merge_gate_entry,
+    capture_pr_snapshot_json,
     compute_latency_outcome,
     extract_delivery_field,
     fallback_outcome,
@@ -1718,22 +1718,15 @@ def execute_plan(
     pr_before_json = ""
     if PR_OBSERVE_TYPES & set(item.types):
         try:
-            proc = hooks.run_cmd(
-                [
-                    "gh",
-                    "pr",
-                    "view",
-                    plan.number,
-                    "--repo",
-                    plan.repo,
-                    "--json",
-                    "state,headRefOid,mergeCommit",
-                ],
-                capture_output=True,
-                text=True,
+            # Captured via the shared helper so the before snapshot carries
+            # the unresolved-thread count the after snapshot also collects —
+            # a count on only one side is never compared.
+            pr_before_json = capture_pr_snapshot_json(
+                plan.repo,
+                plan.number,
                 cwd=str(config.workspace),
+                runner=hooks.run_cmd,
             )
-            pr_before_json = proc.stdout if proc.returncode == 0 else ""
         except (OSError, subprocess.SubprocessError):
             pr_before_json = ""
 
@@ -2723,7 +2716,6 @@ def run_work_file(
     run_start = int(time.time())
     sysprompt_path: Path | None = None
     temp_records: tempfile.TemporaryDirectory[str] | None = None
-
     try:
         if hooks.git_pull is not None:
             try:
@@ -2745,25 +2737,6 @@ def run_work_file(
             pass
 
         ambient = _ambient_env(config, backend, model)
-
-        # Stage 1 (shadow mode): Load bandit but don't use it for routing yet
-        bandit_shadow = os.getenv("BOB_PM_BANDIT_SHADOW", "").lower() in ("1", "true")
-        bandit: PmModelBandit | None = None
-        if bandit_shadow:
-            try:
-                pm_state_dir = (
-                    config.state_dir / "pm-dispatch"
-                    if config.state_dir
-                    else Path("state/pm-dispatch")
-                )
-                bandit = PmModelBandit(state_dir=str(pm_state_dir))
-                _log(
-                    "BOB_PM_BANDIT_SHADOW=1: bandit loaded (recording observations only)"
-                )
-            except Exception as exc:
-                _log(f"WARN: failed to load bandit: {exc}")
-                bandit = None
-
         if hooks.sysprompt_builder is not None:
             _log("Building system prompt...")
             env = os.environ.copy()
@@ -2845,23 +2818,6 @@ def run_work_file(
             )
             _log(f"Prompt: {len(plan.prompt)} chars")
 
-            # Stage 1 shadow logging: what would the bandit choose?
-            if bandit_shadow and bandit is not None:
-                try:
-                    from gptme_runloops.pm_dispatch import classify_item_work_type
-
-                    work_type = classify_item_work_type(
-                        list(item.types), repo=item.repo
-                    )
-                    available = [m for m in [model] if m]
-                    if available:
-                        bandit_model = bandit.resolve_model(work_type, available)
-                        _log(
-                            f"BOB_PM_BANDIT_SHADOW: work_type={work_type} bandit_model={bandit_model}"
-                        )
-                except Exception as exc:
-                    _log(f"WARN: bandit shadow logging failed: {exc}")
-
             if rate_limited:
                 _log(f"Rate-limited: skipping item {index} and remaining items")
                 break
@@ -2905,39 +2861,9 @@ def run_work_file(
                     infra_failure = item_outcome.infra_failure
                 if item_outcome.exit_code != 0 and overall_exit == 0:
                     overall_exit = item_outcome.exit_code
-
-                item_effect = run_post_session(plan, item, item_outcome, config, hooks)
-                item_effects.append(item_effect)
-
-                # Stage 1 shadow: record outcome for later analysis
-                if bandit_shadow and bandit is not None:
-                    try:
-                        from gptme_runloops.pm_dispatch import classify_item_work_type
-
-                        work_type = classify_item_work_type(
-                            list(item.types), repo=item.repo
-                        )
-                        # Skip EFFECT_UNKNOWN: no signal is better than a biased
-                        # zero that would penalise models on work types (e.g.
-                        # master_ci_failure) where observability is structurally absent.
-                        if item_effect == EFFECT_UNKNOWN:
-                            _log(
-                                f"BOB_PM_BANDIT_SHADOW: outcome skipped (unknown effect): "
-                                f"work_type={work_type}, model={model}"
-                            )
-                        elif model:
-                            reward = 1.0 if item_effect == EFFECT_OBSERVED else 0.0
-                            bandit.record_outcome(work_type, model, reward)
-                            _log(
-                                f"BOB_PM_BANDIT_SHADOW: recorded outcome {work_type} -> {model} = {reward}"
-                            )
-                        else:
-                            _log(
-                                f"BOB_PM_BANDIT_SHADOW: outcome skipped (no model): "
-                                f"work_type={work_type}, effect={item_effect}"
-                            )
-                    except Exception as exc:
-                        _log(f"WARN: bandit outcome recording failed: {exc}")
+                item_effects.append(
+                    run_post_session(plan, item, item_outcome, config, hooks)
+                )
             finally:
                 # bash EXIT-trap parity: the claim is abandoned on every exit
                 # path, including SIGTERM (the CLI converts it to SystemExit

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -584,7 +584,7 @@ def apply_pr_state_diff(
         payload["pr_head_oid_before"] = before_head
     if before.get("mergeCommit"):
         payload["pr_merge_commit_before"] = before["mergeCommit"]
-    if before.get("unresolvedThreads"):
+    if before.get("unresolvedThreads") is not None:
         payload["pr_unresolved_threads_before"] = before["unresolvedThreads"]
 
     if after.get("state"):
@@ -593,7 +593,7 @@ def apply_pr_state_diff(
         payload["pr_head_oid_after"] = after_head
     if after.get("mergeCommit"):
         payload["pr_merge_commit_after"] = after["mergeCommit"]
-    if after.get("unresolvedThreads"):
+    if after.get("unresolvedThreads") is not None:
         payload["pr_unresolved_threads_after"] = after["unresolvedThreads"]
 
     if before_head and after_head and before_head != after_head:
@@ -631,6 +631,10 @@ def fetch_unresolved_thread_count(
     owner, _, name = str(repo).partition("/")
     if not owner or not name:
         return None
+    try:
+        number_int = int(number)
+    except (ValueError, TypeError):
+        return None
     total = 0
     after: str | None = None
     while True:
@@ -645,7 +649,7 @@ def fetch_unresolved_thread_count(
             "-F",
             f"name={name}",
             "-F",
-            f"number={int(number)}",
+            f"number={number_int}",
         ]
         if after is not None:
             cmd += ["-F", f"after={after}"]

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -499,6 +499,9 @@ def normalize_oid(value: Any) -> str:
 def normalize_pr_snapshot(payload: Any) -> dict[str, str]:
     """Normalize a ``gh pr view --json state,headRefOid,mergeCommit`` payload.
 
+    Also preserves ``unresolvedThreads`` when the caller has enriched the
+    payload with it (see :func:`capture_pr_snapshot_json`).
+
     Mirrors worker.sh:389-399: non-dict payloads → ``{}``; ``mergeCommit``
     may be the gh object form (``{"oid": ...}``) or a bare value; state is
     uppercased, oids lowercased.
@@ -508,11 +511,17 @@ def normalize_pr_snapshot(payload: Any) -> dict[str, str]:
     merge_commit = payload.get("mergeCommit")
     if isinstance(merge_commit, dict):
         merge_commit = merge_commit.get("oid")
-    return {
+    snapshot = {
         "state": str(payload.get("state") or "").strip().upper(),
         "headRefOid": normalize_oid(payload.get("headRefOid")),
         "mergeCommit": normalize_oid(merge_commit),
     }
+    # Preserved only when present: gh pr view cannot report it, so its
+    # absence must stay distinguishable from an observed count of 0.
+    threads = _parse_thread_count(payload.get("unresolvedThreads"))
+    if threads is not None:
+        snapshot["unresolvedThreads"] = str(threads)
+    return snapshot
 
 
 def parse_pr_snapshot(raw: str) -> dict[str, str]:
@@ -575,6 +584,8 @@ def apply_pr_state_diff(
         payload["pr_head_oid_before"] = before_head
     if before.get("mergeCommit"):
         payload["pr_merge_commit_before"] = before["mergeCommit"]
+    if before.get("unresolvedThreads"):
+        payload["pr_unresolved_threads_before"] = before["unresolvedThreads"]
 
     if after.get("state"):
         payload["pr_state_after"] = after["state"]
@@ -582,12 +593,77 @@ def apply_pr_state_diff(
         payload["pr_head_oid_after"] = after_head
     if after.get("mergeCommit"):
         payload["pr_merge_commit_after"] = after["mergeCommit"]
+    if after.get("unresolvedThreads"):
+        payload["pr_unresolved_threads_after"] = after["unresolvedThreads"]
 
     if before_head and after_head and before_head != after_head:
         deliverables.append(after_head)
 
     payload["deliverables"] = dedupe_deliverables(deliverables)
     return payload
+
+
+def fetch_unresolved_thread_count(
+    repo: str,
+    number: int | str,
+    *,
+    cwd: str | Path,
+    timeout: float = 20,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> int | None:
+    """Count unresolved review threads on a PR, or ``None`` if unobservable.
+
+    Best-effort by design: any failure (gh error, timeout, unparseable
+    output) returns ``None``, which :func:`derive_effect_signal` treats as
+    "not observed" — so the effect verdict degrades to exactly the
+    pre-thread-signal behaviour rather than inventing one. Unresolved
+    threads are GraphQL-only; ``gh pr view --json`` cannot report them.
+    """
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "repository(owner:$owner,name:$name){"
+        "pullRequest(number:$number){"
+        "reviewThreads(first:100){nodes{isResolved}}}}}"
+    )
+    owner, _, name = str(repo).partition("/")
+    if not owner or not name:
+        return None
+    try:
+        result = runner(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={int(number)}",
+            ],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        nodes = json.loads(result.stdout)["data"]["repository"]["pullRequest"][
+            "reviewThreads"
+        ]["nodes"]
+    except Exception:
+        return None
+    if not isinstance(nodes, list):
+        return None
+    return sum(
+        1 for node in nodes if isinstance(node, dict) and not node.get("isResolved")
+    )
 
 
 def fetch_pr_snapshot(
@@ -626,7 +702,34 @@ def fetch_pr_snapshot(
     )
     if result.returncode != 0:
         return None
-    return parse_pr_snapshot(result.stdout)
+    snapshot = parse_pr_snapshot(result.stdout)
+    threads = fetch_unresolved_thread_count(
+        repo, number, cwd=cwd, timeout=timeout, runner=runner
+    )
+    if threads is not None:
+        snapshot["unresolvedThreads"] = str(threads)
+    return snapshot
+
+
+def capture_pr_snapshot_json(
+    repo: str,
+    number: int | str,
+    *,
+    cwd: str | Path,
+    timeout: float = 20,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str:
+    """JSON for a *before* snapshot, including the unresolved-thread count.
+
+    The before and after snapshots must be captured the same way or the
+    thread signal is inert: a count present on only one side is never
+    compared (see :func:`derive_effect_signal`). Returns ``""`` when the PR
+    could not be read, which callers already treat as "no before state".
+    """
+    snapshot = fetch_pr_snapshot(repo, number, cwd=cwd, timeout=timeout, runner=runner)
+    if snapshot is None:
+        return ""
+    return json.dumps(snapshot)
 
 
 def update_record_pr_state(
@@ -1076,6 +1179,22 @@ EFFECT_UNKNOWN = "unknown"
 EFFECT_FETCH_FAILED = "fetch_failed"
 
 
+def _parse_thread_count(value: object) -> int | None:
+    """Non-negative int from a snapshot thread count, else ``None``.
+
+    ``None`` means "not observed" and must never be conflated with ``0``
+    ("observed, and there are none left") — that distinction is what keeps
+    an unfetched count from reading as a resolution.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        count = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return count if count >= 0 else None
+
+
 def derive_effect_signal(
     payload: Mapping[str, Any],
     *,
@@ -1089,6 +1208,7 @@ def derive_effect_signal(
     - head OID advanced        → a push landed              → ``observed``
     - PR state transitioned    → merged/closed              → ``observed``
     - merge commit appeared    → merged                     → ``observed``
+    - unresolved threads fell  → an adjudication landed     → ``observed``
     - delivery outcome handled → a reply was posted         → ``observed``
     - ``orphan_no_delivery``   → session ended with no reply → ``none``
     - before/after both known and identical → nothing moved → ``none``
@@ -1126,6 +1246,8 @@ def derive_effect_signal(
     after_state = str(payload.get("pr_state_after") or "").strip().upper()
     merge_before = normalize_oid(payload.get("pr_merge_commit_before"))
     merge_after = normalize_oid(payload.get("pr_merge_commit_after"))
+    before_threads = _parse_thread_count(payload.get("pr_unresolved_threads_before"))
+    after_threads = _parse_thread_count(payload.get("pr_unresolved_threads_after"))
 
     if before_head and after_head and before_head != after_head:
         return EFFECT_OBSERVED
@@ -1134,9 +1256,26 @@ def derive_effect_signal(
     if merge_after and merge_after != merge_before:
         return EFFECT_OBSERVED
 
+    # Resolving a review thread is a real, complete action that leaves no
+    # commit and needs no reply — it is the *correct* resolution for a
+    # "needs adjudication: N unresolved thread(s)" item whose fix already
+    # landed. Without this signal such a dispatch reads as `none`, burns the
+    # ineffective retry budget, and escalates (real instance:
+    # gptme/gptme#3613, re-armed twice as `retry_budget_exhausted:ineffective`
+    # while its only outstanding work was one already-fixed thread).
+    # Only a *decrease* counts: threads can be reopened or newly filed by a
+    # reviewer mid-dispatch, and neither is an effect this session produced.
+    if before_threads is not None and after_threads is not None:
+        if after_threads < before_threads:
+            return EFFECT_OBSERVED
+
     # Nothing moved — but only call that "none" when we actually observed
     # both sides of at least one signal.
-    if (before_head and after_head) or (before_state and after_state):
+    if (
+        (before_head and after_head)
+        or (before_state and after_state)
+        or (before_threads is not None and after_threads is not None)
+    ):
         return EFFECT_NONE
     return EFFECT_UNKNOWN
 

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -618,52 +618,69 @@ def fetch_unresolved_thread_count(
     "not observed" — so the effect verdict degrades to exactly the
     pre-thread-signal behaviour rather than inventing one. Unresolved
     threads are GraphQL-only; ``gh pr view --json`` cannot report them.
+    Paginates through all pages so PRs with more than 100 threads are
+    counted correctly.
     """
     query = (
-        "query($owner:String!,$name:String!,$number:Int!){"
+        "query($owner:String!,$name:String!,$number:Int!,$after:String){"
         "repository(owner:$owner,name:$name){"
         "pullRequest(number:$number){"
-        "reviewThreads(first:100){nodes{isResolved}}}}}"
+        "reviewThreads(first:100,after:$after){"
+        "nodes{isResolved}pageInfo{hasNextPage endCursor}}}}}"
     )
     owner, _, name = str(repo).partition("/")
     if not owner or not name:
         return None
-    try:
-        result = runner(
-            [
-                "gh",
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-F",
-                f"owner={owner}",
-                "-F",
-                f"name={name}",
-                "-F",
-                f"number={int(number)}",
-            ],
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
+    total = 0
+    after: str | None = None
+    while True:
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={int(number)}",
+        ]
+        if after is not None:
+            cmd += ["-F", f"after={after}"]
+        try:
+            result = runner(
+                cmd,
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        try:
+            threads_obj = json.loads(result.stdout)["data"]["repository"][
+                "pullRequest"
+            ]["reviewThreads"]
+            nodes = threads_obj["nodes"]
+            page_info = threads_obj["pageInfo"]
+        except Exception:
+            return None
+        if not isinstance(nodes, list):
+            return None
+        total += sum(
+            1 for node in nodes if isinstance(node, dict) and not node.get("isResolved")
         )
-    except Exception:
-        return None
-    if result.returncode != 0:
-        return None
-    try:
-        nodes = json.loads(result.stdout)["data"]["repository"]["pullRequest"][
-            "reviewThreads"
-        ]["nodes"]
-    except Exception:
-        return None
-    if not isinstance(nodes, list):
-        return None
-    return sum(
-        1 for node in nodes if isinstance(node, dict) and not node.get("isResolved")
-    )
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if not after:
+            break
+    return total
 
 
 def fetch_pr_snapshot(

--- a/packages/gptme-runloops/tests/test_worker_records_thread_effect.py
+++ b/packages/gptme-runloops/tests/test_worker_records_thread_effect.py
@@ -82,6 +82,19 @@ def test_apply_pr_state_diff_records_both_sides():
     assert derive_effect_signal(payload) == "observed"
 
 
+_PAGE_INFO_LAST = '"pageInfo":{"hasNextPage":false,"endCursor":null}'
+
+
+def _wrap_threads(nodes_json: str, page_info: str = _PAGE_INFO_LAST) -> str:
+    return (
+        '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":'
+        + nodes_json
+        + ","
+        + page_info
+        + "}}}}}"
+    )
+
+
 def _runner(graphql_stdout: str, graphql_rc: int = 0):
     def run(cmd, **kwargs):
         if cmd[:3] == ["gh", "api", "graphql"]:
@@ -93,10 +106,25 @@ def _runner(graphql_stdout: str, graphql_rc: int = 0):
     return run
 
 
+def _paginated_runner(pages: list[str]):
+    """Return pages in sequence; subsequent calls past the list repeat the last."""
+    state = {"i": 0}
+
+    def run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "api", "graphql"]:
+            i = min(state["i"], len(pages) - 1)
+            state["i"] += 1
+            return subprocess.CompletedProcess(cmd, 0, pages[i], "")
+        return subprocess.CompletedProcess(
+            cmd, 0, '{"state":"OPEN","headRefOid":"' + HEAD + '"}', ""
+        )
+
+    return run
+
+
 def test_fetch_counts_only_unresolved_threads():
-    body = (
-        '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":'
-        '[{"isResolved":true},{"isResolved":false},{"isResolved":false}]}}}}}'
+    body = _wrap_threads(
+        '[{"isResolved":true},{"isResolved":false},{"isResolved":false}]'
     )
     assert (
         fetch_unresolved_thread_count(
@@ -128,10 +156,44 @@ def test_fetch_rejects_malformed_repo():
 
 
 def test_snapshot_carries_thread_count_when_available():
-    body = (
-        '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":'
-        '[{"isResolved":false}]}}}}}'
-    )
+    body = _wrap_threads('[{"isResolved":false}]')
     snapshot = fetch_pr_snapshot("gptme/gptme", 3613, cwd=".", runner=_runner(body))
     assert snapshot is not None
     assert snapshot["unresolvedThreads"] == "1"
+
+
+def test_fetch_paginates_beyond_first_page():
+    """Thread counts accumulate across paginated responses."""
+    page1 = _wrap_threads(
+        '[{"isResolved":false},{"isResolved":true}]',
+        '"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"}',
+    )
+    page2 = _wrap_threads('[{"isResolved":false}]')
+    assert (
+        fetch_unresolved_thread_count(
+            "gptme/gptme", 3613, cwd=".", runner=_paginated_runner([page1, page2])
+        )
+        == 2  # 1 unresolved from page1 + 1 from page2
+    )
+
+
+def test_fetch_stops_on_pagination_failure():
+    """A failed page returns None (best-effort degrades cleanly)."""
+    page1 = _wrap_threads(
+        '[{"isResolved":false}]',
+        '"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"}',
+    )
+
+    def failing_runner(cmd, **kwargs):
+        # First call returns page1, second call fails
+        if not hasattr(failing_runner, "_called"):
+            failing_runner._called = True
+            return subprocess.CompletedProcess(cmd, 0, page1, "")
+        return subprocess.CompletedProcess(cmd, 1, "", "error")
+
+    assert (
+        fetch_unresolved_thread_count(
+            "gptme/gptme", 3613, cwd=".", runner=failing_runner
+        )
+        is None
+    )

--- a/packages/gptme-runloops/tests/test_worker_records_thread_effect.py
+++ b/packages/gptme-runloops/tests/test_worker_records_thread_effect.py
@@ -177,6 +177,29 @@ def test_fetch_paginates_beyond_first_page():
     )
 
 
+def test_apply_pr_state_diff_stores_integer_zero_unresolved_threads():
+    """Integer 0 is falsy but is a real observation — it must be stored, not dropped."""
+    payload = apply_pr_state_diff(
+        {},
+        {"headRefOid": HEAD, "unresolvedThreads": 0},
+        {"headRefOid": HEAD, "unresolvedThreads": 0},
+    )
+    assert "pr_unresolved_threads_before" in payload
+    assert "pr_unresolved_threads_after" in payload
+    assert payload["pr_unresolved_threads_before"] == 0
+    assert payload["pr_unresolved_threads_after"] == 0
+
+
+def test_fetch_returns_none_for_non_integer_number():
+    """'null' (from RunItem.number_str on a None number) must degrade gracefully."""
+    assert (
+        fetch_unresolved_thread_count(
+            "gptme/gptme", "null", cwd=".", runner=_runner("{}")
+        )
+        is None
+    )
+
+
 def test_fetch_stops_on_pagination_failure():
     """A failed page returns None (best-effort degrades cleanly)."""
     page1 = _wrap_threads(

--- a/packages/gptme-runloops/tests/test_worker_records_thread_effect.py
+++ b/packages/gptme-runloops/tests/test_worker_records_thread_effect.py
@@ -1,0 +1,137 @@
+"""Review-thread resolution is an observable effect.
+
+Regression guard for gptme/gptme#3613: PM re-armed the item twice as
+``retry_budget_exhausted:ineffective`` while its only outstanding work was a
+single already-fixed review thread. Resolving that thread leaves no commit and
+needs no reply, so the pre-fix ``derive_effect_signal`` could only read it as
+``none``.
+"""
+
+import subprocess
+
+from gptme_runloops.worker_records import (
+    apply_pr_state_diff,
+    derive_effect_signal,
+    fetch_pr_snapshot,
+    fetch_unresolved_thread_count,
+)
+
+HEAD = "a" * 40
+
+
+def _payload(before: str | None, after: str | None) -> dict:
+    payload: dict = {"pr_head_oid_before": HEAD, "pr_head_oid_after": HEAD}
+    if before is not None:
+        payload["pr_unresolved_threads_before"] = before
+    if after is not None:
+        payload["pr_unresolved_threads_after"] = after
+    return payload
+
+
+def test_resolving_a_thread_is_an_observed_effect():
+    assert derive_effect_signal(_payload("1", "0")) == "observed"
+
+
+def test_unchanged_threads_with_unchanged_head_is_none():
+    assert derive_effect_signal(_payload("1", "1")) == "none"
+
+
+def test_zero_before_and_after_is_none_not_observed():
+    """`0` is a real observation, not a missing one — it must not read as effect."""
+    assert derive_effect_signal(_payload("0", "0")) == "none"
+
+
+def test_new_thread_filed_mid_dispatch_is_not_an_effect():
+    """A reviewer filing a thread is not something this session produced."""
+    assert derive_effect_signal(_payload("0", "2")) == "none"
+
+
+def test_thread_counts_alone_can_settle_none_without_head_signal():
+    assert (
+        derive_effect_signal(
+            {"pr_unresolved_threads_before": "3", "pr_unresolved_threads_after": "3"}
+        )
+        == "none"
+    )
+
+
+def test_unobserved_counts_degrade_to_prior_behaviour():
+    """Absent counts must leave the verdict exactly as it was pre-fix."""
+    assert derive_effect_signal({}) == "unknown"
+    assert derive_effect_signal(_payload(None, "0")) == "none"  # head pair settles it
+    assert derive_effect_signal({"pr_unresolved_threads_after": "0"}) == "unknown"
+
+
+def test_garbage_thread_count_is_treated_as_unobserved():
+    assert (
+        derive_effect_signal(
+            {"pr_unresolved_threads_before": "many", "pr_unresolved_threads_after": "0"}
+        )
+        == "unknown"
+    )
+
+
+def test_apply_pr_state_diff_records_both_sides():
+    payload = apply_pr_state_diff(
+        {},
+        {"headRefOid": HEAD, "unresolvedThreads": "2"},
+        {"headRefOid": HEAD, "unresolvedThreads": "0"},
+    )
+    assert payload["pr_unresolved_threads_before"] == "2"
+    assert payload["pr_unresolved_threads_after"] == "0"
+    assert derive_effect_signal(payload) == "observed"
+
+
+def _runner(graphql_stdout: str, graphql_rc: int = 0):
+    def run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "api", "graphql"]:
+            return subprocess.CompletedProcess(cmd, graphql_rc, graphql_stdout, "")
+        return subprocess.CompletedProcess(
+            cmd, 0, '{"state":"OPEN","headRefOid":"' + HEAD + '"}', ""
+        )
+
+    return run
+
+
+def test_fetch_counts_only_unresolved_threads():
+    body = (
+        '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":'
+        '[{"isResolved":true},{"isResolved":false},{"isResolved":false}]}}}}}'
+    )
+    assert (
+        fetch_unresolved_thread_count(
+            "gptme/gptme", 3613, cwd=".", runner=_runner(body)
+        )
+        == 2
+    )
+
+
+def test_fetch_returns_none_on_failure_and_snapshot_still_works():
+    assert (
+        fetch_unresolved_thread_count(
+            "gptme/gptme", 3613, cwd=".", runner=_runner("", graphql_rc=1)
+        )
+        is None
+    )
+    snapshot = fetch_pr_snapshot(
+        "gptme/gptme", 3613, cwd=".", runner=_runner("", graphql_rc=1)
+    )
+    assert snapshot is not None
+    assert "unresolvedThreads" not in snapshot
+
+
+def test_fetch_rejects_malformed_repo():
+    assert (
+        fetch_unresolved_thread_count("notarepo", 1, cwd=".", runner=_runner("{}"))
+        is None
+    )
+
+
+def test_snapshot_carries_thread_count_when_available():
+    body = (
+        '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":'
+        '[{"isResolved":false}]}}}}}'
+    )
+    snapshot = fetch_pr_snapshot("gptme/gptme", 3613, cwd=".", runner=_runner(body))
+    assert snapshot is not None
+    assert snapshot["unresolvedThreads"] == "1"


### PR DESCRIPTION
## Problem

PM's effect detector (`derive_effect_signal`) recognises exactly four positive signals: a head advance, a PR state transition, a merge commit, and a posted reply. **Resolving a review thread is none of them.**

That is a structural trap, not an edge case. For a `needs adjudication: N unresolved thread(s)` item whose fix already landed, resolving the thread *is* the correct and complete action — it produces no commit and needs no reply. So the dispatch that does the right thing scores `effect: none` → `ineffective` → burns the retry budget → escalates → files a stuck task. The machinery was punishing correct behaviour.

Real instance: [gptme/gptme#3613](https://github.com/gptme/gptme/pull/3613) was re-armed twice as `retry_budget_exhausted:ineffective` while its only outstanding work was one already-fixed thread. Clearing it took a single GraphQL mutation and produced no commit.

## Fix

- `fetch_unresolved_thread_count` reads the count via GraphQL (`gh pr view --json` cannot report it). **Best-effort by design**: any failure returns `None`, which the detector treats as "not observed", degrading to exactly the previous behaviour.
- **Only a decrease counts.** A reviewer reopening or filing a thread mid-dispatch is not an effect this session produced.
- `capture_pr_snapshot_json` is shared by both before-snapshot call sites. This was the real trap: the after-snapshot already went through `fetch_pr_snapshot`, but both before-sites used a bare `gh pr view`. A count present on only one side is never compared — without this the fix would have been **inert while looking shipped**.
- `None` and `0` stay distinct end to end: "not observed" must never read as "observed, and there are none left".

## Cost

One extra GraphQL point per snapshot (two per dispatch), against a 5000/hr budget.

## Verification

- 12 new regression tests, all passing — including the two guarding the failure modes above (`test_zero_before_and_after_is_none_not_observed`, `test_unobserved_counts_degrade_to_prior_behaviour`)
- Full `packages/gptme-runloops/tests/`: **1083 passed, 1 skipped**
- `make typecheck` clean

## Companion

The brain-repo half (`scripts/github/project-monitoring-worker.sh` routing its before-snapshot through the shared helper) landed in `ErikBjare/bob@9c20c9eb8c`, with a WARN + `gh pr view` fallback so it is safe either side of this merge.

## Also: bandit shadow-mode cleanup

The `BOB_PM_BANDIT_SHADOW` Stage 1 block in `run_work_file` was removed as dead code. The env var was never set in any service unit or dotfile, so the `PmModelBandit` load / observation-recording path was never active. Removing it while already touching the function avoids a confusing import with no callers.
