### PR TITLE
fix(precommit): make root structure hook installable

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,21 @@ jobs:
       - name: Install pre-commit
         run: |
           pipx install pre-commit
+      - name: Verify remote Python hook installation
+        shell: bash
+        run: |
+          consumer="$(mktemp -d)"
+          git -C "$consumer" init
+          touch "$consumer/README.md"
+          printf '%s\n' \
+            'allowed_entries:' \
+            '  - README.md' \
+            '  - root-structure-allowlist.yaml' \
+            > "$consumer/root-structure-allowlist.yaml"
+          git -C "$consumer" add README.md root-structure-allowlist.yaml
+          cd "$consumer"
+          pre-commit try-repo "$GITHUB_WORKSPACE" \
+            validate-root-structure --all-files
       - name: Create virtual environment
         run: |
           uv sync --all-packages

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,7 +18,7 @@
     a per-repo YAML file (default ``root-structure-allowlist.yaml``) instead of
     repeated ``--allow`` args, so consuming repos own a data file rather than a
     copy of the checker.
-  entry: scripts/precommit/validators/validate_root_structure_yaml.py
+  entry: validate-root-structure
   language: python
   pass_filenames: false
   always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "gptme-contrib-workspace"
 version = "0.1.0"
 description = "Community contributions and utilities for gptme agents"
 requires-python = ">=3.10"
+dependencies = ["PyYAML"]
 
 [build-system]
 requires = ["setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 description = "Community contributions and utilities for gptme agents"
 requires-python = ">=3.10"
 
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project.scripts]
 validate-root-structure = "validate_root_structure_yaml:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,16 @@ version = "0.1.0"
 description = "Community contributions and utilities for gptme agents"
 requires-python = ">=3.10"
 
+[project.scripts]
+validate-root-structure = "validate_root_structure_yaml:main"
+
+# The workspace root is installed when consumers use a remote Python
+# pre-commit hook. Package only the hook module instead of auto-discovering the
+# monorepo's many top-level directories.
+[tool.setuptools]
+py-modules = ["validate_root_structure_yaml"]
+package-dir = { "" = "scripts/precommit/validators" }
+
 [dependency-groups]
 dev = [
     "flask>=3.0.0",


### PR DESCRIPTION
## Summary

- expose `validate-root-structure` as an installed console script
- package only the validator module when pre-commit installs the workspace root
- exercise the remote hook from a clean temporary consumer in CI

## Why

#1505 registered the config-driven validator as a remote `language: python` hook, but a real consumer exposed two installation defects:

1. setuptools rejected the monorepo's flat layout while installing the hook repository;
2. after making the root installable, the file-path entry was not available in the consumer checkout.

The console entry point fixes both without packaging the rest of the monorepo. This unblocks the config-driven migrations in gptme and gptme-cloud.

## Verification

- `uv run pytest tests/test_validate_root_structure_yaml.py -q` — 15 passed
- `pre-commit try-repo <this worktree> validate-root-structure --all-files` — passed from a clean temporary consumer
- `prek try-repo <this worktree> validate-root-structure --all-files` — passed against staged gptme and gptme-cloud migrations
- full pre-commit checks passed under the CI Python version (3.11)
- `uv lock --check`
