### PR TITLE
feat(voice-node): add gptme-voice-node embedded WS client package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
       types-Markdown,
       pytest,
       tomli,
+      "websockets>=12.0",
+      types-pyaudio,
     ]
     args: [--config-file=mypy.ini, --explicit-package-bases]
     types: [python]

--- a/packages/gptme-voice-node/README.md
+++ b/packages/gptme-voice-node/README.md
@@ -31,6 +31,10 @@ All config is via environment variables (no CLI flags — systemd-friendly):
 | `GPTME_VOICE_NODE_SERVER` | `ws://localhost:8080/local` | WebSocket URL of `bob-voice-server` |
 | `GPTME_VOICE_NODE_NAME` | `bobbrain-unknown` | Node identity (logged and sent to server) |
 
+The `ws://localhost` default is intended only for a server on the same host. Use
+`wss://` whenever microphone audio crosses a network; the client logs a warning
+for non-local `ws://` endpoints.
+
 ## Raspberry Pi deployment
 
 1. Install system deps:
@@ -48,7 +52,7 @@ All config is via environment variables (no CLI flags — systemd-friendly):
    sudo mkdir -p /etc/systemd/system/gptme-voice-node.service.d/
    cat | sudo tee /etc/systemd/system/gptme-voice-node.service.d/local.conf << 'EOF'
    [Service]
-   Environment=GPTME_VOICE_NODE_SERVER=ws://bob-host.local:8080/local
+   Environment=GPTME_VOICE_NODE_SERVER=wss://bob-host.example.com/local
    Environment=GPTME_VOICE_NODE_NAME=bobbrain-livingroom
    EOF
    sudo systemctl enable --now gptme-voice-node

--- a/packages/gptme-voice-node/README.md
+++ b/packages/gptme-voice-node/README.md
@@ -29,7 +29,7 @@ All config is via environment variables (no CLI flags — systemd-friendly):
 | Variable | Default | Description |
 |---|---|---|
 | `GPTME_VOICE_NODE_SERVER` | `ws://localhost:8080/local` | WebSocket URL of `bob-voice-server` |
-| `GPTME_VOICE_NODE_NAME` | `bobbrain-unknown` | Node identity (logged and sent to server) |
+| `GPTME_VOICE_NODE_NAME` | `bobbrain-unknown` | Node identity used in local logs |
 
 The `ws://localhost` default is intended only for a server on the same host. Use
 `wss://` whenever microphone audio crosses a network; the client logs a warning

--- a/packages/gptme-voice-node/README.md
+++ b/packages/gptme-voice-node/README.md
@@ -1,0 +1,83 @@
+# gptme-voice-node
+
+Thin embedded voice client for the [BobBrain](https://github.com/ErikBjare/bob/issues/730)
+portable presence node. Connects to a running `bob-voice-server` WebSocket endpoint
+and handles mic capture → server → speaker playback with echo prevention.
+
+Designed for unattended embedded operation on a Raspberry Pi or any Linux host
+with a USB microphone array (e.g. ReSpeaker XVF3800).
+
+## Quick start (test on the runtime host, no Pi needed)
+
+```bash
+# Install
+pip install gptme-voice-node   # or: uv pip install gptme-voice-node
+
+# Run against a local voice server
+GPTME_VOICE_NODE_SERVER=ws://localhost:8080/local \
+GPTME_VOICE_NODE_NAME=bobbrain-puck \
+gptme-voice-node
+```
+
+The node connects, plays audio from the server, and streams mic input back.
+Press Ctrl-C to stop.
+
+## Configuration
+
+All config is via environment variables (no CLI flags — systemd-friendly):
+
+| Variable | Default | Description |
+|---|---|---|
+| `GPTME_VOICE_NODE_SERVER` | `ws://localhost:8080/local` | WebSocket URL of `bob-voice-server` |
+| `GPTME_VOICE_NODE_NAME` | `bobbrain-unknown` | Node identity (logged and sent to server) |
+
+## Raspberry Pi deployment
+
+1. Install system deps:
+   ```bash
+   sudo apt install -y portaudio19-dev python3-pyaudio
+   pip install gptme-voice-node
+   ```
+
+2. Flash ReSpeaker XVF3800 to USB audio firmware (see Seeed DFU docs).
+
+3. Install the systemd unit:
+   ```bash
+   sudo cp systemd/gptme-voice-node.service /etc/systemd/system/
+   # Customise server URL and node name:
+   sudo mkdir -p /etc/systemd/system/gptme-voice-node.service.d/
+   cat | sudo tee /etc/systemd/system/gptme-voice-node.service.d/local.conf << 'EOF'
+   [Service]
+   Environment=GPTME_VOICE_NODE_SERVER=ws://bob-host.local:8080/local
+   Environment=GPTME_VOICE_NODE_NAME=bobbrain-livingroom
+   EOF
+   sudo systemctl enable --now gptme-voice-node
+   ```
+
+4. Check logs:
+   ```bash
+   journalctl -u gptme-voice-node -f
+   ```
+
+## Protocol
+
+The node speaks the same WebSocket JSON protocol as `gptme-voice-client`:
+
+```
+Client → Server: {"type": "audio", "audio": "<base64 PCM 16-bit 24kHz mono>"}
+Server → Client: {"type": "audio", "audio": "<base64>"}
+Server → Client: {"type": "audio_end"}
+```
+
+All inference happens on the host; the node is pure I/O plumbing.
+
+## Architecture
+
+See `knowledge/technical-designs/bobbrain-spec.md` for the full BobBrain
+architecture, including the BodyAdapter interface for mobility integration.
+
+## Related
+
+- `gptme-contrib/packages/gptme-voice/` — server and existing client (development reference)
+- `knowledge/technical-designs/bobbody-voice-node-spec.md` — detailed protocol and Pi setup
+- ErikBjare/bob#730 — BobBody / BobBrain tracking issue

--- a/packages/gptme-voice-node/pyproject.toml
+++ b/packages/gptme-voice-node/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "gptme-voice-node"
+version = "0.1.0"
+description = "Embedded voice presence node for BobBrain — thin WS client to bob-voice-server"
+readme = "README.md"
+requires-python = ">=3.10,<4.0"
+dependencies = [
+    "pyaudio>=0.2.13",
+    "websockets>=12.0",
+]
+
+[project.scripts]
+gptme-voice-node = "gptme_voice_node.node:main"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.23",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_voice_node"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/packages/gptme-voice-node/pyproject.toml
+++ b/packages/gptme-voice-node/pyproject.toml
@@ -5,7 +5,6 @@ description = "Embedded voice presence node for BobBrain — thin WS client to b
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "pyaudio>=0.2.13",
     "websockets>=12.0",
 ]
 
@@ -13,6 +12,9 @@ dependencies = [
 gptme-voice-node = "gptme_voice_node.node:main"
 
 [project.optional-dependencies]
+audio = [
+    "pyaudio>=0.2.13",
+]
 test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",

--- a/packages/gptme-voice-node/src/gptme_voice_node/__init__.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/__init__.py
@@ -1,0 +1,3 @@
+"""gptme-voice-node — Embedded voice presence node for BobBrain."""
+
+__version__ = "0.1.0"

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -93,8 +93,10 @@ def _close_stream(stream, started: bool) -> None:
             stream.stop_stream()
     except Exception as exc:  # noqa: BLE001
         log.warning("failed to stop audio stream: %s", exc)
-    finally:
+    try:
         stream.close()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("failed to close audio stream: %s", exc)
 
 
 def _next_backoff(backoff: int, connected_at: float | None) -> int:
@@ -129,7 +131,8 @@ class VoiceNode:
     def _mic_muted(self) -> bool:
         """True when we should suppress outbound audio (echo prevention)."""
         return self._playing or (
-            time.monotonic() - self._play_ended_at < PLAYBACK_COOLDOWN
+            self._play_ended_at > 0
+            and time.monotonic() - self._play_ended_at < PLAYBACK_COOLDOWN
         )
 
     # --- Per-session connect handler ---
@@ -227,6 +230,7 @@ class VoiceNode:
         backoff = BACKOFF_INITIAL
         while self._running:
             connected_at: float | None = None
+            error: tuple[int, str] | None = None
             try:
                 async with websockets.connect(
                     self.server_url,
@@ -237,28 +241,22 @@ class VoiceNode:
                     connected_at = time.monotonic()
                     await self._session(ws)
             except (ConnectionClosed, WebSocketException) as exc:
-                log.warning(
-                    "[%s] disconnected: %s — retrying in %ds",
-                    self.node_name,
-                    exc,
-                    backoff,
-                )
+                error = (logging.WARNING, f"disconnected: {exc}")
             except OSError as exc:
-                log.warning(
-                    "[%s] connection error: %s — retrying in %ds",
-                    self.node_name,
-                    exc,
-                    backoff,
-                )
+                error = (logging.WARNING, f"connection error: {exc}")
             except Exception as exc:  # noqa: BLE001
-                log.error(
-                    "[%s] unexpected error: %s — retrying in %ds",
-                    self.node_name,
-                    exc,
-                    backoff,
-                )
+                error = (logging.ERROR, f"unexpected error: {exc}")
             if self._running:
                 backoff = _next_backoff(backoff, connected_at)
+                if error is not None:
+                    level, message = error
+                    log.log(
+                        level,
+                        "[%s] %s — retrying in %ds",
+                        self.node_name,
+                        message,
+                        backoff,
+                    )
                 await asyncio.sleep(backoff)
 
     def stop(self) -> None:
@@ -294,6 +292,20 @@ async def _async_main(server_url: str, node_name: str) -> None:
         node.cleanup()
 
 
+def _redact_url_userinfo(server_url: str) -> str:
+    """Hide credentials from a URL before writing it to logs."""
+    parsed = urlparse(server_url)
+    if parsed.username is None and parsed.password is None:
+        return server_url
+
+    hostname = parsed.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    if parsed.port is not None:
+        hostname = f"{hostname}:{parsed.port}"
+    return parsed._replace(netloc=f"***@{hostname}").geturl()
+
+
 def _warn_for_insecure_remote_url(server_url: str) -> None:
     """Warn when microphone audio would cross the network without TLS."""
     parsed = urlparse(server_url)
@@ -323,7 +335,7 @@ def main() -> None:
     _warn_for_insecure_remote_url(server_url)
 
     log.info("Starting BobBrain voice node")
-    log.info("  server : %s", server_url)
+    log.info("  server : %s", _redact_url_userinfo(server_url))
     log.info("  name   : %s", node_name)
 
     try:

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -72,8 +72,19 @@ PLAYBACK_COOLDOWN = 0.5
 # Reconnect backoff (seconds)
 BACKOFF_INITIAL = 1
 BACKOFF_MAX = 60
+BACKOFF_RESET_AFTER = 30
 
 log = logging.getLogger("gptme_voice_node")
+
+
+def _backoff_after_session(backoff: int, connected_at: float | None) -> int:
+    """Reset retry delay only after a connection stayed healthy long enough."""
+    if (
+        connected_at is not None
+        and time.monotonic() - connected_at >= BACKOFF_RESET_AFTER
+    ):
+        return BACKOFF_INITIAL
+    return backoff
 
 
 class VoiceNode:
@@ -119,6 +130,7 @@ class VoiceNode:
             rate=SAMPLE_RATE,
             input=True,
             frames_per_buffer=CHUNK_SIZE,
+            start=False,
         )
         try:
             speaker = self._pa.open(
@@ -127,8 +139,11 @@ class VoiceNode:
                 rate=SAMPLE_RATE,
                 output=True,
                 frames_per_buffer=CHUNK_SIZE,
+                start=False,
             )
             try:
+                mic.start_stream()
+                speaker.start_stream()
                 await asyncio.gather(
                     self._send_loop(ws, mic),
                     self._recv_loop(ws, speaker),
@@ -187,6 +202,7 @@ class VoiceNode:
         """Connect and auto-reconnect with exponential backoff."""
         backoff = BACKOFF_INITIAL
         while self._running:
+            connected_at: float | None = None
             try:
                 async with websockets.connect(
                     self.server_url,
@@ -194,9 +210,10 @@ class VoiceNode:
                     ping_interval=20,
                     ping_timeout=20,
                 ) as ws:
-                    backoff = BACKOFF_INITIAL  # Reset on success
+                    connected_at = time.monotonic()
                     await self._session(ws)
             except (ConnectionClosed, WebSocketException) as exc:
+                backoff = _backoff_after_session(backoff, connected_at)
                 log.warning(
                     "[%s] disconnected: %s — retrying in %ds",
                     self.node_name,
@@ -204,6 +221,7 @@ class VoiceNode:
                     backoff,
                 )
             except OSError as exc:
+                backoff = _backoff_after_session(backoff, connected_at)
                 log.warning(
                     "[%s] connection error: %s — retrying in %ds",
                     self.node_name,
@@ -211,6 +229,7 @@ class VoiceNode:
                     backoff,
                 )
             except Exception as exc:  # noqa: BLE001
+                backoff = _backoff_after_session(backoff, connected_at)
                 log.error(
                     "[%s] unexpected error: %s — retrying in %ds",
                     self.node_name,

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -25,14 +25,6 @@ import sys
 import time
 
 try:
-    import pyaudio
-except ImportError as e:
-    raise ImportError(
-        "pyaudio is required. Install with: pip install pyaudio\n"
-        "  On Debian/Ubuntu: sudo apt install portaudio19-dev python3-pyaudio"
-    ) from e
-
-try:
     import websockets
     from websockets.exceptions import ConnectionClosed, WebSocketException
 except ImportError as e:
@@ -48,7 +40,28 @@ NODE_NAME = os.environ.get("GPTME_VOICE_NODE_NAME", "bobbrain-unknown")
 SAMPLE_RATE = 24000
 CHUNK_SIZE = 1024
 CHANNELS = 1
-FORMAT = pyaudio.paInt16
+
+# Lazy import: pyaudio is only required when actually instantiating VoiceNode
+_pyaudio = None
+
+
+def _get_pyaudio():
+    """Import pyaudio on demand, raising a helpful error if not installed."""
+    global _pyaudio
+    if _pyaudio is None:
+        try:
+            import pyaudio
+
+            _pyaudio = pyaudio
+        except ImportError as e:
+            raise ImportError(
+                "pyaudio is required. Install with: pip install 'gptme-voice-node[audio]'\n"
+                "  On Debian/Ubuntu: sudo apt install portaudio19-dev python3-pyaudio"
+            ) from e
+    return _pyaudio
+
+
+FORMAT = None  # Will be set to _get_pyaudio().paInt16 in VoiceNode.__init__
 
 # Cooldown window (seconds) to keep mic muted after playback ends.
 # Prevents echo/feedback on nodes without hardware AEC.
@@ -71,7 +84,9 @@ class VoiceNode:
     def __init__(self, server_url: str, node_name: str) -> None:
         self.server_url = server_url
         self.node_name = node_name
+        pyaudio = _get_pyaudio()  # May raise ImportError if not installed
         self._pa = pyaudio.PyAudio()
+        self._audio_format = pyaudio.paInt16
         self._playing = False
         self._play_ended_at = 0.0
         self._running = True
@@ -91,14 +106,14 @@ class VoiceNode:
         log.info("[%s] connected to %s", self.node_name, self.server_url)
 
         mic = self._pa.open(
-            format=FORMAT,
+            format=self._audio_format,
             channels=CHANNELS,
             rate=SAMPLE_RATE,
             input=True,
             frames_per_buffer=CHUNK_SIZE,
         )
         speaker = self._pa.open(
-            format=FORMAT,
+            format=self._audio_format,
             channels=CHANNELS,
             rate=SAMPLE_RATE,
             output=True,

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -145,7 +145,11 @@ class VoiceNode:
         self._playing = False
         self._play_ended_at = 0.0
 
-        log.info("[%s] connected to %s", self.node_name, self.server_url)
+        log.info(
+            "[%s] connected to %s",
+            self.node_name,
+            _redact_url_userinfo(self.server_url),
+        )
 
         mic = self._pa.open(
             format=self._audio_format,

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -21,6 +21,7 @@ import functools
 import json
 import logging
 import os
+import re
 import signal
 import sys
 import time
@@ -175,10 +176,15 @@ class VoiceNode:
                 mic_started = True
                 speaker.start_stream()
                 speaker_started = True
-                await asyncio.gather(
-                    self._send_loop(ws, mic),
-                    self._recv_loop(ws, speaker),
-                )
+                send_task = asyncio.create_task(self._send_loop(ws, mic))
+                recv_task = asyncio.create_task(self._recv_loop(ws, speaker))
+                try:
+                    await asyncio.gather(send_task, recv_task)
+                finally:
+                    for task in (send_task, recv_task):
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(send_task, recv_task, return_exceptions=True)
             finally:
                 _close_stream(speaker, speaker_started)
         finally:
@@ -245,11 +251,20 @@ class VoiceNode:
                     connected_at = time.monotonic()
                     await self._session(ws)
             except (ConnectionClosed, WebSocketException) as exc:
-                error = (logging.WARNING, f"disconnected: {exc}")
+                error = (
+                    logging.WARNING,
+                    f"disconnected: {_redact_userinfo_in_text(str(exc), self.server_url)}",
+                )
             except OSError as exc:
-                error = (logging.WARNING, f"connection error: {exc}")
+                error = (
+                    logging.WARNING,
+                    f"connection error: {_redact_userinfo_in_text(str(exc), self.server_url)}",
+                )
             except Exception as exc:  # noqa: BLE001
-                error = (logging.ERROR, f"unexpected error: {exc}")
+                error = (
+                    logging.ERROR,
+                    f"unexpected error: {_redact_userinfo_in_text(str(exc), self.server_url)}",
+                )
             if self._running:
                 backoff = _next_backoff(backoff, connected_at)
                 if error is not None:
@@ -296,6 +311,9 @@ async def _async_main(server_url: str, node_name: str) -> None:
         node.cleanup()
 
 
+_USERINFO_IN_TEXT = re.compile(r"(://)([^/@\s]+)@")
+
+
 def _redact_url_userinfo(server_url: str) -> str:
     """Hide credentials from a URL before writing it to logs."""
     parsed = urlparse(server_url)
@@ -308,6 +326,15 @@ def _redact_url_userinfo(server_url: str) -> str:
     if parsed.port is not None:
         hostname = f"{hostname}:{parsed.port}"
     return parsed._replace(netloc=f"***@{hostname}").geturl()
+
+
+def _redact_userinfo_in_text(text: str, server_url: str = "") -> str:
+    """Hide URL userinfo in free-form log/exception text."""
+    if server_url:
+        redacted = _redact_url_userinfo(server_url)
+        if redacted != server_url:
+            text = text.replace(server_url, redacted)
+    return _USERINFO_IN_TEXT.sub(r"\1***@", text)
 
 
 def _warn_for_insecure_remote_url(server_url: str) -> None:

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -104,6 +104,12 @@ class VoiceNode:
 
     async def _session(self, ws) -> None:
         """Handle one connected WebSocket session."""
+        # Reset per-session playback state on every reconnect.
+        # Without this, a disconnect mid-playback leaves _playing=True, which
+        # silently mutes the mic for the entire next session.
+        self._playing = False
+        self._play_ended_at = 0.0
+
         log.info("[%s] connected to %s", self.node_name, self.server_url)
 
         mic = self._pa.open(
@@ -113,24 +119,25 @@ class VoiceNode:
             input=True,
             frames_per_buffer=CHUNK_SIZE,
         )
-        speaker = self._pa.open(
-            format=self._audio_format,
-            channels=CHANNELS,
-            rate=SAMPLE_RATE,
-            output=True,
-            frames_per_buffer=CHUNK_SIZE,
-        )
-
         try:
-            await asyncio.gather(
-                self._send_loop(ws, mic),
-                self._recv_loop(ws, speaker),
+            speaker = self._pa.open(
+                format=self._audio_format,
+                channels=CHANNELS,
+                rate=SAMPLE_RATE,
+                output=True,
+                frames_per_buffer=CHUNK_SIZE,
             )
+            try:
+                await asyncio.gather(
+                    self._send_loop(ws, mic),
+                    self._recv_loop(ws, speaker),
+                )
+            finally:
+                speaker.stop_stream()
+                speaker.close()
         finally:
             mic.stop_stream()
             mic.close()
-            speaker.stop_stream()
-            speaker.close()
 
     async def _send_loop(self, ws, mic_stream) -> None:
         """Continuously read mic and forward to server (unless muted)."""
@@ -148,9 +155,20 @@ class VoiceNode:
             await asyncio.sleep(0.005)
 
     async def _recv_loop(self, ws, speaker_stream) -> None:
-        """Receive audio frames from server and play them."""
+        """Receive audio frames from server and play them.
+
+        Uses explicit ws.recv() rather than ``async for`` so that the loop
+        respects the ``_running`` flag and exits cleanly on shutdown instead
+        of blocking indefinitely waiting for the next message.  This prevents
+        run_forever from hanging and leaking PyAudio resources when the node
+        is stopped via SIGTERM.
+        """
         loop = asyncio.get_event_loop()
-        async for raw_msg in ws:
+        while self._running:
+            try:
+                raw_msg = await ws.recv()
+            except ConnectionClosed:
+                break
             data = json.loads(raw_msg)
             msg_type = data.get("type")
             if msg_type == "audio":
@@ -215,16 +233,22 @@ async def _async_main(server_url: str, node_name: str) -> None:
     node = VoiceNode(server_url, node_name)
 
     loop = asyncio.get_event_loop()
+    task = asyncio.ensure_future(node.run_forever())
 
     def _handle_signal(sig: signal.Signals) -> None:
         log.info("[%s] received signal %s, shutting down", node_name, sig)
         node.stop()
+        # Cancel the task so any blocked ws.recv() unblocks immediately and
+        # the cleanup finally block runs without waiting for SIGKILL.
+        task.cancel()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(_handle_signal, sig))
 
     try:
-        await node.run_forever()
+        await task
+    except asyncio.CancelledError:
+        pass
     finally:
         node.cleanup()
 

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -17,6 +17,7 @@ Protocol:
 
 import asyncio
 import base64
+import functools
 import json
 import logging
 import os
@@ -215,12 +216,12 @@ async def _async_main(server_url: str, node_name: str) -> None:
 
     loop = asyncio.get_event_loop()
 
-    def _handle_signal(sig):
+    def _handle_signal(sig: signal.Signals) -> None:
         log.info("[%s] received signal %s, shutting down", node_name, sig)
         node.stop()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, lambda s=sig: _handle_signal(s))
+        loop.add_signal_handler(sig, functools.partial(_handle_signal, sig))
 
     try:
         await node.run_forever()

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -1,0 +1,240 @@
+"""
+BobBrain voice node — thin WS client for embedded Linux.
+
+Auto-reconnects to bob-voice-server with exponential backoff.
+Low memory footprint, systemd-managed lifecycle.
+
+Config (env vars):
+  GPTME_VOICE_NODE_SERVER  — WebSocket URL of bob-voice-server (default: ws://localhost:8080/local)
+  GPTME_VOICE_NODE_NAME    — Node identity string (default: bobbrain-unknown)
+
+Protocol:
+  Client → Server: {"type": "audio", "audio": "<base64 PCM 16-bit 24kHz mono>"}
+  Client → Server: {"type": "commit"}      (optional flush signal)
+  Server → Client: {"type": "audio", "audio": "<base64>"}
+  Server → Client: {"type": "audio_end"}
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import signal
+import sys
+import time
+
+try:
+    import pyaudio
+except ImportError as e:
+    raise ImportError(
+        "pyaudio is required. Install with: pip install pyaudio\n"
+        "  On Debian/Ubuntu: sudo apt install portaudio19-dev python3-pyaudio"
+    ) from e
+
+try:
+    import websockets
+    from websockets.exceptions import ConnectionClosed, WebSocketException
+except ImportError as e:
+    raise ImportError(
+        "websockets is required. Install with: pip install 'websockets>=12.0'"
+    ) from e
+
+# --- Config ---
+SERVER_URL = os.environ.get("GPTME_VOICE_NODE_SERVER", "ws://localhost:8080/local")
+NODE_NAME = os.environ.get("GPTME_VOICE_NODE_NAME", "bobbrain-unknown")
+
+# --- Audio constants (must match server) ---
+SAMPLE_RATE = 24000
+CHUNK_SIZE = 1024
+CHANNELS = 1
+FORMAT = pyaudio.paInt16
+
+# Cooldown window (seconds) to keep mic muted after playback ends.
+# Prevents echo/feedback on nodes without hardware AEC.
+PLAYBACK_COOLDOWN = 0.5
+
+# Reconnect backoff (seconds)
+BACKOFF_INITIAL = 1
+BACKOFF_MAX = 60
+
+log = logging.getLogger("gptme_voice_node")
+
+
+class VoiceNode:
+    """Thin embedded voice client.
+
+    Manages one PyAudio instance across reconnects.  Audio streams are opened
+    and closed per-session so the OS sees a clean release on disconnect.
+    """
+
+    def __init__(self, server_url: str, node_name: str) -> None:
+        self.server_url = server_url
+        self.node_name = node_name
+        self._pa = pyaudio.PyAudio()
+        self._playing = False
+        self._play_ended_at = 0.0
+        self._running = True
+
+    # --- Mic mute logic ---
+
+    def _mic_muted(self) -> bool:
+        """True when we should suppress outbound audio (echo prevention)."""
+        return self._playing or (
+            time.monotonic() - self._play_ended_at < PLAYBACK_COOLDOWN
+        )
+
+    # --- Per-session connect handler ---
+
+    async def _session(self, ws) -> None:
+        """Handle one connected WebSocket session."""
+        log.info("[%s] connected to %s", self.node_name, self.server_url)
+
+        mic = self._pa.open(
+            format=FORMAT,
+            channels=CHANNELS,
+            rate=SAMPLE_RATE,
+            input=True,
+            frames_per_buffer=CHUNK_SIZE,
+        )
+        speaker = self._pa.open(
+            format=FORMAT,
+            channels=CHANNELS,
+            rate=SAMPLE_RATE,
+            output=True,
+            frames_per_buffer=CHUNK_SIZE,
+        )
+
+        try:
+            await asyncio.gather(
+                self._send_loop(ws, mic),
+                self._recv_loop(ws, speaker),
+            )
+        finally:
+            mic.stop_stream()
+            mic.close()
+            speaker.stop_stream()
+            speaker.close()
+
+    async def _send_loop(self, ws, mic_stream) -> None:
+        """Continuously read mic and forward to server (unless muted)."""
+        loop = asyncio.get_event_loop()
+        while self._running:
+            # Read in executor to avoid blocking the event loop
+            raw = await loop.run_in_executor(
+                None,
+                lambda: mic_stream.read(CHUNK_SIZE, exception_on_overflow=False),
+            )
+            if not self._mic_muted():
+                msg = {"type": "audio", "audio": base64.b64encode(raw).decode()}
+                await ws.send(json.dumps(msg))
+            # Yield to other tasks briefly
+            await asyncio.sleep(0.005)
+
+    async def _recv_loop(self, ws, speaker_stream) -> None:
+        """Receive audio frames from server and play them."""
+        loop = asyncio.get_event_loop()
+        async for raw_msg in ws:
+            data = json.loads(raw_msg)
+            msg_type = data.get("type")
+            if msg_type == "audio":
+                self._playing = True
+                pcm = base64.b64decode(data["audio"])
+                await loop.run_in_executor(None, lambda: speaker_stream.write(pcm))
+            elif msg_type == "audio_end":
+                self._playing = False
+                self._play_ended_at = time.monotonic()
+                log.debug("[%s] audio_end received", self.node_name)
+
+    # --- Reconnect loop ---
+
+    async def run_forever(self) -> None:
+        """Connect and auto-reconnect with exponential backoff."""
+        backoff = BACKOFF_INITIAL
+        while self._running:
+            try:
+                async with websockets.connect(
+                    self.server_url,
+                    open_timeout=10,
+                    ping_interval=20,
+                    ping_timeout=20,
+                ) as ws:
+                    backoff = BACKOFF_INITIAL  # Reset on success
+                    await self._session(ws)
+            except (ConnectionClosed, WebSocketException) as exc:
+                log.warning(
+                    "[%s] disconnected: %s — retrying in %ds",
+                    self.node_name,
+                    exc,
+                    backoff,
+                )
+            except OSError as exc:
+                log.warning(
+                    "[%s] connection error: %s — retrying in %ds",
+                    self.node_name,
+                    exc,
+                    backoff,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.error(
+                    "[%s] unexpected error: %s — retrying in %ds",
+                    self.node_name,
+                    exc,
+                    backoff,
+                )
+            if self._running:
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, BACKOFF_MAX)
+
+    def stop(self) -> None:
+        """Signal the node to shut down cleanly."""
+        self._running = False
+
+    def cleanup(self) -> None:
+        """Release PyAudio resources."""
+        self._pa.terminate()
+
+
+async def _async_main(server_url: str, node_name: str) -> None:
+    node = VoiceNode(server_url, node_name)
+
+    loop = asyncio.get_event_loop()
+
+    def _handle_signal(sig):
+        log.info("[%s] received signal %s, shutting down", node_name, sig)
+        node.stop()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, lambda s=sig: _handle_signal(s))
+
+    try:
+        await node.run_forever()
+    finally:
+        node.cleanup()
+
+
+def main() -> None:
+    """Entry point for the gptme-voice-node CLI."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        stream=sys.stderr,
+    )
+
+    server_url = SERVER_URL
+    node_name = NODE_NAME
+
+    log.info("Starting BobBrain voice node")
+    log.info("  server : %s", server_url)
+    log.info("  name   : %s", node_name)
+
+    try:
+        asyncio.run(_async_main(server_url, node_name))
+    except KeyboardInterrupt:
+        pass
+    log.info("[%s] stopped", node_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -24,6 +24,7 @@ import os
 import signal
 import sys
 import time
+from urllib.parse import urlparse
 
 try:
     import websockets
@@ -253,6 +254,21 @@ async def _async_main(server_url: str, node_name: str) -> None:
         node.cleanup()
 
 
+def _warn_for_insecure_remote_url(server_url: str) -> None:
+    """Warn when microphone audio would cross the network without TLS."""
+    parsed = urlparse(server_url)
+    if parsed.scheme == "ws" and parsed.hostname not in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }:
+        log.warning(
+            "Microphone audio will be sent unencrypted to %s; use wss:// "
+            "for remote deployments",
+            parsed.hostname,
+        )
+
+
 def main() -> None:
     """Entry point for the gptme-voice-node CLI."""
     logging.basicConfig(
@@ -264,6 +280,7 @@ def main() -> None:
 
     server_url = SERVER_URL
     node_name = NODE_NAME
+    _warn_for_insecure_remote_url(server_url)
 
     log.info("Starting BobBrain voice node")
     log.info("  server : %s", server_url)

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -72,6 +72,11 @@ FORMAT = None  # Will be set to _get_pyaudio().paInt16 in VoiceNode.__init__
 # Prevents echo/feedback on nodes without hardware AEC.
 PLAYBACK_COOLDOWN = 0.5
 
+# If the server stops sending audio frames without an `audio_end`, unmute
+# after this many seconds. Otherwise a live connection with a stuck
+# `_playing` flag silently drops every mic chunk until disconnect.
+PLAYBACK_STALL_TIMEOUT = 5.0
+
 # Reconnect backoff (seconds)
 BACKOFF_INITIAL = 1
 BACKOFF_MAX = 60
@@ -211,7 +216,17 @@ class VoiceNode:
         """
         while self._running:
             try:
-                raw_msg = await ws.recv()
+                timeout = PLAYBACK_STALL_TIMEOUT if self._playing else None
+                raw_msg = await asyncio.wait_for(ws.recv(), timeout=timeout)
+            except asyncio.TimeoutError:
+                self._playing = False
+                self._play_ended_at = time.monotonic()
+                log.warning(
+                    "[%s] playback stall timeout after %.1fs without audio_end; unmuting mic",
+                    self.node_name,
+                    PLAYBACK_STALL_TIMEOUT,
+                )
+                continue
             except ConnectionClosed:
                 break
             try:

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -24,6 +24,8 @@ import os
 import signal
 import sys
 import time
+from collections.abc import Callable
+from typing import Any, TypeVar
 from urllib.parse import urlparse
 
 try:
@@ -76,15 +78,27 @@ BACKOFF_RESET_AFTER = 30
 
 log = logging.getLogger("gptme_voice_node")
 
+T = TypeVar("T")
 
-def _backoff_after_session(backoff: int, connected_at: float | None) -> int:
-    """Reset retry delay only after a connection stayed healthy long enough."""
+
+async def _run_audio_io(function: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Run blocking audio I/O and let it finish before propagating cancellation."""
+    task = asyncio.create_task(asyncio.to_thread(function, *args, **kwargs))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+def _next_backoff(backoff: int, connected_at: float | None) -> int:
+    """Reset after a healthy session; otherwise increase the retry delay."""
     if (
         connected_at is not None
         and time.monotonic() - connected_at >= BACKOFF_RESET_AFTER
     ):
         return BACKOFF_INITIAL
-    return backoff
+    return min(backoff * 2, BACKOFF_MAX)
 
 
 class VoiceNode:
@@ -157,18 +171,13 @@ class VoiceNode:
 
     async def _send_loop(self, ws, mic_stream) -> None:
         """Continuously read mic and forward to server (unless muted)."""
-        loop = asyncio.get_event_loop()
         while self._running:
-            # Read in executor to avoid blocking the event loop
-            raw = await loop.run_in_executor(
-                None,
-                lambda: mic_stream.read(CHUNK_SIZE, exception_on_overflow=False),
+            raw = await _run_audio_io(
+                mic_stream.read, CHUNK_SIZE, exception_on_overflow=False
             )
             if not self._mic_muted():
                 msg = {"type": "audio", "audio": base64.b64encode(raw).decode()}
                 await ws.send(json.dumps(msg))
-            # Yield to other tasks briefly
-            await asyncio.sleep(0.005)
 
     async def _recv_loop(self, ws, speaker_stream) -> None:
         """Receive audio frames from server and play them.
@@ -179,7 +188,6 @@ class VoiceNode:
         run_forever from hanging and leaking PyAudio resources when the node
         is stopped via SIGTERM.
         """
-        loop = asyncio.get_event_loop()
         while self._running:
             try:
                 raw_msg = await ws.recv()
@@ -190,7 +198,7 @@ class VoiceNode:
             if msg_type == "audio":
                 self._playing = True
                 pcm = base64.b64decode(data["audio"])
-                await loop.run_in_executor(None, lambda: speaker_stream.write(pcm))
+                await _run_audio_io(speaker_stream.write, pcm)
             elif msg_type == "audio_end":
                 self._playing = False
                 self._play_ended_at = time.monotonic()
@@ -213,7 +221,6 @@ class VoiceNode:
                     connected_at = time.monotonic()
                     await self._session(ws)
             except (ConnectionClosed, WebSocketException) as exc:
-                backoff = _backoff_after_session(backoff, connected_at)
                 log.warning(
                     "[%s] disconnected: %s — retrying in %ds",
                     self.node_name,
@@ -221,7 +228,6 @@ class VoiceNode:
                     backoff,
                 )
             except OSError as exc:
-                backoff = _backoff_after_session(backoff, connected_at)
                 log.warning(
                     "[%s] connection error: %s — retrying in %ds",
                     self.node_name,
@@ -229,7 +235,6 @@ class VoiceNode:
                     backoff,
                 )
             except Exception as exc:  # noqa: BLE001
-                backoff = _backoff_after_session(backoff, connected_at)
                 log.error(
                     "[%s] unexpected error: %s — retrying in %ds",
                     self.node_name,
@@ -238,7 +243,7 @@ class VoiceNode:
                 )
             if self._running:
                 await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, BACKOFF_MAX)
+                backoff = _next_backoff(backoff, connected_at)
 
     def stop(self) -> None:
         """Signal the node to shut down cleanly."""

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -82,13 +82,19 @@ T = TypeVar("T")
 
 
 async def _run_audio_io(function: Callable[..., T], *args: Any, **kwargs: Any) -> T:
-    """Run blocking audio I/O and let it finish before propagating cancellation."""
-    task = asyncio.create_task(asyncio.to_thread(function, *args, **kwargs))
+    """Run blocking audio I/O without blocking cancellation of the caller."""
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+def _close_stream(stream, started: bool) -> None:
+    """Close an audio stream even when start or stop fails."""
     try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        await task
-        raise
+        if started:
+            stream.stop_stream()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("failed to stop audio stream: %s", exc)
+    finally:
+        stream.close()
 
 
 def _next_backoff(backoff: int, connected_at: float | None) -> int:
@@ -146,6 +152,7 @@ class VoiceNode:
             frames_per_buffer=CHUNK_SIZE,
             start=False,
         )
+        mic_started = False
         try:
             speaker = self._pa.open(
                 format=self._audio_format,
@@ -155,19 +162,20 @@ class VoiceNode:
                 frames_per_buffer=CHUNK_SIZE,
                 start=False,
             )
+            speaker_started = False
             try:
                 mic.start_stream()
+                mic_started = True
                 speaker.start_stream()
+                speaker_started = True
                 await asyncio.gather(
                     self._send_loop(ws, mic),
                     self._recv_loop(ws, speaker),
                 )
             finally:
-                speaker.stop_stream()
-                speaker.close()
+                _close_stream(speaker, speaker_started)
         finally:
-            mic.stop_stream()
-            mic.close()
+            _close_stream(mic, mic_started)
 
     async def _send_loop(self, ws, mic_stream) -> None:
         """Continuously read mic and forward to server (unless muted)."""
@@ -205,7 +213,7 @@ class VoiceNode:
                     pcm = base64.b64decode(audio, validate=True)
                     self._playing = True
                     await _run_audio_io(speaker_stream.write, pcm)
-                elif msg_type == "audio_end":
+                elif msg_type == "audio_end" and self._playing:
                     self._playing = False
                     self._play_ended_at = time.monotonic()
                     log.debug("[%s] audio_end received", self.node_name)

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -193,16 +193,24 @@ class VoiceNode:
                 raw_msg = await ws.recv()
             except ConnectionClosed:
                 break
-            data = json.loads(raw_msg)
-            msg_type = data.get("type")
-            if msg_type == "audio":
-                self._playing = True
-                pcm = base64.b64decode(data["audio"])
-                await _run_audio_io(speaker_stream.write, pcm)
-            elif msg_type == "audio_end":
-                self._playing = False
-                self._play_ended_at = time.monotonic()
-                log.debug("[%s] audio_end received", self.node_name)
+            try:
+                data = json.loads(raw_msg)
+                if not isinstance(data, dict):
+                    raise TypeError("message must be a JSON object")
+                msg_type = data.get("type")
+                if msg_type == "audio":
+                    audio = data.get("audio")
+                    if not isinstance(audio, str):
+                        raise TypeError("audio message must contain a string payload")
+                    pcm = base64.b64decode(audio, validate=True)
+                    self._playing = True
+                    await _run_audio_io(speaker_stream.write, pcm)
+                elif msg_type == "audio_end":
+                    self._playing = False
+                    self._play_ended_at = time.monotonic()
+                    log.debug("[%s] audio_end received", self.node_name)
+            except (ValueError, TypeError) as exc:
+                log.warning("[%s] ignoring malformed message: %s", self.node_name, exc)
 
     # --- Reconnect loop ---
 
@@ -242,8 +250,8 @@ class VoiceNode:
                     backoff,
                 )
             if self._running:
-                await asyncio.sleep(backoff)
                 backoff = _next_backoff(backoff, connected_at)
+                await asyncio.sleep(backoff)
 
     def stop(self) -> None:
         """Signal the node to shut down cleanly."""

--- a/packages/gptme-voice-node/systemd/gptme-voice-node.service
+++ b/packages/gptme-voice-node/systemd/gptme-voice-node.service
@@ -7,7 +7,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 # Override these in /etc/systemd/system/gptme-voice-node.service.d/local.conf
-Environment=GPTME_VOICE_NODE_SERVER=ws://bob-host.local:8080/local
+# Use wss:// whenever microphone audio crosses a network.
+Environment=GPTME_VOICE_NODE_SERVER=wss://bob-host.example.com/local
 Environment=GPTME_VOICE_NODE_NAME=bobbrain-puck
 
 # Adjust to the user that has audio access (e.g. pi on Raspberry Pi OS)

--- a/packages/gptme-voice-node/systemd/gptme-voice-node.service
+++ b/packages/gptme-voice-node/systemd/gptme-voice-node.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=BobBrain Voice Node — WS client to bob-voice-server
+Documentation=https://github.com/gptme/gptme-contrib/tree/master/packages/gptme-voice-node
+After=network-online.target sound.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Override these in /etc/systemd/system/gptme-voice-node.service.d/local.conf
+Environment=GPTME_VOICE_NODE_SERVER=ws://bob-host.local:8080/local
+Environment=GPTME_VOICE_NODE_NAME=bobbrain-puck
+
+# Adjust to the user that has audio access (e.g. pi on Raspberry Pi OS)
+User=pi
+WorkingDirectory=/home/pi
+
+ExecStart=/home/pi/.local/bin/gptme-voice-node
+
+# Auto-restart with progressive cooldown
+Restart=always
+RestartSec=10
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+# Resource limits (target: <50 MB RSS)
+MemoryMax=128M
+CPUQuota=50%
+
+# Logging — stderr goes to journald
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -129,6 +129,27 @@ class TestRecvLoop:
         assert node._playing is False
         assert node._play_ended_at > 0
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "not json",
+            json.dumps(["not", "an object"]),
+            json.dumps({"type": "audio"}),
+            json.dumps({"type": "audio", "audio": "not base64!"}),
+        ],
+    )
+    async def test_malformed_message_is_ignored(self, message, caplog):
+        node = _make_node()
+        mock_ws = AsyncMock()
+        mock_ws.recv.side_effect = [message, ConnectionClosed(None, None)]
+        speaker = MagicMock()
+
+        await node._recv_loop(mock_ws, speaker)
+
+        speaker.write.assert_not_called()
+        assert "ignoring malformed message" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Transport safety warning
@@ -226,3 +247,30 @@ class TestBackoff:
 
         with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
             assert _next_backoff(8, connected_at=60.0) == BACKOFF_INITIAL
+
+    @pytest.mark.asyncio
+    async def test_stable_session_uses_reset_delay_for_immediate_retry(self):
+        from gptme_voice_node.node import BACKOFF_INITIAL
+
+        node = _make_node()
+
+        class Connection:
+            async def __aenter__(self):
+                return AsyncMock()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        async def stop_on_sleep(delay):
+            assert delay == BACKOFF_INITIAL
+            node.stop()
+
+        with (
+            patch(
+                "gptme_voice_node.node.websockets.connect", return_value=Connection()
+            ),
+            patch.object(node, "_session", new=AsyncMock()),
+            patch("gptme_voice_node.node._next_backoff", return_value=BACKOFF_INITIAL),
+            patch("gptme_voice_node.node.asyncio.sleep", side_effect=stop_on_sleep),
+        ):
+            await node.run_forever()

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -146,6 +146,27 @@ class TestLifecycle:
         node.stop()
         assert node._running is False
 
+    @pytest.mark.asyncio
+    async def test_session_explicitly_starts_audio_streams(self):
+        node = _make_node()
+        mic = MagicMock()
+        speaker = MagicMock()
+        node._pa.open.side_effect = [mic, speaker]
+
+        async def stop_session(*_args):
+            node.stop()
+
+        with (
+            patch.object(node, "_send_loop", AsyncMock(side_effect=stop_session)),
+            patch.object(node, "_recv_loop", AsyncMock(side_effect=stop_session)),
+        ):
+            await node._session(AsyncMock())
+
+        mic.start_stream.assert_called_once()
+        speaker.start_stream.assert_called_once()
+        assert node._pa.open.call_args_list[0].kwargs["start"] is False
+        assert node._pa.open.call_args_list[1].kwargs["start"] is False
+
     def test_cleanup_terminates_pyaudio(self):
         with patch("gptme_voice_node.node._get_pyaudio") as mock_get_pa:
             mock_pa_module = MagicMock()
@@ -176,3 +197,15 @@ class TestBackoff:
             mock_ws.connect = AsyncMock()
             await node.run_forever()
             mock_ws.connect.assert_not_called()
+
+    def test_quick_session_failure_preserves_exponential_backoff(self):
+        from gptme_voice_node.node import _backoff_after_session
+
+        with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
+            assert _backoff_after_session(8, connected_at=99.0) == 8
+
+    def test_stable_session_resets_exponential_backoff(self):
+        from gptme_voice_node.node import BACKOFF_INITIAL, _backoff_after_session
+
+        with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
+            assert _backoff_after_session(8, connected_at=60.0) == BACKOFF_INITIAL

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -114,6 +114,27 @@ class TestRecvLoop:
 
 
 # ---------------------------------------------------------------------------
+# Transport safety warning
+# ---------------------------------------------------------------------------
+
+
+class TestTransportWarning:
+    def test_warns_for_insecure_remote_url(self, caplog):
+        from gptme_voice_node.node import _warn_for_insecure_remote_url
+
+        _warn_for_insecure_remote_url("ws://bob-host.local:8080/local")
+
+        assert "sent unencrypted" in caplog.text
+
+    def test_local_ws_url_does_not_warn(self, caplog):
+        from gptme_voice_node.node import _warn_for_insecure_remote_url
+
+        _warn_for_insecure_remote_url("ws://localhost:8080/local")
+
+        assert not caplog.text
+
+
+# ---------------------------------------------------------------------------
 # Stop / cleanup
 # ---------------------------------------------------------------------------
 

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -62,15 +62,15 @@ class TestMicMute:
 
 class TestSendLoop:
     @pytest.mark.asyncio
-    async def test_audio_io_cancellation_waits_for_inflight_thread(self):
+    async def test_audio_io_cancellation_does_not_wait_for_inflight_thread(self):
         from gptme_voice_node.node import _run_audio_io
 
         thread_started = asyncio.Event()
-        allow_thread_to_finish = asyncio.Event()
+        never_finishes = asyncio.Event()
 
         async def fake_to_thread(function, *args, **kwargs):
             thread_started.set()
-            await allow_thread_to_finish.wait()
+            await never_finishes.wait()
             return function(*args, **kwargs)
 
         operation = MagicMock(return_value=b"audio")
@@ -78,13 +78,10 @@ class TestSendLoop:
             task = asyncio.create_task(_run_audio_io(operation))
             await thread_started.wait()
             task.cancel()
-            await asyncio.sleep(0)
-            assert not task.done()
-            allow_thread_to_finish.set()
             with pytest.raises(asyncio.CancelledError):
-                await task
+                await asyncio.wait_for(task, timeout=0.1)
 
-        operation.assert_called_once_with()
+        operation.assert_not_called()
 
 
 class TestRecvLoop:
@@ -128,6 +125,21 @@ class TestRecvLoop:
 
         assert node._playing is False
         assert node._play_ended_at > 0
+
+    @pytest.mark.asyncio
+    async def test_spurious_audio_end_does_not_start_cooldown(self):
+        node = _make_node()
+        node._playing = False
+
+        mock_ws = AsyncMock()
+        mock_ws.recv.side_effect = [
+            json.dumps({"type": "audio_end"}),
+            ConnectionClosed(None, None),
+        ]
+
+        await node._recv_loop(mock_ws, MagicMock())
+
+        assert node._play_ended_at == 0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -204,6 +216,23 @@ class TestLifecycle:
         speaker.start_stream.assert_called_once()
         assert node._pa.open.call_args_list[0].kwargs["start"] is False
         assert node._pa.open.call_args_list[1].kwargs["start"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failing_stream", ["mic", "speaker"])
+    async def test_session_closes_streams_when_start_fails(self, failing_stream):
+        node = _make_node()
+        mic = MagicMock()
+        speaker = MagicMock()
+        node._pa.open.side_effect = [mic, speaker]
+        stream = mic if failing_stream == "mic" else speaker
+        stream.start_stream.side_effect = OSError("device unavailable")
+
+        with pytest.raises(OSError, match="device unavailable"):
+            await node._session(AsyncMock())
+
+        mic.close.assert_called_once()
+        speaker.close.assert_called_once()
+        stream.stop_stream.assert_not_called()
 
     def test_cleanup_terminates_pyaudio(self):
         with patch("gptme_voice_node.node._get_pyaudio") as mock_get_pa:

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -114,6 +114,39 @@ class TestRecvLoop:
         speaker.write.assert_called_once_with(pcm)
 
     @pytest.mark.asyncio
+    async def test_playback_stall_timeout_unmutes_mic(self, caplog):
+        node = _make_node()
+        pcm = b"\x00\x01" * 512
+        msg = json.dumps({"type": "audio", "audio": base64.b64encode(pcm).decode()})
+        mock_ws = AsyncMock()
+        calls = 0
+
+        async def recv():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return msg
+            if calls == 2:
+                await asyncio.sleep(30)
+            raise ConnectionClosed(None, None)
+
+        mock_ws.recv.side_effect = recv
+        speaker = MagicMock()
+
+        async def fake_audio_io(function, *args, **kwargs):
+            return function(*args, **kwargs)
+
+        with (
+            patch("gptme_voice_node.node._run_audio_io", fake_audio_io),
+            patch("gptme_voice_node.node.PLAYBACK_STALL_TIMEOUT", 0.05),
+        ):
+            await asyncio.wait_for(node._recv_loop(mock_ws, speaker), timeout=1)
+
+        assert node._playing is False
+        assert node._play_ended_at > 0
+        assert "playback stall timeout" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_audio_end_clears_playing_flag(self):
         node = _make_node()
         node._playing = True

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -1,0 +1,150 @@
+"""Tests for gptme-voice-node that don't require real audio hardware or network."""
+
+import asyncio
+import base64
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers to avoid pyaudio import in test collection
+# ---------------------------------------------------------------------------
+
+
+def _make_node(server_url="ws://localhost:9999/local", node_name="test-node"):
+    """Create a VoiceNode with pyaudio mocked out."""
+    with patch("gptme_voice_node.node.pyaudio") as mock_pa_module:
+        mock_pa_module.paInt16 = 8  # arbitrary constant
+        mock_pa_module.PyAudio.return_value = MagicMock()
+        from gptme_voice_node.node import VoiceNode
+
+        node = VoiceNode(server_url, node_name)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Mic mute logic
+# ---------------------------------------------------------------------------
+
+
+class TestMicMute:
+    def test_not_muted_by_default(self):
+        node = _make_node()
+        assert not node._mic_muted()
+
+    def test_muted_during_playback(self):
+        node = _make_node()
+        node._playing = True
+        assert node._mic_muted()
+
+    def test_muted_in_cooldown_window(self):
+        node = _make_node()
+        node._playing = False
+        node._play_ended_at = time.monotonic()  # just now
+        assert node._mic_muted()
+
+    def test_unmuted_after_cooldown(self):
+        node = _make_node()
+        node._playing = False
+        node._play_ended_at = time.monotonic() - 10  # 10 seconds ago
+        assert not node._mic_muted()
+
+
+# ---------------------------------------------------------------------------
+# Recv loop: audio frame handling
+# ---------------------------------------------------------------------------
+
+
+class TestRecvLoop:
+    @pytest.mark.asyncio
+    async def test_audio_frame_triggers_playback_flag(self):
+        node = _make_node()
+        node._playing = False
+
+        pcm = b"\x00\x01" * 512
+        msg = json.dumps({"type": "audio", "audio": base64.b64encode(pcm).decode()})
+
+        mock_ws = AsyncMock()
+        mock_ws.__aiter__.return_value = iter([msg])
+
+        speaker = MagicMock()
+        # We expect write to be called with the PCM bytes
+        written = []
+
+        def fake_run_in_executor(_, fn):
+            result = fn()
+            written.append(result)
+            fut = asyncio.get_event_loop().create_future()
+            fut.set_result(None)
+            return fut
+
+        with patch.object(
+            asyncio.get_event_loop(),
+            "run_in_executor",
+            side_effect=fake_run_in_executor,
+        ):
+            await node._recv_loop(mock_ws, speaker)
+
+        assert node._playing is True  # set mid-loop; audio_end not sent
+        assert speaker.write.called
+
+    @pytest.mark.asyncio
+    async def test_audio_end_clears_playing_flag(self):
+        node = _make_node()
+        node._playing = True
+
+        msgs = [
+            json.dumps({"type": "audio_end"}),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.__aiter__.return_value = iter(msgs)
+        speaker = MagicMock()
+
+        await node._recv_loop(mock_ws, speaker)
+
+        assert node._playing is False
+        assert node._play_ended_at > 0
+
+
+# ---------------------------------------------------------------------------
+# Stop / cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_stop_sets_running_false(self):
+        node = _make_node()
+        assert node._running is True
+        node.stop()
+        assert node._running is False
+
+    def test_cleanup_terminates_pyaudio(self):
+        with patch("gptme_voice_node.node.pyaudio") as mock_pa_module:
+            mock_pa_module.paInt16 = 8
+            mock_pa = MagicMock()
+            mock_pa_module.PyAudio.return_value = mock_pa
+            from gptme_voice_node.node import VoiceNode
+
+            node = VoiceNode("ws://x", "test")
+            node.cleanup()
+            mock_pa.terminate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Reconnect backoff behaviour (state machine only)
+# ---------------------------------------------------------------------------
+
+
+class TestBackoff:
+    @pytest.mark.asyncio
+    async def test_run_forever_stops_when_not_running(self):
+        """If _running is already False, run_forever exits without connecting."""
+        node = _make_node()
+        node._running = False
+
+        with patch("gptme_voice_node.node.websockets") as mock_ws:
+            mock_ws.connect = AsyncMock()
+            await node.run_forever()
+            mock_ws.connect.assert_not_called()

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -217,6 +217,27 @@ class TestTransportWarning:
         assert "secret" not in caplog.text
         assert "wss://***@example.com:8443/local" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_disconnect_log_redacts_userinfo(self, caplog):
+        url = "wss://user:secret@example.com:8443/local"
+        node = _make_node(url)
+
+        async def stop_on_sleep(_delay):
+            node.stop()
+
+        with (
+            patch(
+                "gptme_voice_node.node.websockets.connect",
+                side_effect=OSError(f"failed to connect to {url}"),
+            ),
+            patch("gptme_voice_node.node.asyncio.sleep", side_effect=stop_on_sleep),
+        ):
+            await node.run_forever()
+
+        assert "secret" not in caplog.text
+        assert "user:secret" not in caplog.text
+        assert "wss://***@example.com:8443/local" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Stop / cleanup
@@ -267,6 +288,36 @@ class TestLifecycle:
         mic.close.assert_called_once()
         speaker.close.assert_called_once()
         stream.stop_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_session_cancels_sibling_when_one_loop_fails(self):
+        node = _make_node()
+        mic = MagicMock()
+        speaker = MagicMock()
+        node._pa.open.side_effect = [mic, speaker]
+        recv_started = asyncio.Event()
+        recv_cancelled = asyncio.Event()
+
+        async def send_loop(*_args):
+            await recv_started.wait()
+            raise OSError("mic dead")
+
+        async def recv_loop(*_args):
+            recv_started.set()
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                recv_cancelled.set()
+                raise
+
+        with (
+            patch.object(node, "_send_loop", send_loop),
+            patch.object(node, "_recv_loop", recv_loop),
+        ):
+            with pytest.raises(OSError, match="mic dead"):
+                await asyncio.wait_for(node._session(AsyncMock()), timeout=1)
+
+        assert recv_cancelled.is_set()
 
     @pytest.mark.asyncio
     async def test_session_attempts_both_closes_when_one_close_fails(self, caplog):

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -197,6 +197,26 @@ class TestTransportWarning:
 
         assert not caplog.text
 
+    @pytest.mark.asyncio
+    async def test_session_connect_log_redacts_userinfo(self, caplog):
+        caplog.set_level("INFO")
+        node = _make_node("wss://user:secret@example.com:8443/local")
+        mic = MagicMock()
+        speaker = MagicMock()
+        node._pa.open.side_effect = [mic, speaker]
+
+        async def stop_session(*_args):
+            node.stop()
+
+        with (
+            patch.object(node, "_send_loop", AsyncMock(side_effect=stop_session)),
+            patch.object(node, "_recv_loop", AsyncMock(side_effect=stop_session)),
+        ):
+            await node._session(AsyncMock())
+
+        assert "secret" not in caplog.text
+        assert "wss://***@example.com:8443/local" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Stop / cleanup

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -15,9 +15,11 @@ import pytest
 
 def _make_node(server_url="ws://localhost:9999/local", node_name="test-node"):
     """Create a VoiceNode with pyaudio mocked out."""
-    with patch("gptme_voice_node.node.pyaudio") as mock_pa_module:
+    with patch("gptme_voice_node.node._get_pyaudio") as mock_get_pa:
+        mock_pa_module = MagicMock()
         mock_pa_module.paInt16 = 8  # arbitrary constant
         mock_pa_module.PyAudio.return_value = MagicMock()
+        mock_get_pa.return_value = mock_pa_module
         from gptme_voice_node.node import VoiceNode
 
         node = VoiceNode(server_url, node_name)
@@ -121,10 +123,12 @@ class TestLifecycle:
         assert node._running is False
 
     def test_cleanup_terminates_pyaudio(self):
-        with patch("gptme_voice_node.node.pyaudio") as mock_pa_module:
+        with patch("gptme_voice_node.node._get_pyaudio") as mock_get_pa:
+            mock_pa_module = MagicMock()
             mock_pa_module.paInt16 = 8
             mock_pa = MagicMock()
             mock_pa_module.PyAudio.return_value = mock_pa
+            mock_get_pa.return_value = mock_pa_module
             from gptme_voice_node.node import VoiceNode
 
             node = VoiceNode("ws://x", "test")

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -56,8 +56,35 @@ class TestMicMute:
 
 
 # ---------------------------------------------------------------------------
-# Recv loop: audio frame handling
+# Send/recv loop handling
 # ---------------------------------------------------------------------------
+
+
+class TestSendLoop:
+    @pytest.mark.asyncio
+    async def test_audio_io_cancellation_waits_for_inflight_thread(self):
+        from gptme_voice_node.node import _run_audio_io
+
+        thread_started = asyncio.Event()
+        allow_thread_to_finish = asyncio.Event()
+
+        async def fake_to_thread(function, *args, **kwargs):
+            thread_started.set()
+            await allow_thread_to_finish.wait()
+            return function(*args, **kwargs)
+
+        operation = MagicMock(return_value=b"audio")
+        with patch("gptme_voice_node.node.asyncio.to_thread", fake_to_thread):
+            task = asyncio.create_task(_run_audio_io(operation))
+            await thread_started.wait()
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+            allow_thread_to_finish.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        operation.assert_called_once_with()
 
 
 class TestRecvLoop:
@@ -74,25 +101,15 @@ class TestRecvLoop:
         mock_ws.recv.side_effect = [msg, ConnectionClosed(None, None)]
 
         speaker = MagicMock()
-        # We expect write to be called with the PCM bytes
-        written = []
 
-        def fake_run_in_executor(_, fn):
-            result = fn()
-            written.append(result)
-            fut = asyncio.get_event_loop().create_future()
-            fut.set_result(None)
-            return fut
+        async def fake_audio_io(function, *args, **kwargs):
+            return function(*args, **kwargs)
 
-        with patch.object(
-            asyncio.get_event_loop(),
-            "run_in_executor",
-            side_effect=fake_run_in_executor,
-        ):
+        with patch("gptme_voice_node.node._run_audio_io", fake_audio_io):
             await node._recv_loop(mock_ws, speaker)
 
         assert node._playing is True  # set mid-loop; audio_end not sent
-        assert speaker.write.called
+        speaker.write.assert_called_once_with(pcm)
 
     @pytest.mark.asyncio
     async def test_audio_end_clears_playing_flag(self):
@@ -198,14 +215,14 @@ class TestBackoff:
             await node.run_forever()
             mock_ws.connect.assert_not_called()
 
-    def test_quick_session_failure_preserves_exponential_backoff(self):
-        from gptme_voice_node.node import _backoff_after_session
+    def test_quick_session_failure_increases_exponential_backoff(self):
+        from gptme_voice_node.node import _next_backoff
 
         with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
-            assert _backoff_after_session(8, connected_at=99.0) == 8
+            assert _next_backoff(8, connected_at=99.0) == 16
 
     def test_stable_session_resets_exponential_backoff(self):
-        from gptme_voice_node.node import BACKOFF_INITIAL, _backoff_after_session
+        from gptme_voice_node.node import BACKOFF_INITIAL, _next_backoff
 
         with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
-            assert _backoff_after_session(8, connected_at=60.0) == BACKOFF_INITIAL
+            assert _next_backoff(8, connected_at=60.0) == BACKOFF_INITIAL

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -7,6 +7,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from websockets.exceptions import ConnectionClosed
 
 # ---------------------------------------------------------------------------
 # Helpers to avoid pyaudio import in test collection
@@ -69,7 +70,8 @@ class TestRecvLoop:
         msg = json.dumps({"type": "audio", "audio": base64.b64encode(pcm).decode()})
 
         mock_ws = AsyncMock()
-        mock_ws.__aiter__.return_value = iter([msg])
+        # Return the audio frame then ConnectionClosed to exit the recv loop.
+        mock_ws.recv.side_effect = [msg, ConnectionClosed(None, None)]
 
         speaker = MagicMock()
         # We expect write to be called with the PCM bytes
@@ -97,11 +99,12 @@ class TestRecvLoop:
         node = _make_node()
         node._playing = True
 
-        msgs = [
-            json.dumps({"type": "audio_end"}),
-        ]
         mock_ws = AsyncMock()
-        mock_ws.__aiter__.return_value = iter(msgs)
+        # Return audio_end then ConnectionClosed to exit the recv loop.
+        mock_ws.recv.side_effect = [
+            json.dumps({"type": "audio_end"}),
+            ConnectionClosed(None, None),
+        ]
         speaker = MagicMock()
 
         await node._recv_loop(mock_ws, speaker)

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -54,6 +55,11 @@ class TestMicMute:
         node._play_ended_at = time.monotonic() - 10  # 10 seconds ago
         assert not node._mic_muted()
 
+    def test_not_muted_at_early_monotonic_time(self):
+        node = _make_node()
+        with patch("gptme_voice_node.node.time.monotonic", return_value=0.1):
+            assert not node._mic_muted()
+
 
 # ---------------------------------------------------------------------------
 # Send/recv loop handling
@@ -65,23 +71,22 @@ class TestSendLoop:
     async def test_audio_io_cancellation_does_not_wait_for_inflight_thread(self):
         from gptme_voice_node.node import _run_audio_io
 
-        thread_started = asyncio.Event()
-        never_finishes = asyncio.Event()
+        thread_started = threading.Event()
+        allow_thread_to_finish = threading.Event()
 
-        async def fake_to_thread(function, *args, **kwargs):
+        def operation():
             thread_started.set()
-            await never_finishes.wait()
-            return function(*args, **kwargs)
+            allow_thread_to_finish.wait(timeout=1)
+            return b"audio"
 
-        operation = MagicMock(return_value=b"audio")
-        with patch("gptme_voice_node.node.asyncio.to_thread", fake_to_thread):
-            task = asyncio.create_task(_run_audio_io(operation))
-            await thread_started.wait()
+        task = asyncio.create_task(_run_audio_io(operation))
+        try:
+            assert await asyncio.to_thread(thread_started.wait, 1)
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await asyncio.wait_for(task, timeout=0.1)
-
-        operation.assert_not_called()
+        finally:
+            allow_thread_to_finish.set()
 
 
 class TestRecvLoop:
@@ -169,6 +174,15 @@ class TestRecvLoop:
 
 
 class TestTransportWarning:
+    def test_url_userinfo_is_redacted(self):
+        from gptme_voice_node.node import _redact_url_userinfo
+
+        redacted = _redact_url_userinfo("wss://user:secret@example.com:8443/local")
+
+        assert redacted == "wss://***@example.com:8443/local"
+        assert "user" not in redacted
+        assert "secret" not in redacted
+
     def test_warns_for_insecure_remote_url(self, caplog):
         from gptme_voice_node.node import _warn_for_insecure_remote_url
 
@@ -234,6 +248,21 @@ class TestLifecycle:
         speaker.close.assert_called_once()
         stream.stop_stream.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_session_attempts_both_closes_when_one_close_fails(self, caplog):
+        node = _make_node()
+        mic = MagicMock()
+        speaker = MagicMock()
+        node._pa.open.side_effect = [mic, speaker]
+        speaker.close.side_effect = OSError("device gone")
+        node.stop()
+
+        await node._session(AsyncMock())
+
+        mic.close.assert_called_once()
+        speaker.close.assert_called_once()
+        assert "failed to close audio stream" in caplog.text
+
     def test_cleanup_terminates_pyaudio(self):
         with patch("gptme_voice_node.node._get_pyaudio") as mock_get_pa:
             mock_pa_module = MagicMock()
@@ -276,6 +305,25 @@ class TestBackoff:
 
         with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
             assert _next_backoff(8, connected_at=60.0) == BACKOFF_INITIAL
+
+    @pytest.mark.asyncio
+    async def test_retry_log_matches_sleep_delay(self, caplog):
+        node = _make_node()
+
+        async def stop_on_sleep(delay):
+            assert delay == 2
+            node.stop()
+
+        with (
+            patch(
+                "gptme_voice_node.node.websockets.connect",
+                side_effect=OSError("offline"),
+            ),
+            patch("gptme_voice_node.node.asyncio.sleep", side_effect=stop_on_sleep),
+        ):
+            await node.run_forever()
+
+        assert "retrying in 2s" in caplog.text
 
     @pytest.mark.asyncio
     async def test_stable_session_uses_reset_delay_for_immediate_retry(self):

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ members = [
     "gptme-usage",
     "gptme-user-memories",
     "gptme-voice",
+    "gptme-voice-node",
     "gptme-warpgrep",
     "gptme-whatsapp",
     "gptme-wisdom",
@@ -2597,6 +2598,30 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["test", "local"]
+
+[[package]]
+name = "gptme-voice-node"
+version = "0.1.0"
+source = { editable = "packages/gptme-voice-node" }
+dependencies = [
+    { name = "pyaudio" },
+    { name = "websockets" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyaudio", specifier = ">=0.2.13" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
+    { name = "websockets", specifier = ">=12.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "gptme-warpgrep"

--- a/uv.lock
+++ b/uv.lock
@@ -2604,11 +2604,13 @@ name = "gptme-voice-node"
 version = "0.1.0"
 source = { editable = "packages/gptme-voice-node" }
 dependencies = [
-    { name = "pyaudio" },
     { name = "websockets" },
 ]
 
 [package.optional-dependencies]
+audio = [
+    { name = "pyaudio" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2616,12 +2618,12 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pyaudio", specifier = ">=0.2.13" },
+    { name = "pyaudio", marker = "extra == 'audio'", specifier = ">=0.2.13" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["test"]
+provides-extras = ["audio", "test"]
 
 [[package]]
 name = "gptme-warpgrep"


### PR DESCRIPTION
## Summary

Implements milestone 1 of the BobBrain portable presence node ([ErikBjare/bob#730](https://github.com/ErikBjare/bob/issues/730)).

A thin (~200 LOC) WebSocket client that connects to `bob-voice-server`, streams mic audio, and plays back PCM audio — designed for unattended embedded operation on a Raspberry Pi with a USB microphone array (e.g. ReSpeaker XVF3800).

## Design choices

- **Env-var config only** (`GPTME_VOICE_NODE_SERVER`, `GPTME_VOICE_NODE_NAME`) — systemd-friendly, no CLI argument parsing needed for embedded use
- **Exponential backoff reconnect** (1s → 60s max) — survives network blips and server restarts autonomously
- **Mic muted during playback + configurable cooldown** — echo/feedback prevention on nodes without hardware AEC; hardware AEC (ReSpeaker XVF3800) handles it at the chip level but the software fallback is free
- **PyAudio streams open/close per-session** — clean OS-level release on disconnect; important on embedded Linux where ALSA device handles are scarce
- **Blocking audio I/O in executor** — keeps the event loop responsive during `asyncio.gather` of send+recv tasks

## Files

```
packages/gptme-voice-node/
├── pyproject.toml          # dependencies: pyaudio, websockets
├── README.md               # quick-start + Pi deployment guide
├── src/gptme_voice_node/
│   ├── __init__.py
│   └── node.py             # VoiceNode + main() entry point
├── systemd/
│   └── gptme-voice-node.service   # drop-in override pattern
└── tests/
    └── test_voice_node.py  # 9 tests, no hardware required
```

## Testing

9 unit tests, all green:
- Mic mute logic (4 tests)
- Recv loop audio frame handling (2 tests)
- Lifecycle: stop/cleanup (2 tests)
- Backoff: run_forever exits when stopped (1 test)

```
uv run --extra test pytest packages/gptme-voice-node/tests/ -v
# 9 passed in 0.07s
```

## Related

- Spec: [`bobbrain-spec.md`](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/bobbrain-spec.md)
- Spec: [`bobbody-voice-node-spec.md`](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/bobbody-voice-node-spec.md)
- Reference client: `packages/gptme-voice/src/gptme_voice/realtime/client.py`