### PR TITLE
fix(gptme-voice): await in-flight pre-warm on claim + caller-aware external-caller instructions

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -56,6 +56,12 @@ logger = logging.getLogger(__name__)
 class CallerIdentity:
     canonical_name: str
     preferred_spoken_name: str
+    # True when the caller's people file marks them as the operator
+    # (`- Call role: operator`).  Operators get internal context (activity
+    # digest, ops status); everyone else is treated as an external guest.
+    is_operator: bool = False
+    # Preferred spoken language from `- Call language: <lang>`, if present.
+    call_language: str | None = None
 
 
 _DEFAULT_RESUME_WINDOW_SECONDS = 300
@@ -169,13 +175,29 @@ class SessionBootstrap:
     initial_response_instructions: str = ""
 
 
-def _extract_preferred_spoken_name(text: str, canonical_name: str) -> str:
+def _extract_people_field(text: str, field: str) -> str | None:
+    """Extract a `- <field>: value` line from a people file (case-insensitive).
+
+    Handles markdown-bolded property names/values too, e.g.
+    `- **Call name**: Erik` or `- Call name: **Erik**`.
+    """
+    pattern = re.compile(
+        rf"^-\s*\*{{0,2}}{re.escape(field)}\*{{0,2}}\s*:\s*(.+)$",
+        re.IGNORECASE,
+    )
     for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.lower().startswith("- call name:"):
-            value = stripped.split(":", 1)[1].strip()
+        m = pattern.match(line.strip())
+        if m:
+            value = m.group(1).strip().strip("*").strip()
             if value:
                 return value
+    return None
+
+
+def _extract_preferred_spoken_name(text: str, canonical_name: str) -> str:
+    value = _extract_people_field(text, "call name")
+    if value:
+        return value
     parts = canonical_name.split()
     return parts[0] if parts else canonical_name
 
@@ -204,9 +226,12 @@ def _lookup_caller_identity(
                         preferred_spoken_name = _extract_preferred_spoken_name(
                             text, canonical_name
                         )
+                        call_role = _extract_people_field(text, "call role")
                         return CallerIdentity(
                             canonical_name=canonical_name,
                             preferred_spoken_name=preferred_spoken_name,
+                            is_operator=(call_role or "").lower() == "operator",
+                            call_language=_extract_people_field(text, "call language"),
                         )
                 except Exception:
                     pass
@@ -239,13 +264,44 @@ def _build_caller_instructions(
             f"You know this person — refer to them by name."
             f"{name_hint}"
         )
+        if not caller_identity.is_operator:
+            caller_ctx += "\n\n" + _external_caller_guidance(caller_identity)
     else:
         caller_ctx = (
             f"The current caller's phone number is {from_number}. "
-            f"You do not recognise this number; treat the caller as an unknown guest."
+            f"You do not recognise this number; treat the caller as an unknown guest. "
+            + _external_caller_guidance(None)
         )
 
     return f"{caller_ctx}\n\n{base_instructions}"
+
+
+def _external_caller_guidance(caller_identity: CallerIdentity | None) -> str:
+    """Conversation guidance for callers who are not the operator.
+
+    External callers should get a friendly host, not an ops report: no
+    unprompted tool calls, no internal status (subagent state, task queues,
+    work summaries), and speech in their language.
+    """
+    if caller_identity and caller_identity.call_language:
+        language_line = (
+            f"Speak {caller_identity.call_language} with this caller "
+            "unless they switch language themselves."
+        )
+    else:
+        language_line = (
+            "Mirror the caller's language: if they speak another language "
+            "than English, answer in that language."
+        )
+    return (
+        "EXTERNAL CALLER GUIDANCE:\n"
+        "- This caller is NOT the operator. Do not volunteer internal "
+        "operational status (subagent status, task queues, PR/CI state, or "
+        "work summaries), and do not call tools unprompted.\n"
+        "- Be a friendly, concise host: answer their questions, and only use "
+        "tools when their request genuinely needs one.\n"
+        f"- {language_line}"
+    )
 
 
 def _build_fresh_call_greeting_instructions(
@@ -269,9 +325,15 @@ def _build_fresh_call_greeting_instructions(
                 f"not their full name, in one short sentence, for example 'Hi {spoken_name}' "
                 f"or 'Hey {spoken_name}, what's up?'. "
             )
+        language_hint = (
+            f"Greet in {caller_identity.call_language}. "
+            if caller_identity.call_language
+            else ""
+        )
         return (
             self_identity
             + greeting_target
+            + language_hint
             + "Do NOT say 'thanks for calling' or use other stock phone greetings. "
             "Then stop and wait for them to speak."
         )
@@ -749,6 +811,11 @@ class VoiceServer:
         # Pre-warmed realtime connections: from_number -> (client, created_at)
         # Keyed by from_number, claimed and discarded when the Twilio stream starts.
         self._prewarm_sessions: dict[str, tuple[OpenAIRealtimeClient, float]] = {}
+        # In-flight pre-warm tasks by from_number, so _claim_prewarm can await
+        # a pre-warm that hasn't finished connecting yet instead of racing it
+        # into a duplicate cold session (observed 2026-08-27: Twilio's "start"
+        # arrived before "Pre-warm ready", leaving an orphaned provider session).
+        self._prewarm_tasks: dict[str, asyncio.Task] = {}
         # Max seconds a pre-warm session is kept before being discarded
         self._prewarm_ttl_seconds = 30
 
@@ -1060,7 +1127,19 @@ class VoiceServer:
         # do today?" question is answered from the digest rather than a live
         # subagent lookup (which timed out on 2026-07-28).  Only loaded when the
         # digest is fresh (< _VOICE_DIGEST_MAX_AGE_SECONDS).
-        activity_digest = _load_voice_digest(self.workspace)
+        #
+        # Operator-only: external callers (no `- Call role: operator` in their
+        # people file, or unknown numbers) must not get internal work status —
+        # the digest both leaks internals and steers the model into ops-speak
+        # (Philip's first call was greeted with subagent status, 2026-08-27).
+        # Calls with no from_number (local/browser transport) keep the digest.
+        caller_is_operator = True
+        if from_number:
+            identity = _lookup_caller_identity(from_number, self.workspace)
+            caller_is_operator = bool(identity and identity.is_operator)
+        activity_digest = (
+            _load_voice_digest(self.workspace) if caller_is_operator else None
+        )
         if activity_digest and not standup_brief:
             instructions = _prepend_activity_digest(activity_digest, instructions)
 
@@ -1125,6 +1204,7 @@ class VoiceServer:
         call-side WebSocket is ready; activate_session() releases it.
         """
         self._evict_stale_prewarms()
+        client: OpenAIRealtimeClient | None = None
         try:
             # Peek at the resume record (consume_recent=False) so the on-disk
             # state file is NOT deleted until connect() succeeds.  If connect()
@@ -1149,13 +1229,65 @@ class VoiceServer:
             # cold-path fallback won't re-inject the same transcript.
             await self._consume_recent_call(from_number)
             self._prewarm_sessions[from_number] = (client, time.monotonic())
+            # Guarantee eviction even if no further call ever arrives
+            # (_evict_stale_prewarms otherwise only runs on the next inbound).
+            asyncio.get_running_loop().call_later(
+                self._prewarm_ttl_seconds + 1, self._evict_stale_prewarms
+            )
             logger.info("Pre-warm ready for %s", from_number)
+        except asyncio.CancelledError:
+            # Claim timed out and cancelled us (or the server is shutting
+            # down): close the half-open provider session instead of leaking it.
+            logger.info("Pre-warm cancelled for %s", from_number)
+            if client is not None:
+                asyncio.create_task(self._disconnect_realtime_client(client))
+            raise
         except Exception as exc:
             logger.warning("Pre-warm failed for %s: %s", from_number, exc)
 
-    def _claim_prewarm(self, from_number: str) -> OpenAIRealtimeClient | None:
-        """Claim and remove a pre-warmed session for from_number if still fresh."""
+    def _register_prewarm_task(self, from_number: str) -> None:
+        """Start a pre-warm task for from_number and track it for claiming."""
+        task = asyncio.create_task(self._prewarm_for_inbound(from_number))
+        self._prewarm_tasks[from_number] = task
+
+        def _cleanup(done: asyncio.Task, num: str = from_number) -> None:
+            if self._prewarm_tasks.get(num) is done:
+                self._prewarm_tasks.pop(num, None)
+
+        task.add_done_callback(_cleanup)
+
+    async def _claim_prewarm(
+        self, from_number: str, *, wait_seconds: float = 2.0
+    ) -> OpenAIRealtimeClient | None:
+        """Claim and remove a pre-warmed session for from_number if still fresh.
+
+        If the pre-warm is still connecting, wait up to *wait_seconds* for it —
+        a near-ready pre-warm beats starting a cold session from scratch, and
+        racing past it would leave an orphaned provider session (the doubled
+        "Session created" observed on 2026-08-27).  On timeout the in-flight
+        task is cancelled so the cold path doesn't end up with a twin.
+        """
         entry = self._prewarm_sessions.pop(from_number, None)
+        if entry is None:
+            task = self._prewarm_tasks.get(from_number)
+            if task is not None and not task.done():
+                logger.info(
+                    "Pre-warm for %s still connecting — waiting up to %.1fs",
+                    from_number,
+                    wait_seconds,
+                )
+                try:
+                    await asyncio.wait_for(asyncio.shield(task), wait_seconds)
+                except asyncio.TimeoutError:
+                    logger.info(
+                        "Pre-warm for %s not ready in time — cancelling, using cold path",
+                        from_number,
+                    )
+                    task.cancel()
+                    return None
+                except Exception:
+                    pass  # failure already logged by _prewarm_for_inbound
+                entry = self._prewarm_sessions.pop(from_number, None)
         if entry is None:
             return None
         client, created_at = entry
@@ -1618,7 +1750,7 @@ class VoiceServer:
         # Twilio's media-stream WebSocket sends its "start" event.  This eliminates
         # most of the ~1-3s dead air between call answer and first greeting audio.
         if from_number:
-            asyncio.create_task(self._prewarm_for_inbound(from_number))
+            self._register_prewarm_task(from_number)
 
         # Forward caller number to WebSocket handler via TwiML custom parameters.
         custom_params: dict[str, str] = {}
@@ -1725,7 +1857,9 @@ class VoiceServer:
                         from_number and not handoff_id and not standup_brief
                     )
                     prewarm_client = (
-                        self._claim_prewarm(from_number) if prewarm_eligible else None
+                        await self._claim_prewarm(from_number)
+                        if prewarm_eligible
+                        else None
                     )
 
                     if prewarm_client is not None:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -816,6 +816,10 @@ class VoiceServer:
         # into a duplicate cold session (observed 2026-08-27: Twilio's "start"
         # arrived before "Pre-warm ready", leaving an orphaned provider session).
         self._prewarm_tasks: dict[str, asyncio.Task] = {}
+        # Numbers whose pre-warm has connected and is finalizing (consuming
+        # resume state). Cancelling in this phase could lose resume context,
+        # so _claim_prewarm briefly extends its wait instead.
+        self._prewarm_connected: set[str] = set()
         # Max seconds a pre-warm session is kept before being discarded
         self._prewarm_ttl_seconds = 30
 
@@ -1225,6 +1229,11 @@ class VoiceServer:
             )
             client = self._make_client(session_cfg, hold_initial_response=True)
             await client.connect()
+            # Mark the post-connect phase: from here on the task will consume
+            # the caller's resume state, so _claim_prewarm must not cancel it
+            # (cancellation mid-consume could delete the resume file without a
+            # session to show for it — losing the caller's resume context).
+            self._prewarm_connected.add(from_number)
             # connect() succeeded — now safely consume the resume state so a
             # cold-path fallback won't re-inject the same transcript.
             await self._consume_recent_call(from_number)
@@ -1249,6 +1258,8 @@ class VoiceServer:
             # one connection per failed pre-warm attempt.
             if client is not None:
                 asyncio.create_task(self._disconnect_realtime_client(client))
+        finally:
+            self._prewarm_connected.discard(from_number)
 
     def _register_prewarm_task(self, from_number: str) -> None:
         """Start a pre-warm task for from_number and track it for claiming."""
@@ -1284,16 +1295,46 @@ class VoiceServer:
                 try:
                     await asyncio.wait_for(asyncio.shield(task), wait_seconds)
                 except asyncio.TimeoutError:
+                    # The task may have completed (storing its session) between
+                    # the timeout firing and now — never discard that: the
+                    # completed pre-warm holds the caller's (already consumed)
+                    # resume context, so dropping it would greet fresh instead
+                    # of resuming. Claim it.
+                    entry = self._prewarm_sessions.pop(from_number, None)
+                    if entry is not None:
+                        logger.info(
+                            "Pre-warm for %s completed at the timeout boundary — claiming it",
+                            from_number,
+                        )
+                        return entry[0]
+                    if from_number in self._prewarm_connected:
+                        # Connected and finalizing (consuming resume state —
+                        # local file I/O, fast). Cancelling now could delete
+                        # the resume file with no session to show for it, so
+                        # extend the wait briefly instead.
+                        logger.info(
+                            "Pre-warm for %s is finalizing — extending wait",
+                            from_number,
+                        )
+                        try:
+                            await asyncio.wait_for(asyncio.shield(task), 1.0)
+                        except (asyncio.TimeoutError, Exception):
+                            pass
+                        entry = self._prewarm_sessions.pop(from_number, None)
+                        if entry is not None:
+                            logger.info(
+                                "Claimed pre-warm for %s after finalize wait",
+                                from_number,
+                            )
+                            return entry[0]
                     logger.info(
                         "Pre-warm for %s not ready in time — cancelling, using cold path",
                         from_number,
                     )
+                    # Pre-connect cancellation is safe: the peek design means
+                    # the resume state has not been consumed yet.
                     task.cancel()
-                    # The task may have completed (storing its session) between
-                    # the timeout firing and this cancel — cancel() is then a
-                    # no-op on the done task and its CancelledError handler
-                    # never runs. Reap any stored entry synchronously so it
-                    # can't linger and be claimed while we build a cold twin.
+                    # Defensive: reap anything stored despite the paths above.
                     self._reap_prewarm_entry(from_number)
                     return None
                 except Exception:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1273,7 +1273,11 @@ class VoiceServer:
         task.add_done_callback(_cleanup)
 
     async def _claim_prewarm(
-        self, from_number: str, *, wait_seconds: float = 2.0
+        self,
+        from_number: str,
+        *,
+        wait_seconds: float = 2.0,
+        finalize_wait_seconds: float = 5.0,
     ) -> OpenAIRealtimeClient | None:
         """Claim and remove a pre-warmed session for from_number if still fresh.
 
@@ -1309,17 +1313,32 @@ class VoiceServer:
                         return entry[0]
                     if from_number in self._prewarm_connected:
                         # Connected and finalizing (consuming resume state —
-                        # local file I/O, fast). Cancelling now could delete
-                        # the resume file with no session to show for it, so
-                        # extend the wait briefly instead.
+                        # local file I/O, fast in practice). A post-connect
+                        # task is NEVER cancelled: cancellation could
+                        # interrupt _consume_recent_call after the resume
+                        # file's unlink but before the session is stored,
+                        # destroying the caller's resume context. Extend the
+                        # wait instead; if it still isn't done, fall back
+                        # cold WITHOUT cancelling — the finished session is
+                        # disconnected by TTL eviction.
                         logger.info(
                             "Pre-warm for %s is finalizing — extending wait",
                             from_number,
                         )
                         try:
-                            await asyncio.wait_for(asyncio.shield(task), 1.0)
-                        except (asyncio.TimeoutError, Exception):
-                            pass
+                            await asyncio.wait_for(
+                                asyncio.shield(task), finalize_wait_seconds
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "Pre-warm for %s still finalizing after "
+                                "%.1fs — using cold path without cancelling",
+                                from_number,
+                                finalize_wait_seconds,
+                            )
+                            return None
+                        except Exception:
+                            pass  # failure already logged by the task
                         entry = self._prewarm_sessions.pop(from_number, None)
                         if entry is not None:
                             logger.info(
@@ -1327,6 +1346,7 @@ class VoiceServer:
                                 from_number,
                             )
                             return entry[0]
+                        return None  # finalize failed — cold path
                     logger.info(
                         "Pre-warm for %s not ready in time — cancelling, using cold path",
                         from_number,

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1244,6 +1244,11 @@ class VoiceServer:
             raise
         except Exception as exc:
             logger.warning("Pre-warm failed for %s: %s", from_number, exc)
+            # connect() (or _consume_recent_call) failed after the client was
+            # created: close the half-open provider session instead of leaking
+            # one connection per failed pre-warm attempt.
+            if client is not None:
+                asyncio.create_task(self._disconnect_realtime_client(client))
 
     def _register_prewarm_task(self, from_number: str) -> None:
         """Start a pre-warm task for from_number and track it for claiming."""

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1289,6 +1289,12 @@ class VoiceServer:
                         from_number,
                     )
                     task.cancel()
+                    # The task may have completed (storing its session) between
+                    # the timeout firing and this cancel — cancel() is then a
+                    # no-op on the done task and its CancelledError handler
+                    # never runs. Reap any stored entry synchronously so it
+                    # can't linger and be claimed while we build a cold twin.
+                    self._reap_prewarm_entry(from_number)
                     return None
                 except Exception:
                     pass  # failure already logged by _prewarm_for_inbound
@@ -1305,6 +1311,13 @@ class VoiceServer:
             return None
         logger.info("Claimed pre-warm for %s (%.1fs old)", from_number, age)
         return client
+
+    def _reap_prewarm_entry(self, from_number: str) -> None:
+        """Remove and disconnect a stored pre-warm session, if one exists."""
+        entry = self._prewarm_sessions.pop(from_number, None)
+        if entry is not None:
+            client, _ = entry
+            asyncio.create_task(self._disconnect_realtime_client(client))
 
     async def _build_session_instructions(
         self,

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2149,3 +2149,36 @@ def test_register_prewarm_task_cleans_up_after_completion() -> None:
         assert "+46700000002" not in server._prewarm_tasks
 
     asyncio.run(_exercise())
+
+
+def test_prewarm_connect_failure_disconnects_half_open_client() -> None:
+    """AI-review P1: a connect() failure must disconnect the created client,
+    not leak one provider connection per failed pre-warm attempt."""
+
+    async def _exercise() -> None:
+        server = VoiceServer()
+
+        class _FailingClient:
+            async def connect(self):
+                raise ConnectionError("simulated provider failure")
+
+        failing_client = _FailingClient()
+        disconnected: list[object] = []
+
+        async def _record_disconnect(client) -> None:
+            disconnected.append(client)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                server,
+                "_make_client",
+                lambda *args, **kwargs: failing_client,  # type: ignore[assignment]
+            )
+            mp.setattr(server, "_disconnect_realtime_client", _record_disconnect)
+            await server._prewarm_for_inbound("+46700000099")
+            # disconnect is scheduled as a task; let it run
+            await asyncio.sleep(0)
+
+        assert disconnected == [failing_client]
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2184,11 +2184,11 @@ def test_prewarm_connect_failure_disconnects_half_open_client() -> None:
     asyncio.run(_exercise())
 
 
-def test_claim_prewarm_timeout_reaps_entry_stored_by_completed_task() -> None:
-    """AI-review P1 (round 2): if the pre-warm task completes and stores its
-    session between the claim timeout and task.cancel(), the cancel is a no-op
-    and nothing disconnects the stored session. The timeout branch must reap it
-    so it can't be claimed while a cold twin is being built."""
+def test_claim_prewarm_timeout_claims_entry_stored_by_completed_task() -> None:
+    """AI-review P1s (rounds 2+3): if the pre-warm task completes — storing
+    its session — in the gap between the claim timeout and cancellation, the
+    completed session must be CLAIMED, not discarded: it holds the caller's
+    already-consumed resume context, so dropping it would lose the resume."""
 
     async def _exercise() -> None:
         server = VoiceServer()
@@ -2200,35 +2200,57 @@ def test_claim_prewarm_timeout_reaps_entry_stored_by_completed_task() -> None:
 
         server._disconnect_realtime_client = _record_disconnect  # type: ignore[method-assign]
 
-        async def _slow_then_store() -> None:
-            # Simulates the race: still pending when wait_for times out, but
-            # the entry is present by the time the timeout branch runs.
+        async def _never_finishes() -> None:
             await asyncio.Event().wait()
 
-        task = asyncio.create_task(_slow_then_store())
+        task = asyncio.create_task(_never_finishes())
         server._prewarm_tasks["+46700000002"] = task
         await asyncio.sleep(0)
-        # Entry appears after the first pop (claim's initial pop sees nothing,
-        # the wait times out, and the store lands before cancel is processed).
-        original_cancel = task.cancel
-
-        def _store_then_cancel() -> bool:
-            server._prewarm_sessions["+46700000002"] = (
-                fake_client,
-                time.monotonic(),
-            )
-            return original_cancel()
-
-        task.cancel = _store_then_cancel  # type: ignore[method-assign]
+        # Simulate the boundary: the entry lands after wait_for times out but
+        # before the timeout branch inspects state.
+        server._prewarm_sessions["+46700000002"] = (fake_client, time.monotonic())
 
         claimed = await server._claim_prewarm("+46700000002", wait_seconds=0.05)
-        await asyncio.sleep(0)  # let the disconnect task run
+        await asyncio.sleep(0)
 
-        assert claimed is None
+        assert claimed is fake_client
         assert "+46700000002" not in server._prewarm_sessions
-        assert disconnected == [fake_client]
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        assert disconnected == []
+        task.cancel()  # test cleanup
+
+    asyncio.run(_exercise())
+
+
+def test_claim_prewarm_timeout_waits_out_finalizing_task() -> None:
+    """AI-review P1 (round 3): a pre-warm that connected and is consuming the
+    resume state must not be cancelled on claim timeout — the claim extends
+    its wait and picks up the session when finalization lands."""
+
+    async def _exercise() -> None:
+        server = VoiceServer()
+        fake_client = _FakeRealtimeClient()
+        finalize = asyncio.Event()
+
+        async def _finalizing_prewarm() -> None:
+            server._prewarm_connected.add("+46700000002")
+            try:
+                await finalize.wait()
+                server._prewarm_sessions["+46700000002"] = (
+                    fake_client,
+                    time.monotonic(),
+                )
+            finally:
+                server._prewarm_connected.discard("+46700000002")
+
+        task = asyncio.create_task(_finalizing_prewarm())
+        server._prewarm_tasks["+46700000002"] = task
+        await asyncio.sleep(0)
+        asyncio.get_running_loop().call_later(0.1, finalize.set)
+
+        claimed = await server._claim_prewarm("+46700000002", wait_seconds=0.05)
+
+        assert claimed is fake_client
+        assert not task.cancelled()
 
     asyncio.run(_exercise())
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2275,3 +2275,37 @@ def test_reap_prewarm_entry_disconnects_and_removes() -> None:
         server._reap_prewarm_entry("+1")  # absent entry is a no-op
 
     asyncio.run(_exercise())
+
+
+def test_claim_prewarm_never_cancels_finalizing_task_on_expiry() -> None:
+    """AI-review P1 (round 4): when even the extended finalize wait expires,
+    the claim must fall back cold WITHOUT cancelling the post-connect task —
+    cancellation mid-_consume_recent_call can delete the resume file before
+    the session is stored, destroying the caller's resume context."""
+
+    async def _exercise() -> None:
+        server = VoiceServer()
+        never = asyncio.Event()
+
+        async def _stuck_finalizing() -> None:
+            server._prewarm_connected.add("+46700000002")
+            try:
+                await never.wait()
+            finally:
+                server._prewarm_connected.discard("+46700000002")
+
+        task = asyncio.create_task(_stuck_finalizing())
+        server._prewarm_tasks["+46700000002"] = task
+        await asyncio.sleep(0)
+
+        claimed = await server._claim_prewarm(
+            "+46700000002", wait_seconds=0.05, finalize_wait_seconds=0.05
+        )
+
+        assert claimed is None
+        assert not task.cancelled()
+        assert not task.done(), "post-connect task must be left running"
+        never.set()  # test cleanup
+        await task
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -23,6 +23,7 @@ from gptme_voice.realtime.server import (
     _build_fresh_call_greeting_instructions,
     _build_resume_instructions,
     _build_runtime_identity_instructions,
+    _extract_people_field,
     _get_twilio_field,
     _load_voice_digest,
     _lookup_caller_identity,
@@ -522,7 +523,10 @@ def test_handle_twilio_websocket_rebinds_speech_started_clear_callback_on_prewar
         async def _fake_on_call_end(*args, **kwargs) -> None:
             return None
 
-        monkeypatch.setattr(server, "_claim_prewarm", lambda _from_number: fake_client)
+        async def _fake_claim(_from_number, **_kwargs):
+            return fake_client
+
+        monkeypatch.setattr(server, "_claim_prewarm", _fake_claim)
         monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
         monkeypatch.setattr(
             "gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge
@@ -1917,3 +1921,231 @@ def test_assistant_turns_with_shared_prefix_are_not_collapsed() -> None:
     ), "Two distinct assistant turns must remain separate even when the second starts with the first"
     assert transcript[0].text == "Sure"
     assert transcript[1].text == "Sure, let me check"
+
+
+# --- Caller-aware external-caller handling (2026-08-27) ---
+
+
+def _write_person(tmpdir: str, filename: str, body: str) -> None:
+    people_dir = Path(tmpdir) / "people"
+    people_dir.mkdir(exist_ok=True)
+    (people_dir / filename).write_text(body)
+
+
+def test_lookup_caller_identity_parses_call_role_and_language() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_person(
+            tmpdir,
+            "erik.md",
+            "# Erik Bjäreholt\n\n- Call role: operator\nPhone: +46700000001\n",
+        )
+        _write_person(
+            tmpdir,
+            "philip.md",
+            "# Philip Johansson\n\n- Call language: Swedish\nPhone: +46700000002\n",
+        )
+
+        erik = _lookup_caller_identity("+46700000001", tmpdir)
+        philip = _lookup_caller_identity("+46700000002", tmpdir)
+
+    assert erik is not None and erik.is_operator is True
+    assert erik.call_language is None
+    assert philip is not None and philip.is_operator is False
+    assert philip.call_language == "Swedish"
+
+
+def test_extract_people_field_parses_bolded_property_name() -> None:
+    text = "# Erik Bjäreholt\n\n- **Call name**: Erik\n- **Call role**: operator\n"
+    assert _extract_people_field(text, "call name") == "Erik"
+    assert _extract_people_field(text, "call role") == "operator"
+
+
+def test_extract_people_field_strips_bolded_value() -> None:
+    text = "# Erik Bjäreholt\n\n- Call name: **Erik**\n"
+    assert _extract_people_field(text, "call name") == "Erik"
+
+
+def test_lookup_caller_identity_parses_bolded_call_role() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_person(
+            tmpdir,
+            "erik.md",
+            "# Erik Bjäreholt\n\n- **Call role**: operator\nPhone: +46700000001\n",
+        )
+
+        erik = _lookup_caller_identity("+46700000001", tmpdir)
+
+    assert erik is not None and erik.is_operator is True
+
+
+def test_caller_instructions_external_caller_gets_guidance() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_person(
+            tmpdir,
+            "philip.md",
+            "# Philip Johansson\n\n- Call language: Swedish\nPhone: +46700000002\n",
+        )
+        result = _build_caller_instructions("You are Bob.", "+46700000002", tmpdir)
+
+    assert "EXTERNAL CALLER GUIDANCE" in result
+    assert "Speak Swedish" in result
+    assert "Do not volunteer internal" in result
+
+
+def test_caller_instructions_operator_gets_no_external_guidance() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_person(
+            tmpdir,
+            "erik.md",
+            "# Erik Bjäreholt\n\n- Call role: operator\nPhone: +46700000001\n",
+        )
+        result = _build_caller_instructions("You are Bob.", "+46700000001", tmpdir)
+
+    assert "EXTERNAL CALLER GUIDANCE" not in result
+
+
+def test_caller_instructions_unknown_number_gets_guidance() -> None:
+    result = _build_caller_instructions("You are Bob.", "+15551234567", None)
+    assert "EXTERNAL CALLER GUIDANCE" in result
+    assert "Mirror the caller's language" in result
+
+
+def test_fresh_call_greeting_uses_call_language() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_person(
+            tmpdir,
+            "philip.md",
+            "# Philip Johansson\n\n- Call language: Swedish\nPhone: +46700000002\n",
+        )
+        greeting = _build_fresh_call_greeting_instructions(
+            "+46700000002", tmpdir, "bob"
+        )
+
+    assert "Greet in Swedish" in greeting
+    assert "Philip" in greeting
+
+
+def _write_fresh_digest(tmpdir: str) -> None:
+    state_dir = Path(tmpdir) / "state"
+    state_dir.mkdir(exist_ok=True)
+    (state_dir / "voice-digest.md").write_text("Generated at now\n- did things\n")
+
+
+def test_bootstrap_injects_digest_for_operator_only() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_fresh_digest(tmpdir)
+        _write_person(
+            tmpdir,
+            "erik.md",
+            "# Erik Bjäreholt\n\n- Call role: operator\nPhone: +46700000001\n",
+        )
+        _write_person(
+            tmpdir,
+            "philip.md",
+            "# Philip Johansson\n\nPhone: +46700000002\n",
+        )
+        server = VoiceServer(workspace=tmpdir)
+        server._instructions = "You are Bob."
+
+        operator_bootstrap = asyncio.run(
+            server._build_session_bootstrap(
+                caller_id="+46700000001", from_number="+46700000001"
+            )
+        )
+        external_bootstrap = asyncio.run(
+            server._build_session_bootstrap(
+                caller_id="+46700000002", from_number="+46700000002"
+            )
+        )
+        unknown_bootstrap = asyncio.run(
+            server._build_session_bootstrap(
+                caller_id="+15551234567", from_number="+15551234567"
+            )
+        )
+        # No from_number (local/browser transport) keeps the digest
+        local_bootstrap = asyncio.run(
+            server._build_session_bootstrap(caller_id=None, from_number="")
+        )
+
+    assert "ACTIVITY DIGEST" in operator_bootstrap.instructions
+    assert "ACTIVITY DIGEST" not in external_bootstrap.instructions
+    assert "ACTIVITY DIGEST" not in unknown_bootstrap.instructions
+    assert "ACTIVITY DIGEST" in local_bootstrap.instructions
+
+
+# --- Pre-warm claim race (2026-08-27) ---
+
+
+def test_claim_prewarm_waits_for_inflight_task() -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+        fake_client = _FakeRealtimeClient()
+        ready = asyncio.Event()
+
+        async def _slow_prewarm() -> None:
+            await ready.wait()
+            server._prewarm_sessions["+46700000002"] = (
+                fake_client,
+                time.monotonic(),
+            )
+
+        task = asyncio.create_task(_slow_prewarm())
+        server._prewarm_tasks["+46700000002"] = task
+        asyncio.get_running_loop().call_later(0.05, ready.set)
+
+        claimed = await server._claim_prewarm("+46700000002", wait_seconds=1.0)
+
+        assert claimed is fake_client
+        assert "+46700000002" not in server._prewarm_sessions
+
+    asyncio.run(_exercise())
+
+
+def test_claim_prewarm_timeout_cancels_inflight_task() -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+
+        async def _never_ready() -> None:
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(_never_ready())
+        server._prewarm_tasks["+46700000002"] = task
+
+        claimed = await server._claim_prewarm("+46700000002", wait_seconds=0.05)
+
+        assert claimed is None
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+
+    asyncio.run(_exercise())
+
+
+def test_claim_prewarm_ready_session_claimed_without_waiting() -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+        fake_client = _FakeRealtimeClient()
+        server._prewarm_sessions["+46700000002"] = (fake_client, time.monotonic())
+
+        claimed = await server._claim_prewarm("+46700000002")
+
+        assert claimed is fake_client
+
+    asyncio.run(_exercise())
+
+
+def test_register_prewarm_task_cleans_up_after_completion() -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+
+        async def _noop_prewarm(_from_number: str) -> None:
+            return None
+
+        server._prewarm_for_inbound = _noop_prewarm  # type: ignore[method-assign]
+        server._register_prewarm_task("+46700000002")
+        assert "+46700000002" in server._prewarm_tasks
+        await server._prewarm_tasks["+46700000002"]
+        await asyncio.sleep(0)  # let done-callback run
+        assert "+46700000002" not in server._prewarm_tasks
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2182,3 +2182,74 @@ def test_prewarm_connect_failure_disconnects_half_open_client() -> None:
         assert disconnected == [failing_client]
 
     asyncio.run(_exercise())
+
+
+def test_claim_prewarm_timeout_reaps_entry_stored_by_completed_task() -> None:
+    """AI-review P1 (round 2): if the pre-warm task completes and stores its
+    session between the claim timeout and task.cancel(), the cancel is a no-op
+    and nothing disconnects the stored session. The timeout branch must reap it
+    so it can't be claimed while a cold twin is being built."""
+
+    async def _exercise() -> None:
+        server = VoiceServer()
+        fake_client = _FakeRealtimeClient()
+        disconnected: list[object] = []
+
+        async def _record_disconnect(client) -> None:
+            disconnected.append(client)
+
+        server._disconnect_realtime_client = _record_disconnect  # type: ignore[method-assign]
+
+        async def _slow_then_store() -> None:
+            # Simulates the race: still pending when wait_for times out, but
+            # the entry is present by the time the timeout branch runs.
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(_slow_then_store())
+        server._prewarm_tasks["+46700000002"] = task
+        await asyncio.sleep(0)
+        # Entry appears after the first pop (claim's initial pop sees nothing,
+        # the wait times out, and the store lands before cancel is processed).
+        original_cancel = task.cancel
+
+        def _store_then_cancel() -> bool:
+            server._prewarm_sessions["+46700000002"] = (
+                fake_client,
+                time.monotonic(),
+            )
+            return original_cancel()
+
+        task.cancel = _store_then_cancel  # type: ignore[method-assign]
+
+        claimed = await server._claim_prewarm("+46700000002", wait_seconds=0.05)
+        await asyncio.sleep(0)  # let the disconnect task run
+
+        assert claimed is None
+        assert "+46700000002" not in server._prewarm_sessions
+        assert disconnected == [fake_client]
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_exercise())
+
+
+def test_reap_prewarm_entry_disconnects_and_removes() -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+        fake_client = _FakeRealtimeClient()
+        disconnected: list[object] = []
+
+        async def _record_disconnect(client) -> None:
+            disconnected.append(client)
+
+        server._disconnect_realtime_client = _record_disconnect  # type: ignore[method-assign]
+        server._prewarm_sessions["+1"] = (fake_client, time.monotonic())
+
+        server._reap_prewarm_entry("+1")
+        await asyncio.sleep(0)
+
+        assert "+1" not in server._prewarm_sessions
+        assert disconnected == [fake_client]
+        server._reap_prewarm_entry("+1")  # absent entry is a no-op
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Problem

Observed on the first real external caller call (2026-08-27): the caller heard garbled internal ops-speak, then silence. Two independent defects:

1. **Pre-warm claim race**: `POST /incoming` fired-and-forgot `_prewarm_for_inbound`, while the Twilio WS `"start"` handler called sync `_claim_prewarm` — the claim could run before "Pre-warm ready", so the call fell back to a duplicate cold session while the pre-warm completed into an orphaned provider session (doubled "Session created" in the logs).
2. **External callers got operator instructions**: the session bootstrap injected the internal activity digest (subagent status etc.) for every caller, so an unknown external caller was greeted with internal ops status.

## Fix

**Race**: in-flight pre-warm tasks are now tracked via `_register_prewarm_task` (with done-callback cleanup); `_claim_prewarm` is async and awaits an in-flight pre-warm up to 2s (`asyncio.shield` + `wait_for`), cancelling it on timeout. `_prewarm_for_inbound` handles `CancelledError` by disconnecting a half-open client, and schedules stale-prewarm eviction at TTL+1 so orphans don't linger until the next call.

**Caller-aware instructions**: `CallerIdentity` gains `is_operator` (from `- Call role: operator` in `people/*.md`) and `call_language` (from `- Call language: <lang>`). Non-operator and unknown callers get external-caller guidance (no internal ops status, no unprompted tool use, speak the caller's language); fresh-call greetings honor `call_language`; the activity digest is injected only for operator callers (local/browser transport without a from_number keeps the digest). `_extract_people_field` parses both plain and markdown-bolded property lines (`- **Call role**: operator`) and strips bolded values.

## Tests

13 new tests: caller role/language parsing (plain + bolded), external guidance presence/absence, digest operator-gating, claim-awaits-inflight, claim-timeout-cancels, ready-claim, register-cleanup. Full gptme-voice suite: 228 passed.

https://claude.ai/code/session_01V5jRRQtMvq5eYQ6bNK6PA2