### PR TITLE
fix(release-announce): handle naive publication timestamps

### DIFF
--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -465,7 +465,7 @@ def main() -> int:
                 datetime.now(timezone.utc)
                 - datetime.fromisoformat(published.replace("Z", "+00:00"))
             ).total_seconds() / 86400
-        except ValueError:
+        except (ValueError, TypeError):
             age_days = None
         if age_days is None or age_days > args.max_age_days:
             print(

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -943,3 +943,29 @@ def test_force_bypasses_freshness_gate(monkeypatch, capsys, tmp_path):
     assert "exceeds --max-age-days" not in capsys.readouterr().out
     assert calls, "--force should have reached _main and attempted to post"
     assert result == 0
+
+
+def test_naive_published_at_skips_safely(monkeypatch, capsys, tmp_path):
+    """A timezone-less publishedAt must fail closed instead of crashing."""
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v1.0.0",
+            "isPrerelease": False,
+            "body": "",
+            "url": "u",
+            "publishedAt": "2024-06-16T12:00:00",  # no Z / no offset → naive datetime
+        },
+    )
+    posted: list = []
+
+    def _stub_post(a, account=None):
+        posted.append(a)
+        return True, "1", ""
+
+    monkeypatch.setattr(ra, "_post", _stub_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 0
+    assert posted == [], "naive publishedAt should skip, not crash or announce"


### PR DESCRIPTION
## Problem

The freshness gate merged in #1518 catches `ValueError` for malformed `publishedAt`, but a valid ISO timestamp without a timezone parses as a naive datetime. Subtracting it from the aware UTC clock raises `TypeError`, crashing the announcement job instead of failing closed.

## Fix

Catch `TypeError` alongside `ValueError`, so timezone-less timestamps are treated as unverifiable and skipped. Add a regression test proving no tweet is posted and the CLI exits cleanly.

## Verification

- `uv run pytest tests/test_release_announce.py -q --disable-warnings --maxfail=1 --durations=5` — 43 passed
- `git diff --cached --check` before commit

Follow-up to #1518.
