### PR TITLE
feat(voice): capability-gated body_* tools — BodyAdapter + MAVSDK/PX4 support

### DIFF
--- a/packages/gptme-voice/pyproject.toml
+++ b/packages/gptme-voice/pyproject.toml
@@ -22,6 +22,9 @@ test = [
 local = [
     "pyaudio>=0.2.13",
 ]
+body = [
+    "mavsdk>=2.0",
+]
 
 [project.scripts]
 gptme-voice-server = "gptme_voice.realtime.server:main"

--- a/packages/gptme-voice/src/gptme_voice/body/__init__.py
+++ b/packages/gptme-voice/src/gptme_voice/body/__init__.py
@@ -1,0 +1,26 @@
+"""Body adapters: the Brain↔Body contract for BobBrain presence nodes.
+
+See adapter.py for the design rule (goals, not control) and capability
+gating. MavsdkAdapter (PX4 quad / SITL) lives in mavsdk_adapter.py behind
+the optional ``gptme-voice[body]`` extra.
+"""
+
+from .adapter import (
+    CAP_ALTITUDE,
+    CAP_MOVE,
+    CAP_ROTATE,
+    BodyAdapter,
+    NullAdapter,
+    body_adapter_from_env,
+    body_tool_schemas,
+)
+
+__all__ = [
+    "CAP_ALTITUDE",
+    "CAP_MOVE",
+    "CAP_ROTATE",
+    "BodyAdapter",
+    "NullAdapter",
+    "body_adapter_from_env",
+    "body_tool_schemas",
+]

--- a/packages/gptme-voice/src/gptme_voice/body/adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/adapter.py
@@ -253,8 +253,7 @@ def body_tool_schemas(adapter: BodyAdapter | None) -> list[dict]:
                         "altitude_m": {
                             "type": "number",
                             "description": (
-                                "Hover altitude in meters above ground "
-                                "(default 2.5)."
+                                "Hover altitude in meters above ground (default 2.5)."
                             ),
                         }
                     },
@@ -288,6 +287,14 @@ def body_adapter_from_env() -> BodyAdapter | None:
     if url == "null":
         return NullAdapter()
     if url.startswith("mavsdk://"):
+        try:
+            __import__("mavsdk")
+        except ImportError:
+            logger.warning(
+                "GPTME_VOICE_BODY_URL uses mavsdk:// but the mavsdk dependency "
+                "is unavailable; install gptme-voice[body] (body disabled)"
+            )
+            return None
         from .mavsdk_adapter import MavsdkAdapter
 
         return MavsdkAdapter(url.removeprefix("mavsdk://"))

--- a/packages/gptme-voice/src/gptme_voice/body/adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/adapter.py
@@ -1,0 +1,295 @@
+"""Body adapter protocol — the Brain↔Body contract.
+
+BobBrain design rule (bobbrain-spec, ErikBjare/bob#730): the brain emits
+*goals* (goto / move / turn / stop / dock), never control loops. A per-body
+adapter translates goals into the body's protocol and owns safety. The
+autopilot's own failsafes (e.g. PX4 offboard/link-loss behavior) remain the
+final authority — a dropped brain link must always leave the body safe.
+
+Capabilities gate which voice tools get registered for a session:
+a tabletop puck (NullAdapter, no capabilities) exposes no motion tools at
+all, so the model cannot try to fly a desk ornament.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Capability names
+CAP_MOVE = "move"  # horizontal translation (goto/move/return home)
+CAP_ROTATE = "rotate"  # yaw control
+CAP_ALTITUDE = "altitude"  # vertical control (takeoff/land/up-down)
+
+
+@runtime_checkable
+class BodyAdapter(Protocol):
+    """Minimal protocol every body implements.
+
+    Methods for capabilities an adapter does not advertise are never
+    called by the tool bridge; implementations may raise for them.
+    """
+
+    capabilities: set[str]
+    name: str
+
+    async def ensure_connected(self) -> None: ...
+
+    async def takeoff(self, altitude_m: float) -> dict[str, Any]: ...
+
+    async def land(self) -> dict[str, Any]: ...
+
+    async def goto(
+        self,
+        latitude_deg: float,
+        longitude_deg: float,
+        altitude_m: float | None,
+    ) -> dict[str, Any]: ...
+
+    async def move(
+        self, forward_m: float, right_m: float, up_m: float
+    ) -> dict[str, Any]: ...
+
+    async def turn(self, yaw_deg: float) -> dict[str, Any]: ...
+
+    async def stop(self) -> dict[str, Any]: ...
+
+    async def return_home(self) -> dict[str, Any]: ...
+
+    def telemetry(self) -> dict[str, Any]: ...
+
+
+class NullAdapter:
+    """Body with no locomotion — the tabletop puck.
+
+    Registers only ``body_status``; every motion method reports
+    unsupported (defense in depth — the bridge never routes these).
+    """
+
+    capabilities: set[str] = set()
+    name = "null"
+
+    async def ensure_connected(self) -> None:
+        return None
+
+    def telemetry(self) -> dict[str, Any]:
+        return {"body": self.name, "mobile": False}
+
+    async def _unsupported(self) -> dict[str, Any]:
+        return {"error": "This body has no locomotion."}
+
+    async def takeoff(self, altitude_m: float) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def land(self) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def goto(
+        self,
+        latitude_deg: float,
+        longitude_deg: float,
+        altitude_m: float | None,
+    ) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def move(
+        self, forward_m: float, right_m: float, up_m: float
+    ) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def turn(self, yaw_deg: float) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def stop(self) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def return_home(self) -> dict[str, Any]:
+        return await self._unsupported()
+
+
+def body_tool_schemas(adapter: BodyAdapter | None) -> list[dict]:
+    """Realtime-API function schemas for the adapter's capability set.
+
+    Returns [] when no adapter is configured, so callers can always
+    ``extend()`` the session tool list unconditionally.
+    """
+    if adapter is None:
+        return []
+
+    caps = adapter.capabilities
+    tools: list[dict] = [
+        {
+            "type": "function",
+            "name": "body_status",
+            "description": (
+                "Read the physical body's current state: position, altitude, "
+                "battery, heading, flight mode. Use it before motion commands "
+                "and whenever the caller asks where the body is or how it is "
+                "doing."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+
+    if CAP_MOVE in caps:
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_stop",
+                "description": (
+                    "IMMEDIATELY halt all body motion and hold position. "
+                    "Call this first, without asking, whenever the caller "
+                    "says stop/wait/freeze or anything sounds wrong."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            }
+        )
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_return_home",
+                "description": (
+                    "Send the body back to its home/launch position "
+                    "(quadcopter: return-to-launch and land)."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            }
+        )
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_move",
+                "description": (
+                    "Move the body a relative distance in meters from where "
+                    "it is now, in its own frame: forward/backward, "
+                    "right/left, up/down. Use small distances (1-5 m) and "
+                    "check body_status after."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "forward_m": {
+                            "type": "number",
+                            "description": "Meters forward (negative = backward).",
+                        },
+                        "right_m": {
+                            "type": "number",
+                            "description": "Meters right (negative = left).",
+                        },
+                        "up_m": {
+                            "type": "number",
+                            "description": "Meters up (negative = down). 0 to hold altitude.",
+                        },
+                    },
+                },
+            }
+        )
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_goto",
+                "description": (
+                    "Fly/drive the body to absolute GPS coordinates. Only "
+                    "use coordinates you got from body_status or the caller "
+                    "— never invent them."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "latitude_deg": {"type": "number"},
+                        "longitude_deg": {"type": "number"},
+                        "altitude_m": {
+                            "type": "number",
+                            "description": (
+                                "Target altitude in meters above the home "
+                                "position. Omit to keep current altitude."
+                            ),
+                        },
+                    },
+                    "required": ["latitude_deg", "longitude_deg"],
+                },
+            }
+        )
+
+    if CAP_ROTATE in caps:
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_turn",
+                "description": (
+                    "Rotate the body in place by a relative angle in degrees "
+                    "(positive = clockwise/right, negative = "
+                    "counter-clockwise/left)."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "yaw_deg": {
+                            "type": "number",
+                            "description": "Relative turn in degrees, -180..180.",
+                        }
+                    },
+                    "required": ["yaw_deg"],
+                },
+            }
+        )
+
+    if CAP_ALTITUDE in caps:
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_takeoff",
+                "description": (
+                    "Arm and take off to a hover at the given altitude. Only "
+                    "do this when the caller explicitly asks to take off or "
+                    "fly."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "altitude_m": {
+                            "type": "number",
+                            "description": (
+                                "Hover altitude in meters above ground "
+                                "(default 2.5)."
+                            ),
+                        }
+                    },
+                },
+            }
+        )
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_land",
+                "description": "Land the body at its current position and disarm.",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        )
+
+    return tools
+
+
+def body_adapter_from_env() -> BodyAdapter | None:
+    """Build a body adapter from ``GPTME_VOICE_BODY_URL``.
+
+    - unset/empty  -> None (no body tools registered)
+    - ``null``     -> NullAdapter (body_status only; tabletop puck)
+    - ``mavsdk://<system_address>`` -> MavsdkAdapter, e.g.
+      ``mavsdk://udpin://0.0.0.0:14540`` (SITL) or
+      ``mavsdk://serial:///dev/ttyUSB0:57600`` (SiK radio)
+    """
+    url = os.environ.get("GPTME_VOICE_BODY_URL", "").strip()
+    if not url:
+        return None
+    if url == "null":
+        return NullAdapter()
+    if url.startswith("mavsdk://"):
+        from .mavsdk_adapter import MavsdkAdapter
+
+        return MavsdkAdapter(url.removeprefix("mavsdk://"))
+    logger.warning("Unknown GPTME_VOICE_BODY_URL scheme: %s (ignored)", url)
+    return None

--- a/packages/gptme-voice/src/gptme_voice/body/adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/adapter.py
@@ -38,6 +38,8 @@ class BodyAdapter(Protocol):
 
     async def ensure_connected(self) -> None: ...
 
+    async def close(self) -> None: ...
+
     async def takeoff(self, altitude_m: float) -> dict[str, Any]: ...
 
     async def land(self) -> dict[str, Any]: ...
@@ -73,6 +75,9 @@ class NullAdapter:
     name = "null"
 
     async def ensure_connected(self) -> None:
+        return None
+
+    async def close(self) -> None:
         return None
 
     def telemetry(self) -> dict[str, Any]:

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -1,0 +1,233 @@
+"""MAVSDK body adapter — PX4 vehicles (X500 v2 quad, SITL).
+
+Translates BodyAdapter goals into MAVSDK action calls. Deliberately uses
+only the high-level Action API (goto_location, takeoff, land, hold, RTL) —
+no offboard control loops. PX4's own failsafes remain the safety authority:
+if the brain link drops mid-goal, the vehicle keeps its autopilot behavior.
+
+Validated against PX4 SITL (jonasvautherin/px4-gazebo-headless);
+see projects/bobbody-flight/ in the Bob workspace for the harness.
+
+Requires the optional ``mavsdk`` dependency: ``gptme-voice[body]``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_EARTH_M_PER_DEG_LAT = 111_320.0
+
+
+def body_to_ned(
+    forward_m: float, right_m: float, yaw_deg: float
+) -> tuple[float, float]:
+    """Rotate a body-frame (forward, right) offset into NED (north, east).
+
+    ``yaw_deg`` is heading from north, clockwise-positive (NED convention).
+    """
+    yaw = math.radians(yaw_deg)
+    north = forward_m * math.cos(yaw) - right_m * math.sin(yaw)
+    east = forward_m * math.sin(yaw) + right_m * math.cos(yaw)
+    return north, east
+
+
+def offset_latlon(
+    latitude_deg: float, longitude_deg: float, north_m: float, east_m: float
+) -> tuple[float, float]:
+    """Offset a lat/lon by meters north/east (small-distance approximation)."""
+    dlat = north_m / _EARTH_M_PER_DEG_LAT
+    denom = _EARTH_M_PER_DEG_LAT * math.cos(math.radians(latitude_deg))
+    dlon = east_m / denom if abs(denom) > 1e-9 else 0.0
+    return latitude_deg + dlat, longitude_deg + dlon
+
+
+class MavsdkAdapter:
+    """BodyAdapter for PX4/MAVSDK vehicles."""
+
+    capabilities = {"move", "rotate", "altitude"}
+    name = "mavsdk"
+
+    def __init__(self, system_address: str, connect_timeout_s: float = 20.0):
+        self.system_address = system_address
+        self.connect_timeout_s = connect_timeout_s
+        self._system: Any = None
+        self._connected = False
+        self._lock = asyncio.Lock()
+        self._telemetry_tasks: list[asyncio.Task] = []
+        # Telemetry caches (filled by background subscriptions)
+        self._position: dict[str, float] = {}
+        self._heading_deg: float | None = None
+        self._battery: dict[str, float] = {}
+        self._in_air: bool | None = None
+        self._flight_mode: str | None = None
+        self._armed: bool | None = None
+
+    async def ensure_connected(self) -> None:
+        async with self._lock:
+            if self._connected:
+                return
+            from mavsdk import System
+
+            system = System()
+            logger.info("MavsdkAdapter connecting to %s", self.system_address)
+            await system.connect(system_address=self.system_address)
+
+            async def _wait_connected() -> None:
+                async for state in system.core.connection_state():
+                    if state.is_connected:
+                        return
+
+            await asyncio.wait_for(_wait_connected(), timeout=self.connect_timeout_s)
+            self._system = system
+            self._start_telemetry_cache()
+            self._connected = True
+            logger.info("MavsdkAdapter connected")
+
+    def _start_telemetry_cache(self) -> None:
+        system = self._system
+
+        async def _position() -> None:
+            async for p in system.telemetry.position():
+                self._position = {
+                    "latitude_deg": p.latitude_deg,
+                    "longitude_deg": p.longitude_deg,
+                    "absolute_altitude_m": p.absolute_altitude_m,
+                    "relative_altitude_m": p.relative_altitude_m,
+                }
+
+        async def _heading() -> None:
+            async for h in system.telemetry.heading():
+                self._heading_deg = h.heading_deg
+
+        async def _battery() -> None:
+            async for b in system.telemetry.battery():
+                self._battery = {
+                    "voltage_v": round(b.voltage_v, 2),
+                    "remaining_percent": round(b.remaining_percent, 1),
+                }
+
+        async def _in_air() -> None:
+            async for in_air in system.telemetry.in_air():
+                self._in_air = in_air
+
+        async def _flight_mode() -> None:
+            async for mode in system.telemetry.flight_mode():
+                self._flight_mode = str(mode)
+
+        async def _armed() -> None:
+            async for armed in system.telemetry.armed():
+                self._armed = armed
+
+        for coro in (
+            _position(),
+            _heading(),
+            _battery(),
+            _in_air(),
+            _flight_mode(),
+            _armed(),
+        ):
+            self._telemetry_tasks.append(asyncio.create_task(coro))
+
+    async def close(self) -> None:
+        for task in self._telemetry_tasks:
+            task.cancel()
+        self._telemetry_tasks.clear()
+        self._connected = False
+        self._system = None
+
+    # -- BodyAdapter interface -------------------------------------------
+
+    def telemetry(self) -> dict[str, Any]:
+        return {
+            "body": self.name,
+            "mobile": True,
+            "connected": self._connected,
+            "position": self._position or None,
+            "heading_deg": self._heading_deg,
+            "battery": self._battery or None,
+            "in_air": self._in_air,
+            "flight_mode": self._flight_mode,
+            "armed": self._armed,
+        }
+
+    async def takeoff(self, altitude_m: float) -> dict[str, Any]:
+        system = self._system
+        await system.action.set_takeoff_altitude(altitude_m)
+        await system.action.arm()
+        await system.action.takeoff()
+        return {
+            "status": "taking_off",
+            "target_altitude_m": altitude_m,
+            "message": "Armed and taking off. Check body_status for altitude.",
+        }
+
+    async def land(self) -> dict[str, Any]:
+        await self._system.action.land()
+        return {"status": "landing"}
+
+    async def stop(self) -> dict[str, Any]:
+        await self._system.action.hold()
+        return {"status": "holding", "message": "Motion stopped; holding position."}
+
+    async def return_home(self) -> dict[str, Any]:
+        await self._system.action.return_to_launch()
+        return {"status": "returning_home"}
+
+    async def goto(
+        self,
+        latitude_deg: float,
+        longitude_deg: float,
+        altitude_m: float | None,
+    ) -> dict[str, Any]:
+        pos = self._position
+        if not pos:
+            return {"error": "No position fix yet; cannot goto."}
+        home_abs = pos["absolute_altitude_m"] - pos["relative_altitude_m"]
+        target_abs = (
+            home_abs + altitude_m
+            if altitude_m is not None
+            else pos["absolute_altitude_m"]
+        )
+        yaw = self._heading_deg if self._heading_deg is not None else float("nan")
+        await self._system.action.goto_location(
+            latitude_deg, longitude_deg, target_abs, yaw
+        )
+        return {
+            "status": "en_route",
+            "target": {
+                "latitude_deg": latitude_deg,
+                "longitude_deg": longitude_deg,
+                "altitude_m": altitude_m,
+            },
+        }
+
+    async def move(
+        self, forward_m: float, right_m: float, up_m: float
+    ) -> dict[str, Any]:
+        pos = self._position
+        if not pos:
+            return {"error": "No position fix yet; cannot move."}
+        yaw = self._heading_deg or 0.0
+        north, east = body_to_ned(forward_m, right_m, yaw)
+        lat, lon = offset_latlon(pos["latitude_deg"], pos["longitude_deg"], north, east)
+        target_rel = pos["relative_altitude_m"] + up_m
+        return await self.goto(lat, lon, target_rel)
+
+    async def turn(self, yaw_deg: float) -> dict[str, Any]:
+        pos = self._position
+        if not pos:
+            return {"error": "No position fix yet; cannot turn."}
+        current = self._heading_deg or 0.0
+        target_yaw = (current + yaw_deg + 180.0) % 360.0 - 180.0
+        await self._system.action.goto_location(
+            pos["latitude_deg"],
+            pos["longitude_deg"],
+            pos["absolute_altitude_m"],
+            target_yaw,
+        )
+        return {"status": "turning", "target_heading_deg": round(target_yaw, 1)}

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -219,15 +219,18 @@ class MavsdkAdapter:
     async def _run_action(self, awaitable: Any) -> Any:
         try:
             return await asyncio.wait_for(awaitable, timeout=self.command_timeout_s)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             # The MAVSDK command is already on the vehicle. Dropping the
             # adapter here would cancel telemetry and invite a reconnect
             # while land/takeoff/goto is still executing.
+            # Python 3.10: wait_for raises asyncio.TimeoutError, distinct from
+            # builtin TimeoutError. Re-raise TimeoutError so callers and tests
+            # can catch one type on every supported Python.
             logger.warning(
                 "MAVSDK action timed out after %.1fs; leaving adapter connected",
                 self.command_timeout_s,
             )
-            raise
+            raise TimeoutError from None
 
     # -- BodyAdapter interface -------------------------------------------
 

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -57,7 +57,8 @@ class MavsdkAdapter:
         self.connect_timeout_s = connect_timeout_s
         self._system: Any = None
         self._connected = False
-        self._lock = asyncio.Lock()
+        self._connection_lock = asyncio.Lock()
+        self._command_lock = asyncio.Lock()
         self._telemetry_tasks: list[asyncio.Task] = []
         # Telemetry caches (filled by background subscriptions)
         self._position: dict[str, float] = {}
@@ -68,9 +69,10 @@ class MavsdkAdapter:
         self._armed: bool | None = None
 
     async def ensure_connected(self) -> None:
-        async with self._lock:
+        async with self._connection_lock:
             if self._connected:
                 return
+            await self._cancel_telemetry_tasks()
             from mavsdk import System
 
             system = System()
@@ -123,21 +125,56 @@ class MavsdkAdapter:
             async for armed in system.telemetry.armed():
                 self._armed = armed
 
-        for coro in (
-            _position(),
-            _heading(),
-            _battery(),
-            _in_air(),
-            _flight_mode(),
-            _armed(),
-        ):
-            self._telemetry_tasks.append(asyncio.create_task(coro))
+        async def _watch(stream_name: str, subscription: Any) -> None:
+            try:
+                await subscription
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - MAVSDK stream errors vary by backend
+                logger.exception("MAVSDK %s telemetry stream failed", stream_name)
+                self._mark_disconnected()
+            else:
+                logger.error("MAVSDK %s telemetry stream ended", stream_name)
+                self._mark_disconnected()
+
+        subscriptions = {
+            "position": _position(),
+            "heading": _heading(),
+            "battery": _battery(),
+            "in_air": _in_air(),
+            "flight_mode": _flight_mode(),
+            "armed": _armed(),
+        }
+        self._telemetry_tasks.extend(
+            asyncio.create_task(_watch(name, subscription))
+            for name, subscription in subscriptions.items()
+        )
+
+    def _mark_disconnected(self) -> None:
+        self._connected = False
+        self._position = {}
+        self._heading_deg = None
+        self._battery = {}
+        self._in_air = None
+        self._flight_mode = None
+        self._armed = None
+        current = asyncio.current_task()
+        for task in self._telemetry_tasks:
+            if task is not current:
+                task.cancel()
+        self._telemetry_tasks.clear()
+
+    async def _cancel_telemetry_tasks(self) -> None:
+        tasks = list(self._telemetry_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._telemetry_tasks.clear()
 
     async def close(self) -> None:
-        for task in self._telemetry_tasks:
-            task.cancel()
-        self._telemetry_tasks.clear()
-        self._connected = False
+        await self._cancel_telemetry_tasks()
+        self._mark_disconnected()
         self._system = None
 
     # -- BodyAdapter interface -------------------------------------------
@@ -156,29 +193,45 @@ class MavsdkAdapter:
         }
 
     async def takeoff(self, altitude_m: float) -> dict[str, Any]:
-        system = self._system
-        await system.action.set_takeoff_altitude(altitude_m)
-        await system.action.arm()
-        await system.action.takeoff()
-        return {
-            "status": "taking_off",
-            "target_altitude_m": altitude_m,
-            "message": "Armed and taking off. Check body_status for altitude.",
-        }
+        async with self._command_lock:
+            system = self._system
+            await system.action.set_takeoff_altitude(altitude_m)
+            await system.action.arm()
+            await system.action.takeoff()
+            return {
+                "status": "taking_off",
+                "target_altitude_m": altitude_m,
+                "message": "Armed and taking off. Check body_status for altitude.",
+            }
 
     async def land(self) -> dict[str, Any]:
-        await self._system.action.land()
-        return {"status": "landing"}
+        async with self._command_lock:
+            await self._system.action.land()
+            return {"status": "landing"}
 
     async def stop(self) -> dict[str, Any]:
-        await self._system.action.hold()
-        return {"status": "holding", "message": "Motion stopped; holding position."}
+        async with self._command_lock:
+            await self._system.action.hold()
+            return {
+                "status": "holding",
+                "message": "Motion stopped; holding position.",
+            }
 
     async def return_home(self) -> dict[str, Any]:
-        await self._system.action.return_to_launch()
-        return {"status": "returning_home"}
+        async with self._command_lock:
+            await self._system.action.return_to_launch()
+            return {"status": "returning_home"}
 
     async def goto(
+        self,
+        latitude_deg: float,
+        longitude_deg: float,
+        altitude_m: float | None,
+    ) -> dict[str, Any]:
+        async with self._command_lock:
+            return await self._goto_unlocked(latitude_deg, longitude_deg, altitude_m)
+
+    async def _goto_unlocked(
         self,
         latitude_deg: float,
         longitude_deg: float,
@@ -209,25 +262,32 @@ class MavsdkAdapter:
     async def move(
         self, forward_m: float, right_m: float, up_m: float
     ) -> dict[str, Any]:
-        pos = self._position
-        if not pos:
-            return {"error": "No position fix yet; cannot move."}
-        yaw = self._heading_deg or 0.0
-        north, east = body_to_ned(forward_m, right_m, yaw)
-        lat, lon = offset_latlon(pos["latitude_deg"], pos["longitude_deg"], north, east)
-        target_rel = pos["relative_altitude_m"] + up_m
-        return await self.goto(lat, lon, target_rel)
+        async with self._command_lock:
+            pos = self._position
+            if not pos:
+                return {"error": "No position fix yet; cannot move."}
+            yaw = self._heading_deg or 0.0
+            north, east = body_to_ned(forward_m, right_m, yaw)
+            lat, lon = offset_latlon(
+                pos["latitude_deg"], pos["longitude_deg"], north, east
+            )
+            target_rel = max(1.0, pos["relative_altitude_m"] + up_m)
+            return await self._goto_unlocked(lat, lon, target_rel)
 
     async def turn(self, yaw_deg: float) -> dict[str, Any]:
-        pos = self._position
-        if not pos:
-            return {"error": "No position fix yet; cannot turn."}
-        current = self._heading_deg or 0.0
-        target_yaw = (current + yaw_deg + 180.0) % 360.0 - 180.0
-        await self._system.action.goto_location(
-            pos["latitude_deg"],
-            pos["longitude_deg"],
-            pos["absolute_altitude_m"],
-            target_yaw,
-        )
-        return {"status": "turning", "target_heading_deg": round(target_yaw, 1)}
+        async with self._command_lock:
+            pos = self._position
+            if not pos:
+                return {"error": "No position fix yet; cannot turn."}
+            current = self._heading_deg or 0.0
+            target_yaw = (current + yaw_deg + 180.0) % 360.0 - 180.0
+            await self._system.action.goto_location(
+                pos["latitude_deg"],
+                pos["longitude_deg"],
+                pos["absolute_altitude_m"],
+                target_yaw,
+            )
+            return {
+                "status": "turning",
+                "target_heading_deg": round(target_yaw, 1),
+            }

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -52,11 +52,19 @@ class MavsdkAdapter:
     capabilities = {"move", "rotate", "altitude"}
     name = "mavsdk"
 
-    def __init__(self, system_address: str, connect_timeout_s: float = 20.0):
+    def __init__(
+        self,
+        system_address: str,
+        connect_timeout_s: float = 5.0,
+        command_timeout_s: float = 10.0,
+    ):
         self.system_address = system_address
         self.connect_timeout_s = connect_timeout_s
+        self.command_timeout_s = command_timeout_s
         self._system: Any = None
         self._connected = False
+        # Command calls are serialized, and reconnect takes this lock after the
+        # connection lock so a new System cannot replace one in active use.
         self._connection_lock = asyncio.Lock()
         self._command_lock = asyncio.Lock()
         self._telemetry_tasks: list[asyncio.Task] = []
@@ -72,23 +80,36 @@ class MavsdkAdapter:
         async with self._connection_lock:
             if self._connected:
                 return
-            await self._cancel_telemetry_tasks()
-            from mavsdk import System
+            async with self._command_lock:
+                if self._connected:
+                    return
+                await self._cancel_telemetry_tasks()
+                await self._release_system()
+                from mavsdk import System  # type: ignore[import-not-found]
 
-            system = System()
-            logger.info("MavsdkAdapter connecting to %s", self.system_address)
-            await system.connect(system_address=self.system_address)
+                system = System()
+                logger.info("MavsdkAdapter connecting to %s", self.system_address)
+                try:
+                    await asyncio.wait_for(
+                        system.connect(system_address=self.system_address),
+                        timeout=self.connect_timeout_s,
+                    )
 
-            async def _wait_connected() -> None:
-                async for state in system.core.connection_state():
-                    if state.is_connected:
-                        return
+                    async def _wait_connected() -> None:
+                        async for state in system.core.connection_state():
+                            if state.is_connected:
+                                return
 
-            await asyncio.wait_for(_wait_connected(), timeout=self.connect_timeout_s)
-            self._system = system
-            self._start_telemetry_cache()
-            self._connected = True
-            logger.info("MavsdkAdapter connected")
+                    await asyncio.wait_for(
+                        _wait_connected(), timeout=self.connect_timeout_s
+                    )
+                except BaseException:
+                    self._stop_system(system)
+                    raise
+                self._system = system
+                self._start_telemetry_cache()
+                self._connected = True
+                logger.info("MavsdkAdapter connected")
 
     def _start_telemetry_cache(self) -> None:
         system = self._system
@@ -125,9 +146,9 @@ class MavsdkAdapter:
             async for armed in system.telemetry.armed():
                 self._armed = armed
 
-        async def _watch(stream_name: str, subscription: Any) -> None:
+        async def _watch(stream_name: str, subscription_factory: Any) -> None:
             try:
-                await subscription
+                await subscription_factory()
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001 - MAVSDK stream errors vary by backend
@@ -138,16 +159,16 @@ class MavsdkAdapter:
                 self._mark_disconnected()
 
         subscriptions = {
-            "position": _position(),
-            "heading": _heading(),
-            "battery": _battery(),
-            "in_air": _in_air(),
-            "flight_mode": _flight_mode(),
-            "armed": _armed(),
+            "position": _position,
+            "heading": _heading,
+            "battery": _battery,
+            "in_air": _in_air,
+            "flight_mode": _flight_mode,
+            "armed": _armed,
         }
         self._telemetry_tasks.extend(
-            asyncio.create_task(_watch(name, subscription))
-            for name, subscription in subscriptions.items()
+            asyncio.create_task(_watch(name, subscription_factory))
+            for name, subscription_factory in subscriptions.items()
         )
 
     def _mark_disconnected(self) -> None:
@@ -172,10 +193,31 @@ class MavsdkAdapter:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._telemetry_tasks.clear()
 
+    @staticmethod
+    def _stop_system(system: Any) -> None:
+        """Release MAVSDK-Python's subprocess and gRPC resources.
+
+        MAVSDK-Python 2.x has no public close method. Its destructor invokes
+        this cleanup hook, but garbage collection is too late for reconnects.
+        """
+        stop = getattr(system, "_stop_mavsdk_server", None)
+        if callable(stop):
+            stop()
+
+    async def _release_system(self) -> None:
+        system, self._system = self._system, None
+        if system is not None:
+            self._stop_system(system)
+
     async def close(self) -> None:
-        await self._cancel_telemetry_tasks()
-        self._mark_disconnected()
-        self._system = None
+        async with self._connection_lock:
+            async with self._command_lock:
+                await self._cancel_telemetry_tasks()
+                self._mark_disconnected()
+                await self._release_system()
+
+    async def _run_action(self, awaitable: Any) -> Any:
+        return await asyncio.wait_for(awaitable, timeout=self.command_timeout_s)
 
     # -- BodyAdapter interface -------------------------------------------
 
@@ -195,9 +237,9 @@ class MavsdkAdapter:
     async def takeoff(self, altitude_m: float) -> dict[str, Any]:
         async with self._command_lock:
             system = self._system
-            await system.action.set_takeoff_altitude(altitude_m)
-            await system.action.arm()
-            await system.action.takeoff()
+            await self._run_action(system.action.set_takeoff_altitude(altitude_m))
+            await self._run_action(system.action.arm())
+            await self._run_action(system.action.takeoff())
             return {
                 "status": "taking_off",
                 "target_altitude_m": altitude_m,
@@ -206,12 +248,12 @@ class MavsdkAdapter:
 
     async def land(self) -> dict[str, Any]:
         async with self._command_lock:
-            await self._system.action.land()
+            await self._run_action(self._system.action.land())
             return {"status": "landing"}
 
     async def stop(self) -> dict[str, Any]:
         async with self._command_lock:
-            await self._system.action.hold()
+            await self._run_action(self._system.action.hold())
             return {
                 "status": "holding",
                 "message": "Motion stopped; holding position.",
@@ -219,7 +261,7 @@ class MavsdkAdapter:
 
     async def return_home(self) -> dict[str, Any]:
         async with self._command_lock:
-            await self._system.action.return_to_launch()
+            await self._run_action(self._system.action.return_to_launch())
             return {"status": "returning_home"}
 
     async def goto(
@@ -247,8 +289,10 @@ class MavsdkAdapter:
             else pos["absolute_altitude_m"]
         )
         yaw = self._heading_deg if self._heading_deg is not None else float("nan")
-        await self._system.action.goto_location(
-            latitude_deg, longitude_deg, target_abs, yaw
+        await self._run_action(
+            self._system.action.goto_location(
+                latitude_deg, longitude_deg, target_abs, yaw
+            )
         )
         return {
             "status": "en_route",
@@ -266,7 +310,9 @@ class MavsdkAdapter:
             pos = self._position
             if not pos:
                 return {"error": "No position fix yet; cannot move."}
-            yaw = self._heading_deg or 0.0
+            if self._heading_deg is None:
+                return {"error": "No heading fix yet; cannot move safely."}
+            yaw = self._heading_deg
             north, east = body_to_ned(forward_m, right_m, yaw)
             lat, lon = offset_latlon(
                 pos["latitude_deg"], pos["longitude_deg"], north, east
@@ -279,13 +325,16 @@ class MavsdkAdapter:
             pos = self._position
             if not pos:
                 return {"error": "No position fix yet; cannot turn."}
-            current = self._heading_deg or 0.0
-            target_yaw = (current + yaw_deg + 180.0) % 360.0 - 180.0
-            await self._system.action.goto_location(
-                pos["latitude_deg"],
-                pos["longitude_deg"],
-                pos["absolute_altitude_m"],
-                target_yaw,
+            if self._heading_deg is None:
+                return {"error": "No heading fix yet; cannot turn safely."}
+            target_yaw = (self._heading_deg + yaw_deg + 180.0) % 360.0 - 180.0
+            await self._run_action(
+                self._system.action.goto_location(
+                    pos["latitude_deg"],
+                    pos["longitude_deg"],
+                    pos["absolute_altitude_m"],
+                    target_yaw,
+                )
             )
             return {
                 "status": "turning",

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -217,7 +217,11 @@ class MavsdkAdapter:
                 await self._release_system()
 
     async def _run_action(self, awaitable: Any) -> Any:
-        return await asyncio.wait_for(awaitable, timeout=self.command_timeout_s)
+        try:
+            return await asyncio.wait_for(awaitable, timeout=self.command_timeout_s)
+        except TimeoutError:
+            self._mark_disconnected()
+            raise
 
     # -- BodyAdapter interface -------------------------------------------
 
@@ -317,7 +321,7 @@ class MavsdkAdapter:
             lat, lon = offset_latlon(
                 pos["latitude_deg"], pos["longitude_deg"], north, east
             )
-            target_rel = max(1.0, pos["relative_altitude_m"] + up_m)
+            target_rel = max(0.0, pos["relative_altitude_m"] + up_m)
             return await self._goto_unlocked(lat, lon, target_rel)
 
     async def turn(self, yaw_deg: float) -> dict[str, Any]:

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -286,13 +286,15 @@ class MavsdkAdapter:
         pos = self._position
         if not pos:
             return {"error": "No position fix yet; cannot goto."}
+        if self._heading_deg is None:
+            return {"error": "No heading fix yet; cannot goto safely."}
         home_abs = pos["absolute_altitude_m"] - pos["relative_altitude_m"]
         target_abs = (
             home_abs + altitude_m
             if altitude_m is not None
             else pos["absolute_altitude_m"]
         )
-        yaw = self._heading_deg if self._heading_deg is not None else float("nan")
+        yaw = self._heading_deg
         await self._run_action(
             self._system.action.goto_location(
                 latitude_deg, longitude_deg, target_abs, yaw

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -220,7 +220,13 @@ class MavsdkAdapter:
         try:
             return await asyncio.wait_for(awaitable, timeout=self.command_timeout_s)
         except TimeoutError:
-            self._mark_disconnected()
+            # The MAVSDK command is already on the vehicle. Dropping the
+            # adapter here would cancel telemetry and invite a reconnect
+            # while land/takeoff/goto is still executing.
+            logger.warning(
+                "MAVSDK action timed out after %.1fs; leaving adapter connected",
+                self.command_timeout_s,
+            )
             raise
 
     # -- BodyAdapter interface -------------------------------------------
@@ -240,6 +246,13 @@ class MavsdkAdapter:
 
     async def takeoff(self, altitude_m: float) -> dict[str, Any]:
         async with self._command_lock:
+            if self._in_air is True:
+                return {
+                    "error": (
+                        "Already in the air; refuse takeoff. "
+                        "Use body_move, body_goto, or body_land."
+                    )
+                }
             system = self._system
             await self._run_action(system.action.set_takeoff_altitude(altitude_m))
             await self._run_action(system.action.arm())

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -224,6 +224,9 @@ class SessionConfig:
     available_agents: list[str] = field(
         default_factory=lambda: ["alice", "gordon", "sven"]
     )
+    # Extra function-tool schemas appended to the built-in tool set —
+    # e.g. capability-gated body_* tools from gptme_voice.body.
+    extra_tools: list[dict] = field(default_factory=list)
     # When True, configure the OpenAI session to send/receive G.711 μ-law at
     # 8kHz directly. The Twilio bridge uses this to skip an otherwise-required
     # PCM16 ↔ μ-law and 8k ↔ 24k resampling round on the OpenAI branch.
@@ -624,6 +627,10 @@ class OpenAIRealtimeClient:
                 },
             ],
         }
+        if self.session_config.extra_tools:
+            session_params["tools"] = list(session_params["tools"]) + list(
+                self.session_config.extra_tools
+            )
         if self.session_config.output_speed is not None:
             session_params["output"] = {"speed": self.session_config.output_speed}
         reasoning = self._get_reasoning_config()

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -50,6 +50,28 @@ from .twilio_integration import (
 )
 from .xai_client import XAIRealtimeClient, _get_xai_api_key
 
+
+def _websocket_peer_host(websocket) -> str | None:
+    """Peer host from a Starlette (or mock) websocket.
+
+    Starlette's ``websocket.client`` is ``Address(host, port)`` — a namedtuple
+    with a ``.host`` field that is also a plain ``(host, port)`` tuple. ASGI
+    scope values and some test doubles are just the tuple. Accept both; never
+    assume ``.host`` exists.
+    """
+    client = getattr(websocket, "client", None)
+    if client is None:
+        return None
+    host = getattr(client, "host", None)
+    if isinstance(host, str) and host:
+        return host
+    if isinstance(client, tuple | list) and client:
+        first = client[0]
+        if isinstance(first, str) and first:
+            return first
+    return None
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -809,8 +831,7 @@ class VoiceServer:
                 caller_id or "unknown",
             )
             return None
-        client = getattr(websocket, "client", None)
-        host = getattr(client, "host", None)
+        host = _websocket_peer_host(websocket)
         if host in {"127.0.0.1", "::1", "localhost"}:
             return self.body_adapter
         logger.warning(

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -31,6 +31,7 @@ from starlette.responses import FileResponse, PlainTextResponse
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocketDisconnect
 
+from ..body import body_adapter_from_env, body_tool_schemas
 from ..handoff import HandoffWriter
 from .audio import AudioConverter
 from .openai_client import (
@@ -721,6 +722,15 @@ class VoiceServer:
             if handoff_agents_env
             else _default_agents
         )
+        # Optional physical body (BobBrain): registers capability-gated
+        # body_* tools when GPTME_VOICE_BODY_URL is set.
+        self.body_adapter = body_adapter_from_env()
+        if self.body_adapter is not None:
+            logger.info(
+                "Body adapter configured: %s (capabilities: %s)",
+                self.body_adapter.name,
+                sorted(self.body_adapter.capabilities) or "none",
+            )
         if handoff_dir_env:
             if not handoff_secret_env:
                 logger.warning(
@@ -1780,6 +1790,7 @@ class VoiceServer:
                         on_hangup=_twilio_hangup,
                         on_handoff=self._make_handoff_callback([caller_id], transcript),
                         transcript_provider=lambda: transcript,
+                        body_adapter=self.body_adapter,
                     )
                     realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -1874,6 +1885,8 @@ class VoiceServer:
             kwargs["output_speed"] = self.output_speed
         if self.openai_g711_passthrough:
             kwargs["g711_passthrough"] = True
+        if self.body_adapter is not None:
+            kwargs["extra_tools"] = body_tool_schemas(self.body_adapter)
         return SessionConfig(**kwargs)
 
     def _make_client(
@@ -2009,6 +2022,7 @@ class VoiceServer:
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
+                body_adapter=self.body_adapter,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -2099,6 +2113,7 @@ class VoiceServer:
                 on_hangup=_browser_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
+                body_adapter=self.body_adapter,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -772,7 +772,30 @@ class VoiceServer:
             routes.append(WebSocketRoute("/voice", self.handle_browser_websocket))
             routes.append(Route("/browser", self.serve_browser_client, methods=["GET"]))
 
-        self.app = Starlette(routes=routes)
+        self.app = Starlette(routes=routes, lifespan=self._lifespan)
+
+    @contextlib.asynccontextmanager
+    async def _lifespan(self, _app):
+        try:
+            yield
+        finally:
+            if self.body_adapter is not None:
+                await self.body_adapter.close()
+
+    def _body_adapter_for_websocket(self, websocket, *, transport: str):
+        """Expose motion tools only on authenticated or loopback transports."""
+        if self.body_adapter is None or transport == "twilio":
+            return self.body_adapter
+        client = getattr(websocket, "client", None)
+        host = getattr(client, "host", None)
+        if host in {"127.0.0.1", "::1", "localhost"}:
+            return self.body_adapter
+        logger.warning(
+            "Body tools disabled for unauthenticated %s client %s",
+            transport,
+            host or "unknown",
+        )
+        return None
 
     def _recent_call_path(self, caller_id: str) -> Path:
         digest = hashlib.sha256(caller_id.encode("utf-8")).hexdigest()[:16]
@@ -2022,7 +2045,9 @@ class VoiceServer:
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
-                body_adapter=self.body_adapter,
+                body_adapter=self._body_adapter_for_websocket(
+                    websocket, transport="local"
+                ),
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -2113,7 +2138,9 @@ class VoiceServer:
                 on_hangup=_browser_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
-                body_adapter=self.body_adapter,
+                body_adapter=self._body_adapter_for_websocket(
+                    websocket, transport="browser"
+                ),
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -787,8 +787,10 @@ class VoiceServer:
         # One-shot body-tool grants minted by the signed /incoming webhook.
         # The /twilio WebSocket is unauthenticated; customParameters.from_number
         # is attacker-controlled, so body tools must not key off it. Token ->
-        # (from_number, expires_monotonic).
-        self._twilio_body_grants: dict[str, tuple[str, float]] = {}
+        # (from_number, call_sid, expires_monotonic). CallSid is bound from the
+        # signed webhook and is not copied into TwiML, so a stolen grant cannot
+        # be replayed onto a different call.
+        self._twilio_body_grants: dict[str, tuple[str, str, float]] = {}
         self._twilio_body_grant_ttl_s = 120.0
 
         routes = [
@@ -828,24 +830,25 @@ class VoiceServer:
         now = time.monotonic()
         expired = [
             token
-            for token, (_, expires) in self._twilio_body_grants.items()
+            for token, (*_, expires) in self._twilio_body_grants.items()
             if now > expires
         ]
         for token in expired:
             self._twilio_body_grants.pop(token, None)
 
-    def _mint_twilio_body_grant(self, from_number: str) -> str:
+    def _mint_twilio_body_grant(self, from_number: str, call_sid: str = "") -> str:
         """Mint a one-shot token proving /incoming authorized this caller."""
         self._expire_twilio_body_grants()
         token = secrets.token_urlsafe(32)
         self._twilio_body_grants[token] = (
             from_number,
+            call_sid,
             time.monotonic() + self._twilio_body_grant_ttl_s,
         )
         return token
 
-    def _consume_twilio_body_grant(self, token: str | None) -> str | None:
-        """Return the from_number bound to a live grant, or None.
+    def _consume_twilio_body_grant(self, token: str | None) -> tuple[str, str] | None:
+        """Return ``(from_number, call_sid)`` bound to a live grant, or None.
 
         Single-use: a replay or a raw WebSocket that invents customParameters
         cannot satisfy this. Expired and unknown tokens fail closed.
@@ -856,10 +859,10 @@ class VoiceServer:
         entry = self._twilio_body_grants.pop(token, None)
         if entry is None:
             return None
-        from_number, expires = entry
+        from_number, call_sid, expires = entry
         if time.monotonic() > expires:
             return None
-        return from_number
+        return from_number, call_sid
 
     def _body_adapter_for_websocket(
         self, websocket, *, transport: str, caller_id: str | None = None
@@ -1691,9 +1694,16 @@ class VoiceServer:
         """
         form_params = dict(await request.form())
         from_number = form_params.get("From", "")
+        incoming_call_sid = form_params.get("CallSid", "") or form_params.get(
+            "call_sid", ""
+        )
 
         # Validate Twilio webhook signature when auth token is configured.
         # Skip in dev environments where TWILIO_AUTH_TOKEN is absent.
+        # Body-tool grants are fail-closed: they are only minted when this
+        # request was signature-validated. An unsigned /incoming must never
+        # mint a grant from a spoofable From field.
+        signature_validated = False
         auth_token = _get_config_env("TWILIO_AUTH_TOKEN")
         if auth_token:
             from twilio.request_validator import RequestValidator
@@ -1706,6 +1716,7 @@ class VoiceServer:
             ):
                 logger.warning("Rejected request with invalid Twilio signature")
                 return PlainTextResponse("Forbidden", status_code=403)
+            signature_validated = True
 
         # Allowlist: only accept calls from known numbers.
         # Set TWILIO_CALLER_ALLOWLIST to a comma-separated list of E.164 numbers.
@@ -1747,9 +1758,13 @@ class VoiceServer:
         if from_number:
             custom_params["from_number"] = from_number
             # Body tools on /twilio must not trust client-supplied from_number.
-            # Mint a one-shot grant here (signed webhook) and require it on start.
-            if self._twilio_body_caller_allowed(from_number):
-                custom_params["body_grant"] = self._mint_twilio_body_grant(from_number)
+            # Mint a one-shot grant here only after signature validation, and
+            # bind it to CallSid (kept off TwiML so a stolen grant cannot be
+            # replayed onto a different start event).
+            if signature_validated and self._twilio_body_caller_allowed(from_number):
+                custom_params["body_grant"] = self._mint_twilio_body_grant(
+                    from_number, incoming_call_sid
+                )
         twiml = build_connect_stream_twiml(ws_url, custom_params or None)
         return PlainTextResponse(twiml, media_type="text/xml")
 
@@ -1848,9 +1863,26 @@ class VoiceServer:
 
                     # Body-tool authorization is the signed-webhook grant, not
                     # customParameters.from_number (attacker-controlled on /twilio).
-                    granted_from = self._consume_twilio_body_grant(
+                    grant = self._consume_twilio_body_grant(
                         custom_params.get("body_grant") or None
                     )
+                    granted_from: str | None = None
+                    if grant is not None:
+                        grant_from, grant_sid = grant
+                        if grant_from != from_number:
+                            logger.warning(
+                                "Twilio body grant From mismatch: grant=%s start=%s",
+                                grant_from,
+                                from_number,
+                            )
+                        elif grant_sid and grant_sid != call_sid:
+                            logger.warning(
+                                "Twilio body grant CallSid mismatch: grant=%s start=%s",
+                                grant_sid,
+                                call_sid,
+                            )
+                        else:
+                            granted_from = grant_from
                     body_adapter = self._body_adapter_for_websocket(
                         websocket,
                         transport="twilio",

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import shlex
 import subprocess
 import time
@@ -783,6 +784,12 @@ class VoiceServer:
         self._prewarm_sessions: dict[str, tuple[OpenAIRealtimeClient, float]] = {}
         # Max seconds a pre-warm session is kept before being discarded
         self._prewarm_ttl_seconds = 30
+        # One-shot body-tool grants minted by the signed /incoming webhook.
+        # The /twilio WebSocket is unauthenticated; customParameters.from_number
+        # is attacker-controlled, so body tools must not key off it. Token ->
+        # (from_number, expires_monotonic).
+        self._twilio_body_grants: dict[str, tuple[str, float]] = {}
+        self._twilio_body_grant_ttl_s = 120.0
 
         routes = [
             Route("/", self.health_check, methods=["GET"]),
@@ -816,6 +823,43 @@ class VoiceServer:
             return False
         allowlist = {n.strip() for n in raw.split(",") if n.strip()}
         return caller_id in allowlist
+
+    def _expire_twilio_body_grants(self) -> None:
+        now = time.monotonic()
+        expired = [
+            token
+            for token, (_, expires) in self._twilio_body_grants.items()
+            if now > expires
+        ]
+        for token in expired:
+            self._twilio_body_grants.pop(token, None)
+
+    def _mint_twilio_body_grant(self, from_number: str) -> str:
+        """Mint a one-shot token proving /incoming authorized this caller."""
+        self._expire_twilio_body_grants()
+        token = secrets.token_urlsafe(32)
+        self._twilio_body_grants[token] = (
+            from_number,
+            time.monotonic() + self._twilio_body_grant_ttl_s,
+        )
+        return token
+
+    def _consume_twilio_body_grant(self, token: str | None) -> str | None:
+        """Return the from_number bound to a live grant, or None.
+
+        Single-use: a replay or a raw WebSocket that invents customParameters
+        cannot satisfy this. Expired and unknown tokens fail closed.
+        """
+        self._expire_twilio_body_grants()
+        if not token:
+            return None
+        entry = self._twilio_body_grants.pop(token, None)
+        if entry is None:
+            return None
+        from_number, expires = entry
+        if time.monotonic() > expires:
+            return None
+        return from_number
 
     def _body_adapter_for_websocket(
         self, websocket, *, transport: str, caller_id: str | None = None
@@ -1702,6 +1746,10 @@ class VoiceServer:
         custom_params: dict[str, str] = {}
         if from_number:
             custom_params["from_number"] = from_number
+            # Body tools on /twilio must not trust client-supplied from_number.
+            # Mint a one-shot grant here (signed webhook) and require it on start.
+            if self._twilio_body_caller_allowed(from_number):
+                custom_params["body_grant"] = self._mint_twilio_body_grant(from_number)
         twiml = build_connect_stream_twiml(ws_url, custom_params or None)
         return PlainTextResponse(twiml, media_type="text/xml")
 
@@ -1798,17 +1846,31 @@ class VoiceServer:
                         )
                     )
 
-                    # Try to claim a pre-warmed session (no handoff/standup for inbound fresh calls)
-                    prewarm_eligible = (
-                        from_number and not handoff_id and not standup_brief
-                    )
-                    prewarm_client = (
-                        self._claim_prewarm(from_number) if prewarm_eligible else None
+                    # Body-tool authorization is the signed-webhook grant, not
+                    # customParameters.from_number (attacker-controlled on /twilio).
+                    granted_from = self._consume_twilio_body_grant(
+                        custom_params.get("body_grant") or None
                     )
                     body_adapter = self._body_adapter_for_websocket(
                         websocket,
                         transport="twilio",
-                        caller_id=from_number or None,
+                        caller_id=granted_from,
+                    )
+
+                    # Try to claim a pre-warmed session (no handoff/standup for inbound fresh calls)
+                    prewarm_eligible = (
+                        from_number and not handoff_id and not standup_brief
+                    )
+                    # A spoofed start event must not steal a body-capable prewarm.
+                    if (
+                        prewarm_eligible
+                        and self.body_adapter is not None
+                        and self._twilio_body_caller_allowed(from_number)
+                        and granted_from is None
+                    ):
+                        prewarm_eligible = False
+                    prewarm_client = (
+                        self._claim_prewarm(from_number) if prewarm_eligible else None
                     )
 
                     if prewarm_client is not None:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1891,6 +1891,8 @@ class VoiceServer:
         self,
         instructions: str,
         initial_response_instructions: str = "",
+        *,
+        include_body_tools: bool = True,
     ) -> SessionConfig:
         """Build a SessionConfig with optional runtime overrides."""
         kwargs: dict = dict(
@@ -1908,7 +1910,7 @@ class VoiceServer:
             kwargs["output_speed"] = self.output_speed
         if self.openai_g711_passthrough:
             kwargs["g711_passthrough"] = True
-        if self.body_adapter is not None:
+        if include_body_tools and self.body_adapter is not None:
             kwargs["extra_tools"] = body_tool_schemas(self.body_adapter)
         return SessionConfig(**kwargs)
 
@@ -2020,7 +2022,13 @@ class VoiceServer:
                 caller_id=caller_id,
                 handoff_id=handoff_id,
             )
-            session_cfg = self._build_session_config(instructions=instructions)
+            body_adapter = self._body_adapter_for_websocket(
+                websocket, transport="local"
+            )
+            session_cfg = self._build_session_config(
+                instructions=instructions,
+                include_body_tools=body_adapter is not None,
+            )
             on_ai_transcript, on_user_transcript, _local_hangup = (
                 self._make_transcript_callbacks(
                     transcript=transcript,
@@ -2045,9 +2053,7 @@ class VoiceServer:
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
-                body_adapter=self._body_adapter_for_websocket(
-                    websocket, transport="local"
-                ),
+                body_adapter=body_adapter,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -2113,7 +2119,13 @@ class VoiceServer:
                 caller_id=caller_id,
                 handoff_id=handoff_id,
             )
-            session_cfg = self._build_session_config(instructions=instructions)
+            body_adapter = self._body_adapter_for_websocket(
+                websocket, transport="browser"
+            )
+            session_cfg = self._build_session_config(
+                instructions=instructions,
+                include_body_tools=body_adapter is not None,
+            )
             on_ai_transcript, on_user_transcript, _browser_hangup = (
                 self._make_transcript_callbacks(
                     transcript=transcript,
@@ -2138,9 +2150,7 @@ class VoiceServer:
                 on_hangup=_browser_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
-                body_adapter=self._body_adapter_for_websocket(
-                    websocket, transport="browser"
-                ),
+                body_adapter=body_adapter,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -793,10 +793,14 @@ class VoiceServer:
         # reconnects resend the same start customParameters, and popping would
         # leave an airborne vehicle with no body_stop. Mint TTL covers the
         # /incoming-to-first-start window; first successful consume pins the
-        # grant (expires=inf) until Twilio stop, hangup, or process restart.
-        # Do not revoke on websocket drop.
+        # grant (expires=inf) until Twilio stop, hangup, idle-disconnect, or
+        # process restart. Do not revoke on websocket drop itself — that is
+        # the reconnect path — but schedule an idle revoke so a call that
+        # never sends ``stop`` cannot leave a live bearer token forever.
         self._twilio_body_grants: dict[str, tuple[str, str, float]] = {}
         self._twilio_body_grant_ttl_s = 120.0
+        self._twilio_body_grant_idle_s = 90.0
+        self._twilio_grant_idle_tasks: dict[str, asyncio.Task[None]] = {}
 
         routes = [
             Route("/", self.health_check, methods=["GET"]),
@@ -815,6 +819,7 @@ class VoiceServer:
         try:
             yield
         finally:
+            await self._cancel_all_twilio_body_grant_idle_revokes()
             if self.body_adapter is not None:
                 await self.body_adapter.close()
 
@@ -896,6 +901,7 @@ class VoiceServer:
         """Drop grants bound to a CallSid. Twilio ``stop`` is the real call end."""
         if not call_sid:
             return
+        self._cancel_twilio_body_grant_idle_revoke(call_sid)
         to_drop = [
             token
             for token, (_from, sid, _exp) in self._twilio_body_grants.items()
@@ -903,6 +909,69 @@ class VoiceServer:
         ]
         for token in to_drop:
             self._twilio_body_grants.pop(token, None)
+
+    def _cancel_twilio_body_grant_idle_revoke(self, call_sid: str | None) -> None:
+        """Cancel a pending idle-disconnect revoke for this CallSid."""
+        if not call_sid:
+            return
+        task = self._twilio_grant_idle_tasks.pop(call_sid, None)
+        if task is None or task.done():
+            return
+        # The idle task itself calls revoke; don't cancel the running task.
+        try:
+            if task is asyncio.current_task():
+                return
+        except RuntimeError:
+            pass
+        task.cancel()
+
+    async def _cancel_all_twilio_body_grant_idle_revokes(self) -> None:
+        tasks = [
+            self._twilio_grant_idle_tasks.pop(sid)
+            for sid in list(self._twilio_grant_idle_tasks)
+        ]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _schedule_twilio_body_grant_idle_revoke(self, call_sid: str | None) -> None:
+        """Revoke pinned grants if this CallSid does not reconnect.
+
+        Twilio Media Stream reconnects drop the websocket without ``stop``.
+        Revoking in ``finally`` would take ``body_stop`` away mid-flight.
+        Waiting ``_twilio_body_grant_idle_s`` then revoking iff the CallSid
+        is still absent from ``_connections`` bounds the leak when neither
+        ``stop`` nor hangup arrives.
+        """
+        if not call_sid:
+            return
+        if not any(
+            sid == call_sid for _from, sid, _exp in self._twilio_body_grants.values()
+        ):
+            return
+        self._cancel_twilio_body_grant_idle_revoke(call_sid)
+        delay = self._twilio_body_grant_idle_s
+
+        async def _idle_revoke() -> None:
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+            if call_sid in self._connections:
+                return
+            logger.info(
+                "Revoking Twilio body grants for %s after idle disconnect",
+                call_sid,
+            )
+            self._revoke_twilio_body_grants_for_call(call_sid)
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._twilio_grant_idle_tasks[call_sid] = loop.create_task(_idle_revoke())
 
     def _body_adapter_for_websocket(
         self, websocket, *, transport: str, caller_id: str | None = None
@@ -2014,6 +2083,8 @@ class VoiceServer:
                         await realtime_client.connect()
 
                     self._connections[call_sid] = (websocket, realtime_client)
+                    # A reconnect arrived inside the idle window — keep the grant.
+                    self._cancel_twilio_body_grant_idle_revoke(call_sid)
 
                 elif event == "media":
                     # Audio chunk from Twilio
@@ -2036,6 +2107,7 @@ class VoiceServer:
                     # Real call end — revoke so a reconnect after hangup cannot
                     # re-attach motion tools with the stolen start parameters.
                     # Do not revoke in ``finally``: websocket drop is a reconnect.
+                    # Idle-revoke in ``finally`` covers the drop-without-stop path.
                     self._revoke_twilio_body_grants_for_call(call_sid)
                     break
 
@@ -2055,6 +2127,10 @@ class VoiceServer:
                 await self._disconnect_realtime_client(realtime_client)
             if call_sid and call_sid in self._connections:
                 del self._connections[call_sid]
+            # Websocket drop ≠ call end. If this CallSid does not reconnect
+            # inside the idle window, drop the pinned grant so an abrupt
+            # hangup that skipped ``stop`` cannot leave a live bearer token.
+            self._schedule_twilio_body_grant_idle_revoke(call_sid)
             await self._on_call_end(
                 caller_id,
                 "twilio",

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -791,8 +791,10 @@ class VoiceServer:
         # signed webhook and is not copied into TwiML, so a stolen grant cannot
         # be replayed onto a different call. Consume does not pop: Twilio
         # reconnects resend the same start customParameters, and popping would
-        # leave an airborne vehicle with no body_stop. Revoke on Twilio stop
-        # (real call end) or TTL; do not revoke on websocket drop.
+        # leave an airborne vehicle with no body_stop. Mint TTL covers the
+        # /incoming-to-first-start window; first successful consume pins the
+        # grant (expires=inf) until Twilio stop, hangup, or process restart.
+        # Do not revoke on websocket drop.
         self._twilio_body_grants: dict[str, tuple[str, str, float]] = {}
         self._twilio_body_grant_ttl_s = 120.0
 
@@ -857,8 +859,8 @@ class VoiceServer:
         ``start`` customParameters, so popping the token would leave an
         airborne vehicle with no ``body_stop``. Replay onto a different
         call is still fail-closed via CallSid binding. Unknown, expired,
-        and revoked tokens fail closed. The grant is removed on Twilio
-        ``stop`` or TTL expiry.
+        and revoked tokens fail closed. Mint TTL covers first start;
+        a successful consume pins the grant until Twilio ``stop`` or hangup.
         """
         self._expire_twilio_body_grants()
         if not token:
@@ -870,6 +872,10 @@ class VoiceServer:
         if time.monotonic() > expires:
             self._twilio_body_grants.pop(token, None)
             return None
+        # Pin after first start so a long call's later reconnect still
+        # has body_stop. Unused grants still expire at mint TTL.
+        if expires != float("inf"):
+            self._twilio_body_grants[token] = (from_number, call_sid, float("inf"))
         return from_number, call_sid
 
     def _revoke_twilio_body_grants_for_call(self, call_sid: str | None) -> None:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -782,10 +782,33 @@ class VoiceServer:
             if self.body_adapter is not None:
                 await self.body_adapter.close()
 
-    def _body_adapter_for_websocket(self, websocket, *, transport: str):
-        """Expose motion tools only on authenticated or loopback transports."""
-        if self.body_adapter is None or transport == "twilio":
-            return self.body_adapter
+    def _twilio_body_caller_allowed(self, caller_id: str | None) -> bool:
+        """Twilio body tools require an explicit caller allowlist match.
+
+        Twilio's request signature proves the webhook came from Twilio, not
+        that the human on the line is authorized to fly a vehicle. Fail
+        closed: no allowlist, or a caller not on it, means no motion tools.
+        """
+        raw = _get_config_env("TWILIO_CALLER_ALLOWLIST")
+        if not raw or not caller_id:
+            return False
+        allowlist = {n.strip() for n in raw.split(",") if n.strip()}
+        return caller_id in allowlist
+
+    def _body_adapter_for_websocket(
+        self, websocket, *, transport: str, caller_id: str | None = None
+    ):
+        """Expose motion tools only on loopback or allowlisted Twilio callers."""
+        if self.body_adapter is None:
+            return None
+        if transport == "twilio":
+            if self._twilio_body_caller_allowed(caller_id):
+                return self.body_adapter
+            logger.warning(
+                "Body tools disabled for Twilio caller %s (not on TWILIO_CALLER_ALLOWLIST)",
+                caller_id or "unknown",
+            )
+            return None
         client = getattr(websocket, "client", None)
         host = getattr(client, "host", None)
         if host in {"127.0.0.1", "::1", "localhost"}:
@@ -1175,6 +1198,7 @@ class VoiceServer:
                     if bootstrap.should_greet_first
                     else ""
                 ),
+                include_body_tools=self._twilio_body_caller_allowed(from_number),
             )
             client = self._make_client(session_cfg, hold_initial_response=True)
             await client.connect()
@@ -1760,6 +1784,11 @@ class VoiceServer:
                     prewarm_client = (
                         self._claim_prewarm(from_number) if prewarm_eligible else None
                     )
+                    body_adapter = self._body_adapter_for_websocket(
+                        websocket,
+                        transport="twilio",
+                        caller_id=from_number or None,
+                    )
 
                     if prewarm_client is not None:
                         realtime_client = prewarm_client
@@ -1784,6 +1813,7 @@ class VoiceServer:
                         session_cfg = self._build_session_config(
                             instructions=instructions,
                             initial_response_instructions=initial_response_instructions,
+                            include_body_tools=body_adapter is not None,
                         )
                         realtime_client = self._make_client(
                             session_cfg,
@@ -1813,7 +1843,7 @@ class VoiceServer:
                         on_hangup=_twilio_hangup,
                         on_handoff=self._make_handoff_callback([caller_id], transcript),
                         transcript_provider=lambda: transcript,
-                        body_adapter=self.body_adapter,
+                        body_adapter=body_adapter,
                     )
                     realtime_client.on_function_call = tool_bridge.handle_function_call
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -784,12 +784,15 @@ class VoiceServer:
         self._prewarm_sessions: dict[str, tuple[OpenAIRealtimeClient, float]] = {}
         # Max seconds a pre-warm session is kept before being discarded
         self._prewarm_ttl_seconds = 30
-        # One-shot body-tool grants minted by the signed /incoming webhook.
+        # Call-scoped body-tool grants minted by the signed /incoming webhook.
         # The /twilio WebSocket is unauthenticated; customParameters.from_number
         # is attacker-controlled, so body tools must not key off it. Token ->
         # (from_number, call_sid, expires_monotonic). CallSid is bound from the
         # signed webhook and is not copied into TwiML, so a stolen grant cannot
-        # be replayed onto a different call.
+        # be replayed onto a different call. Consume does not pop: Twilio
+        # reconnects resend the same start customParameters, and popping would
+        # leave an airborne vehicle with no body_stop. Revoke on Twilio stop
+        # (real call end) or TTL; do not revoke on websocket drop.
         self._twilio_body_grants: dict[str, tuple[str, str, float]] = {}
         self._twilio_body_grant_ttl_s = 120.0
 
@@ -837,7 +840,7 @@ class VoiceServer:
             self._twilio_body_grants.pop(token, None)
 
     def _mint_twilio_body_grant(self, from_number: str, call_sid: str = "") -> str:
-        """Mint a one-shot token proving /incoming authorized this caller."""
+        """Mint a call-scoped token proving /incoming authorized this caller."""
         self._expire_twilio_body_grants()
         token = secrets.token_urlsafe(32)
         self._twilio_body_grants[token] = (
@@ -850,19 +853,36 @@ class VoiceServer:
     def _consume_twilio_body_grant(self, token: str | None) -> tuple[str, str] | None:
         """Return ``(from_number, call_sid)`` bound to a live grant, or None.
 
-        Single-use: a replay or a raw WebSocket that invents customParameters
-        cannot satisfy this. Expired and unknown tokens fail closed.
+        Call-scoped, not single-use: Twilio reconnects resend the same
+        ``start`` customParameters, so popping the token would leave an
+        airborne vehicle with no ``body_stop``. Replay onto a different
+        call is still fail-closed via CallSid binding. Unknown, expired,
+        and revoked tokens fail closed. The grant is removed on Twilio
+        ``stop`` or TTL expiry.
         """
         self._expire_twilio_body_grants()
         if not token:
             return None
-        entry = self._twilio_body_grants.pop(token, None)
+        entry = self._twilio_body_grants.get(token)
         if entry is None:
             return None
         from_number, call_sid, expires = entry
         if time.monotonic() > expires:
+            self._twilio_body_grants.pop(token, None)
             return None
         return from_number, call_sid
+
+    def _revoke_twilio_body_grants_for_call(self, call_sid: str | None) -> None:
+        """Drop grants bound to a CallSid. Twilio ``stop`` is the real call end."""
+        if not call_sid:
+            return
+        to_drop = [
+            token
+            for token, (_from, sid, _exp) in self._twilio_body_grants.items()
+            if sid == call_sid
+        ]
+        for token in to_drop:
+            self._twilio_body_grants.pop(token, None)
 
     def _body_adapter_for_websocket(
         self, websocket, *, transport: str, caller_id: str | None = None
@@ -1758,7 +1778,7 @@ class VoiceServer:
         if from_number:
             custom_params["from_number"] = from_number
             # Body tools on /twilio must not trust client-supplied from_number.
-            # Mint a one-shot grant here only after signature validation, and
+            # Mint a call-scoped grant here only after signature validation, and
             # bind it to CallSid (kept off TwiML so a stolen grant cannot be
             # replayed onto a different start event).
             if signature_validated and self._twilio_body_caller_allowed(from_number):
@@ -1987,7 +2007,10 @@ class VoiceServer:
                                 await realtime_client.send_audio(pcm_data)
 
                 elif event == "stop":
-                    # Call ended
+                    # Real call end — revoke so a reconnect after hangup cannot
+                    # re-attach motion tools with the stolen start parameters.
+                    # Do not revoke in ``finally``: websocket drop is a reconnect.
+                    self._revoke_twilio_body_grants_for_call(call_sid)
                     break
 
         except WebSocketDisconnect:
@@ -2388,6 +2411,9 @@ class VoiceServer:
             call_sid,
             reason or "<none>",
         )
+        # Hangup is a real call end even if Twilio never sends ``stop``.
+        if "twilio" in source:
+            self._revoke_twilio_body_grants_for_call(call_sid)
 
         # Fire-and-forget Twilio REST API call termination (authoritative kill).
         # Do this BEFORE the farewell delay so the call stops accepting audio

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -841,8 +841,18 @@ class VoiceServer:
         for token in expired:
             self._twilio_body_grants.pop(token, None)
 
-    def _mint_twilio_body_grant(self, from_number: str, call_sid: str = "") -> str:
-        """Mint a call-scoped token proving /incoming authorized this caller."""
+    def _mint_twilio_body_grant(self, from_number: str, call_sid: str) -> str:
+        """Mint a call-scoped token proving /incoming authorized this caller.
+
+        Both From and CallSid must be non-empty. An empty CallSid would skip
+        the consume-time bind and let a stolen grant replay onto any start
+        event that presents the same From.
+        """
+        from_number = from_number.strip()
+        call_sid = call_sid.strip()
+        if not from_number or not call_sid:
+            logger.warning("Refusing Twilio body grant with empty From or CallSid")
+            return ""
         self._expire_twilio_body_grants()
         token = secrets.token_urlsafe(32)
         self._twilio_body_grants[token] = (
@@ -869,6 +879,10 @@ class VoiceServer:
         if entry is None:
             return None
         from_number, call_sid, expires = entry
+        if not from_number or not call_sid:
+            # Empty CallSid skips the start-event bind; drop the grant.
+            self._twilio_body_grants.pop(token, None)
+            return None
         if time.monotonic() > expires:
             self._twilio_body_grants.pop(token, None)
             return None
@@ -1719,10 +1733,10 @@ class VoiceServer:
         Twilio will then open a Media Stream WebSocket to /twilio.
         """
         form_params = dict(await request.form())
-        from_number = form_params.get("From", "")
-        incoming_call_sid = form_params.get("CallSid", "") or form_params.get(
-            "call_sid", ""
-        )
+        from_number = (form_params.get("From", "") or "").strip()
+        incoming_call_sid = (
+            form_params.get("CallSid", "") or form_params.get("call_sid", "") or ""
+        ).strip()
 
         # Validate Twilio webhook signature when auth token is configured.
         # Skip in dev environments where TWILIO_AUTH_TOKEN is absent.
@@ -1787,10 +1801,16 @@ class VoiceServer:
             # Mint a call-scoped grant here only after signature validation, and
             # bind it to CallSid (kept off TwiML so a stolen grant cannot be
             # replayed onto a different start event).
-            if signature_validated and self._twilio_body_caller_allowed(from_number):
-                custom_params["body_grant"] = self._mint_twilio_body_grant(
+            if (
+                signature_validated
+                and incoming_call_sid
+                and self._twilio_body_caller_allowed(from_number)
+            ):
+                grant_token = self._mint_twilio_body_grant(
                     from_number, incoming_call_sid
                 )
+                if grant_token:
+                    custom_params["body_grant"] = grant_token
         twiml = build_connect_stream_twiml(ws_url, custom_params or None)
         return PlainTextResponse(twiml, media_type="text/xml")
 
@@ -1901,7 +1921,7 @@ class VoiceServer:
                                 grant_from,
                                 from_number,
                             )
-                        elif grant_sid and grant_sid != call_sid:
+                        elif not grant_sid or grant_sid != call_sid:
                             logger.warning(
                                 "Twilio body grant CallSid mismatch: grant=%s start=%s",
                                 grant_sid,

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -979,7 +979,7 @@ class GptmeToolBridge:
 
         try:
             await _call(adapter.ensure_connected())
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.error(
                 "Body adapter connect timed out after %.1fs",
                 self.body_call_timeout_s,
@@ -1022,7 +1022,18 @@ class GptmeToolBridge:
                 )
                 position = adapter.telemetry().get("position") or {}
                 current_altitude = position.get("relative_altitude_m")
-                if current_altitude is not None:
+                if current_altitude is None:
+                    # Without a relative-altitude fix the absolute ceiling
+                    # cannot be enforced. Climbing is fail-closed; descent
+                    # and level flight still go through (clamped up <= 0).
+                    if up > 0:
+                        return {
+                            "error": (
+                                "Cannot climb: current altitude unknown. "
+                                "Refuse to exceed the altitude ceiling without telemetry."
+                            )
+                        }
+                else:
                     # Floor at 0 m so "descend" on the ground is a no-op, not
                     # a forced climb to the old 1 m takeoff floor.
                     target_altitude = max(
@@ -1046,7 +1057,7 @@ class GptmeToolBridge:
                 return await _call(adapter.turn(yaw))
         except (KeyError, TypeError, ValueError) as e:
             return {"error": f"Invalid arguments for {name}: {e}"}
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.error(
                 "Body call %s timed out after %.1fs",
                 name,

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -13,6 +13,7 @@ conversation when ready.
 
 import asyncio
 import logging
+import math
 import os
 import shutil
 import tempfile
@@ -139,11 +140,11 @@ class GptmeToolBridge:
         self.on_handoff = on_handoff
         self.transcript_provider = transcript_provider
         self.body_adapter = body_adapter
-        self.body_max_altitude_m = float(
-            os.environ.get("GPTME_VOICE_BODY_MAX_ALT_M", "30")
+        self.body_max_altitude_m = self._parse_env_float(
+            "GPTME_VOICE_BODY_MAX_ALT_M", default=30.0, minimum=1.0
         )
-        self.body_max_move_m = float(
-            os.environ.get("GPTME_VOICE_BODY_MAX_MOVE_M", "50")
+        self.body_max_move_m = self._parse_env_float(
+            "GPTME_VOICE_BODY_MAX_MOVE_M", default=50.0, minimum=0.1
         )
         legacy_env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         env_model_fast = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_FAST")
@@ -178,6 +179,26 @@ class GptmeToolBridge:
         except ValueError:
             logger.warning("%s=%r is not an integer; using %s", name, value, default)
             return default
+
+    @staticmethod
+    def _parse_env_float(name: str, *, default: float, minimum: float) -> float:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        try:
+            parsed = float(value)
+        except ValueError:
+            parsed = float("nan")
+        if not math.isfinite(parsed) or parsed < minimum:
+            logger.warning(
+                "%s=%r must be a finite number >= %s; using %s",
+                name,
+                value,
+                minimum,
+                default,
+            )
+            return default
+        return parsed
 
     @staticmethod
     def _extract_error_text(stdout: str, stderr: str, output: str) -> str:
@@ -944,8 +965,7 @@ class GptmeToolBridge:
         if adapter is None:
             return {
                 "error": (
-                    "No body is connected to this session, so there is "
-                    "nothing to move."
+                    "No body is connected to this session, so there is nothing to move."
                 )
             }
         try:
@@ -978,6 +998,14 @@ class GptmeToolBridge:
                 up = self._clamp(
                     float(arguments.get("up_m", 0.0)), self.body_max_altitude_m
                 )
+                position = adapter.telemetry().get("position") or {}
+                current_altitude = position.get("relative_altitude_m")
+                if current_altitude is not None:
+                    target_altitude = max(
+                        1.0,
+                        min(self.body_max_altitude_m, float(current_altitude) + up),
+                    )
+                    up = target_altitude - float(current_altitude)
                 return await adapter.move(forward, right, up)
             if name == "body_goto" and "move" in caps:
                 lat = float(arguments["latitude_deg"])

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -998,6 +998,13 @@ class GptmeToolBridge:
             if name == "body_return_home" and "move" in caps:
                 return await _call(adapter.return_home())
             if name == "body_takeoff" and "altitude" in caps:
+                if adapter.telemetry().get("in_air") is True:
+                    return {
+                        "error": (
+                            "Already in the air; refuse takeoff. "
+                            "Use body_move, body_goto, or body_land."
+                        )
+                    }
                 altitude = float(arguments.get("altitude_m", 2.5))
                 altitude = max(1.0, min(self.body_max_altitude_m, altitude))
                 return await _call(adapter.takeoff(altitude))

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -1016,8 +1016,10 @@ class GptmeToolBridge:
                 position = adapter.telemetry().get("position") or {}
                 current_altitude = position.get("relative_altitude_m")
                 if current_altitude is not None:
+                    # Floor at 0 m so "descend" on the ground is a no-op, not
+                    # a forced climb to the old 1 m takeoff floor.
                     target_altitude = max(
-                        1.0,
+                        0.0,
                         min(self.body_max_altitude_m, float(current_altitude) + up),
                     )
                     up = target_altitude - float(current_altitude)

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -21,12 +21,14 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Awaitable, Callable, Sequence
+from typing import TYPE_CHECKING, Awaitable, Callable, Sequence, TypeVar
 
 if TYPE_CHECKING:
     from ..body import BodyAdapter
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 # Max task-description length to echo back when reporting status
 _MAX_TASK_PREVIEW = 120
@@ -145,6 +147,9 @@ class GptmeToolBridge:
         )
         self.body_max_move_m = self._parse_env_float(
             "GPTME_VOICE_BODY_MAX_MOVE_M", default=50.0, minimum=0.1
+        )
+        self.body_call_timeout_s = self._parse_env_float(
+            "GPTME_VOICE_BODY_CALL_TIMEOUT_S", default=12.0, minimum=0.1
         )
         legacy_env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         env_model_fast = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_FAST")
@@ -968,8 +973,18 @@ class GptmeToolBridge:
                     "No body is connected to this session, so there is nothing to move."
                 )
             }
+
+        async def _call(awaitable: Awaitable[_T]) -> _T:
+            return await asyncio.wait_for(awaitable, timeout=self.body_call_timeout_s)
+
         try:
-            await adapter.ensure_connected()
+            await _call(adapter.ensure_connected())
+        except TimeoutError:
+            logger.error(
+                "Body adapter connect timed out after %.1fs",
+                self.body_call_timeout_s,
+            )
+            return {"error": "Could not reach the body before the timeout."}
         except Exception as e:
             logger.error("Body adapter connect failed: %s", e)
             return {"error": f"Could not reach the body: {e}"}
@@ -979,15 +994,15 @@ class GptmeToolBridge:
             if name == "body_status":
                 return {"status": "ok", "telemetry": adapter.telemetry()}
             if name == "body_stop" and "move" in caps:
-                return await adapter.stop()
+                return await _call(adapter.stop())
             if name == "body_return_home" and "move" in caps:
-                return await adapter.return_home()
+                return await _call(adapter.return_home())
             if name == "body_takeoff" and "altitude" in caps:
                 altitude = float(arguments.get("altitude_m", 2.5))
                 altitude = max(1.0, min(self.body_max_altitude_m, altitude))
-                return await adapter.takeoff(altitude)
+                return await _call(adapter.takeoff(altitude))
             if name == "body_land" and "altitude" in caps:
-                return await adapter.land()
+                return await _call(adapter.land())
             if name == "body_move" and "move" in caps:
                 forward = self._clamp(
                     float(arguments.get("forward_m", 0.0)), self.body_max_move_m
@@ -1006,7 +1021,7 @@ class GptmeToolBridge:
                         min(self.body_max_altitude_m, float(current_altitude) + up),
                     )
                     up = target_altitude - float(current_altitude)
-                return await adapter.move(forward, right, up)
+                return await _call(adapter.move(forward, right, up))
             if name == "body_goto" and "move" in caps:
                 lat = float(arguments["latitude_deg"])
                 lon = float(arguments["longitude_deg"])
@@ -1016,12 +1031,19 @@ class GptmeToolBridge:
                     goto_alt = max(
                         1.0, min(self.body_max_altitude_m, float(altitude_arg))
                     )
-                return await adapter.goto(lat, lon, goto_alt)
+                return await _call(adapter.goto(lat, lon, goto_alt))
             if name == "body_turn" and "rotate" in caps:
                 yaw = self._clamp(float(arguments.get("yaw_deg", 0.0)), 180.0)
-                return await adapter.turn(yaw)
+                return await _call(adapter.turn(yaw))
         except (KeyError, TypeError, ValueError) as e:
             return {"error": f"Invalid arguments for {name}: {e}"}
+        except TimeoutError:
+            logger.error(
+                "Body call %s timed out after %.1fs",
+                name,
+                self.body_call_timeout_s,
+            )
+            return {"error": f"{name} timed out before the body responded."}
         except Exception as e:  # noqa: BLE001 - report body errors to the model
             logger.error("Body call %s failed: %s", name, e)
             return {"error": f"{name} failed: {e}"}

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -20,7 +20,10 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable, Sequence
+from typing import TYPE_CHECKING, Awaitable, Callable, Sequence
+
+if TYPE_CHECKING:
+    from ..body import BodyAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +127,7 @@ class GptmeToolBridge:
         on_hangup: Callable[[str | None], Awaitable[None]] | None = None,
         on_handoff: Callable[[str, str, str | None], Awaitable[dict]] | None = None,
         transcript_provider: Callable[[], Sequence[object]] | None = None,
+        body_adapter: "BodyAdapter | None" = None,
     ):
         self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
@@ -134,6 +138,13 @@ class GptmeToolBridge:
         self.on_hangup = on_hangup
         self.on_handoff = on_handoff
         self.transcript_provider = transcript_provider
+        self.body_adapter = body_adapter
+        self.body_max_altitude_m = float(
+            os.environ.get("GPTME_VOICE_BODY_MAX_ALT_M", "30")
+        )
+        self.body_max_move_m = float(
+            os.environ.get("GPTME_VOICE_BODY_MAX_MOVE_M", "50")
+        )
         legacy_env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         env_model_fast = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_FAST")
         env_model_smart = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_SMART")
@@ -911,4 +922,85 @@ class GptmeToolBridge:
             result = await self.on_handoff(to_agent, reason, context_summary)
             return result
 
+        if name.startswith("body_"):
+            return await self._handle_body_call(name, arguments)
+
         return {"error": f"Unknown function: {name}"}
+
+    @staticmethod
+    def _clamp(value: float, limit: float) -> float:
+        return max(-limit, min(limit, value))
+
+    async def _handle_body_call(self, name: str, arguments: dict) -> dict:
+        """Route body_* tools to the configured body adapter.
+
+        Direct, low-latency path by design: motion goals (especially
+        body_stop) must not round-trip through subagent dispatch. Numeric
+        inputs are clamped to conservative envelopes here so a confused
+        model cannot request a 500 m climb; the autopilot's own failsafes
+        and geofence remain the final safety authority.
+        """
+        adapter = self.body_adapter
+        if adapter is None:
+            return {
+                "error": (
+                    "No body is connected to this session, so there is "
+                    "nothing to move."
+                )
+            }
+        try:
+            await adapter.ensure_connected()
+        except Exception as e:
+            logger.error("Body adapter connect failed: %s", e)
+            return {"error": f"Could not reach the body: {e}"}
+
+        caps = adapter.capabilities
+        try:
+            if name == "body_status":
+                return {"status": "ok", "telemetry": adapter.telemetry()}
+            if name == "body_stop" and "move" in caps:
+                return await adapter.stop()
+            if name == "body_return_home" and "move" in caps:
+                return await adapter.return_home()
+            if name == "body_takeoff" and "altitude" in caps:
+                altitude = float(arguments.get("altitude_m", 2.5))
+                altitude = max(1.0, min(self.body_max_altitude_m, altitude))
+                return await adapter.takeoff(altitude)
+            if name == "body_land" and "altitude" in caps:
+                return await adapter.land()
+            if name == "body_move" and "move" in caps:
+                forward = self._clamp(
+                    float(arguments.get("forward_m", 0.0)), self.body_max_move_m
+                )
+                right = self._clamp(
+                    float(arguments.get("right_m", 0.0)), self.body_max_move_m
+                )
+                up = self._clamp(
+                    float(arguments.get("up_m", 0.0)), self.body_max_altitude_m
+                )
+                return await adapter.move(forward, right, up)
+            if name == "body_goto" and "move" in caps:
+                lat = float(arguments["latitude_deg"])
+                lon = float(arguments["longitude_deg"])
+                altitude_arg = arguments.get("altitude_m")
+                goto_alt: float | None = None
+                if altitude_arg is not None:
+                    goto_alt = max(
+                        1.0, min(self.body_max_altitude_m, float(altitude_arg))
+                    )
+                return await adapter.goto(lat, lon, goto_alt)
+            if name == "body_turn" and "rotate" in caps:
+                yaw = self._clamp(float(arguments.get("yaw_deg", 0.0)), 180.0)
+                return await adapter.turn(yaw)
+        except (KeyError, TypeError, ValueError) as e:
+            return {"error": f"Invalid arguments for {name}: {e}"}
+        except Exception as e:  # noqa: BLE001 - report body errors to the model
+            logger.error("Body call %s failed: %s", name, e)
+            return {"error": f"{name} failed: {e}"}
+
+        return {
+            "error": (
+                f"{name} is not available on this body "
+                f"(capabilities: {sorted(caps) or 'none'})."
+            )
+        }

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -24,6 +24,7 @@ class FakeAdapter:
         capabilities: set[str] | None = None,
         *,
         relative_altitude_m: float | None = None,
+        in_air: bool = False,
     ):
         self.capabilities = (
             capabilities if capabilities is not None else {"move", "rotate", "altitude"}
@@ -31,6 +32,7 @@ class FakeAdapter:
         self.calls: list[tuple[str, tuple]] = []
         self.connect_calls = 0
         self.relative_altitude_m = relative_altitude_m
+        self.in_air = in_air
 
     async def ensure_connected(self) -> None:
         self.connect_calls += 1
@@ -44,7 +46,7 @@ class FakeAdapter:
             if self.relative_altitude_m is not None
             else None
         )
-        return {"body": "fake", "in_air": False, "position": position}
+        return {"body": "fake", "in_air": self.in_air, "position": position}
 
     async def takeoff(self, altitude_m: float) -> dict:
         self.calls.append(("takeoff", (altitude_m,)))
@@ -143,6 +145,14 @@ def test_bridge_status_and_stop(loop):
     assert stop["status"] == "holding"
     assert ("stop", ()) in adapter.calls
     assert adapter.connect_calls == 2  # ensure_connected before every call
+
+
+def test_bridge_refuses_takeoff_when_already_in_air(loop):
+    adapter = FakeAdapter(in_air=True)
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    result = _call(bridge, "body_takeoff", {"altitude_m": 2.5})
+    assert "in the air" in result["error"]
+    assert adapter.calls == []
 
 
 def test_bridge_takeoff_clamps_altitude(loop, monkeypatch):
@@ -390,6 +400,26 @@ def test_mavsdk_move_and_turn_require_heading(loop):
     assert "heading fix" in goto["error"]
 
 
+def test_mavsdk_takeoff_refuses_when_in_air(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    class Action:
+        async def set_takeoff_altitude(self, _altitude: float) -> None:
+            raise AssertionError("takeoff must not run while in air")
+
+        async def arm(self) -> None:
+            raise AssertionError("takeoff must not run while in air")
+
+        async def takeoff(self) -> None:
+            raise AssertionError("takeoff must not run while in air")
+
+    adapter = MavsdkAdapter("unused")
+    adapter._system = type("System", (), {"action": Action()})()
+    adapter._in_air = True
+    result = loop.run_until_complete(adapter.takeoff(2.5))
+    assert "in the air" in result["error"]
+
+
 def test_mavsdk_action_timeout(loop):
     from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
 
@@ -404,7 +434,8 @@ def test_mavsdk_action_timeout(loop):
     with pytest.raises(TimeoutError):
         loop.run_until_complete(adapter.stop())
 
-    assert adapter._connected is False
+    # Timeout must not drop the link: the vehicle may still be executing.
+    assert adapter._connected is True
 
 
 def test_mavsdk_close_releases_system(loop):

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -209,6 +209,28 @@ def test_bridge_descent_on_ground_does_not_become_ascent(loop):
     assert adapter.calls[-1] == ("move", (0.0, 0.0, 0.0))
 
 
+def test_bridge_move_refuses_climb_without_altitude_telemetry(loop):
+    adapter = FakeAdapter()  # relative_altitude_m defaults to None
+    bridge = GptmeToolBridge(body_adapter=adapter)
+
+    result = _call(bridge, "body_move", {"up_m": 5.0})
+
+    assert "error" in result
+    assert "altitude unknown" in result["error"]
+    assert adapter.calls == []
+
+
+def test_bridge_move_allows_level_and_descent_without_altitude_telemetry(loop):
+    adapter = FakeAdapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+
+    _call(bridge, "body_move", {"forward_m": 2.0, "up_m": 0.0})
+    assert adapter.calls[-1] == ("move", (2.0, 0.0, 0.0))
+
+    _call(bridge, "body_move", {"up_m": -3.0})
+    assert adapter.calls[-1] == ("move", (0.0, 0.0, -3.0))
+
+
 def test_bridge_capability_gate_blocks_uncapable_calls(loop):
     adapter = FakeAdapter({"move"})
     bridge = GptmeToolBridge(body_adapter=adapter)

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -383,9 +383,11 @@ def test_mavsdk_move_and_turn_require_heading(loop):
 
     move = loop.run_until_complete(adapter.move(1.0, 0.0, 0.0))
     turn = loop.run_until_complete(adapter.turn(90.0))
+    goto = loop.run_until_complete(adapter.goto(47.1, 8.1, 10.0))
 
     assert "heading fix" in move["error"]
     assert "heading fix" in turn["error"]
+    assert "heading fix" in goto["error"]
 
 
 def test_mavsdk_action_timeout(loop):

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -35,6 +35,9 @@ class FakeAdapter:
     async def ensure_connected(self) -> None:
         self.connect_calls += 1
 
+    async def close(self) -> None:
+        return None
+
     def telemetry(self) -> dict[str, Any]:
         position = (
             {"relative_altitude_m": self.relative_altitude_m}
@@ -212,6 +215,28 @@ def test_bridge_body_error_is_reported_not_raised(loop):
     assert "body_stop failed" in result["error"]
 
 
+def test_bridge_body_call_times_out(loop, monkeypatch):
+    class HangingAdapter(FakeAdapter):
+        async def stop(self) -> dict:
+            await asyncio.Future()
+
+    monkeypatch.setenv("GPTME_VOICE_BODY_CALL_TIMEOUT_S", "0.01")
+    bridge = GptmeToolBridge(body_adapter=HangingAdapter())
+    result = _call(bridge, "body_stop")
+    assert "timed out" in result["error"]
+
+
+def test_bridge_connect_times_out(loop, monkeypatch):
+    class HangingAdapter(FakeAdapter):
+        async def ensure_connected(self) -> None:
+            await asyncio.Future()
+
+    monkeypatch.setenv("GPTME_VOICE_BODY_CALL_TIMEOUT_S", "0.01")
+    bridge = GptmeToolBridge(body_adapter=HangingAdapter())
+    result = _call(bridge, "body_status")
+    assert "timeout" in result["error"]
+
+
 def test_bridge_turn_clamps_yaw(loop):
     adapter = FakeAdapter()
     bridge = GptmeToolBridge(body_adapter=adapter)
@@ -327,11 +352,64 @@ def test_mavsdk_move_never_targets_below_home(loop):
         "absolute_altitude_m": 502.0,
         "relative_altitude_m": 2.0,
     }
+    adapter._heading_deg = 0.0
 
     result = loop.run_until_complete(adapter.move(0.0, 0.0, -30.0))
 
     assert result["target"]["altitude_m"] == 1.0
     assert action.goto_args[2] == 501.0
+
+
+def test_mavsdk_move_and_turn_require_heading(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    adapter = MavsdkAdapter("unused")
+    adapter._system = object()
+    adapter._position = {
+        "latitude_deg": 47.0,
+        "longitude_deg": 8.0,
+        "absolute_altitude_m": 502.0,
+        "relative_altitude_m": 2.0,
+    }
+
+    move = loop.run_until_complete(adapter.move(1.0, 0.0, 0.0))
+    turn = loop.run_until_complete(adapter.turn(90.0))
+
+    assert "heading fix" in move["error"]
+    assert "heading fix" in turn["error"]
+
+
+def test_mavsdk_action_timeout(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    class Action:
+        async def hold(self):
+            await asyncio.Future()
+
+    adapter = MavsdkAdapter("unused", command_timeout_s=0.01)
+    adapter._system = type("System", (), {"action": Action()})()
+
+    with pytest.raises(TimeoutError):
+        loop.run_until_complete(adapter.stop())
+
+
+def test_mavsdk_close_releases_system(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    class System:
+        stopped = False
+
+        def _stop_mavsdk_server(self):
+            self.stopped = True
+
+    system = System()
+    adapter = MavsdkAdapter("unused")
+    adapter._system = system
+
+    loop.run_until_complete(adapter.close())
+
+    assert system.stopped is True
+    assert adapter._system is None
 
 
 def test_mavsdk_serializes_action_commands(loop):

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -187,7 +187,16 @@ def test_bridge_move_clamps_resulting_absolute_altitude(loop, monkeypatch):
 
     adapter.relative_altitude_m = 2.0
     _call(bridge, "body_move", {"up_m": -30})
-    assert adapter.calls[-1] == ("move", (0.0, 0.0, -1.0))
+    assert adapter.calls[-1] == ("move", (0.0, 0.0, -2.0))
+
+
+def test_bridge_descent_on_ground_does_not_become_ascent(loop):
+    adapter = FakeAdapter(relative_altitude_m=0.0)
+    bridge = GptmeToolBridge(body_adapter=adapter)
+
+    _call(bridge, "body_move", {"up_m": -1.0})
+
+    assert adapter.calls[-1] == ("move", (0.0, 0.0, 0.0))
 
 
 def test_bridge_capability_gate_blocks_uncapable_calls(loop):
@@ -356,8 +365,8 @@ def test_mavsdk_move_never_targets_below_home(loop):
 
     result = loop.run_until_complete(adapter.move(0.0, 0.0, -30.0))
 
-    assert result["target"]["altitude_m"] == 1.0
-    assert action.goto_args[2] == 501.0
+    assert result["target"]["altitude_m"] == 0.0
+    assert action.goto_args[2] == 500.0
 
 
 def test_mavsdk_move_and_turn_require_heading(loop):
@@ -388,9 +397,12 @@ def test_mavsdk_action_timeout(loop):
 
     adapter = MavsdkAdapter("unused", command_timeout_s=0.01)
     adapter._system = type("System", (), {"action": Action()})()
+    adapter._connected = True
 
     with pytest.raises(TimeoutError):
         loop.run_until_complete(adapter.stop())
+
+    assert adapter._connected is False
 
 
 def test_mavsdk_close_releases_system(loop):

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -1,0 +1,258 @@
+"""Tests for the body adapter layer and its tool-bridge routing."""
+
+import asyncio
+from typing import Any
+
+import pytest
+from gptme_voice.body import (
+    NullAdapter,
+    body_adapter_from_env,
+    body_tool_schemas,
+)
+from gptme_voice.body.mavsdk_adapter import body_to_ned, offset_latlon
+from gptme_voice.realtime.tool_bridge import GptmeToolBridge
+
+
+class FakeAdapter:
+    """Records calls; full capability set unless overridden."""
+
+    name = "fake"
+
+    def __init__(self, capabilities: set[str] | None = None):
+        self.capabilities = (
+            capabilities if capabilities is not None else {"move", "rotate", "altitude"}
+        )
+        self.calls: list[tuple[str, tuple]] = []
+        self.connect_calls = 0
+
+    async def ensure_connected(self) -> None:
+        self.connect_calls += 1
+
+    def telemetry(self) -> dict[str, Any]:
+        return {"body": "fake", "in_air": False}
+
+    async def takeoff(self, altitude_m: float) -> dict:
+        self.calls.append(("takeoff", (altitude_m,)))
+        return {"status": "taking_off"}
+
+    async def land(self) -> dict:
+        self.calls.append(("land", ()))
+        return {"status": "landing"}
+
+    async def goto(self, latitude_deg, longitude_deg, altitude_m) -> dict:
+        self.calls.append(("goto", (latitude_deg, longitude_deg, altitude_m)))
+        return {"status": "en_route"}
+
+    async def move(self, forward_m, right_m, up_m) -> dict:
+        self.calls.append(("move", (forward_m, right_m, up_m)))
+        return {"status": "en_route"}
+
+    async def turn(self, yaw_deg) -> dict:
+        self.calls.append(("turn", (yaw_deg,)))
+        return {"status": "turning"}
+
+    async def stop(self) -> dict:
+        self.calls.append(("stop", ()))
+        return {"status": "holding"}
+
+    async def return_home(self) -> dict:
+        self.calls.append(("return_home", ()))
+        return {"status": "returning_home"}
+
+
+def _call(bridge: GptmeToolBridge, name: str, args: dict | None = None) -> dict:
+    return asyncio.get_event_loop().run_until_complete(
+        bridge.handle_function_call(name, args or {})
+    )
+
+
+@pytest.fixture
+def loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+# --- schema gating ------------------------------------------------------
+
+
+def test_schemas_none_adapter_is_empty():
+    assert body_tool_schemas(None) == []
+
+
+def test_schemas_null_adapter_status_only():
+    names = [t["name"] for t in body_tool_schemas(NullAdapter())]
+    assert names == ["body_status"]
+
+
+def test_schemas_full_capabilities():
+    names = {t["name"] for t in body_tool_schemas(FakeAdapter())}
+    assert names == {
+        "body_status",
+        "body_stop",
+        "body_return_home",
+        "body_move",
+        "body_goto",
+        "body_turn",
+        "body_takeoff",
+        "body_land",
+    }
+
+
+def test_schemas_move_only_excludes_altitude_tools():
+    names = {t["name"] for t in body_tool_schemas(FakeAdapter({"move"}))}
+    assert "body_takeoff" not in names
+    assert "body_turn" not in names
+    assert "body_move" in names
+    assert "body_stop" in names
+
+
+# --- bridge routing -----------------------------------------------------
+
+
+def test_bridge_without_adapter_reports_no_body(loop):
+    bridge = GptmeToolBridge()
+    result = _call(bridge, "body_status")
+    assert "error" in result
+    assert "No body" in result["error"]
+
+
+def test_bridge_status_and_stop(loop):
+    adapter = FakeAdapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    status = _call(bridge, "body_status")
+    assert status["status"] == "ok"
+    assert status["telemetry"]["body"] == "fake"
+    stop = _call(bridge, "body_stop")
+    assert stop["status"] == "holding"
+    assert ("stop", ()) in adapter.calls
+    assert adapter.connect_calls == 2  # ensure_connected before every call
+
+
+def test_bridge_takeoff_clamps_altitude(loop, monkeypatch):
+    monkeypatch.setenv("GPTME_VOICE_BODY_MAX_ALT_M", "30")
+    adapter = FakeAdapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    _call(bridge, "body_takeoff", {"altitude_m": 500})
+    assert adapter.calls[-1] == ("takeoff", (30.0,))
+    _call(bridge, "body_takeoff", {"altitude_m": 0.1})
+    assert adapter.calls[-1] == ("takeoff", (1.0,))
+    _call(bridge, "body_takeoff", {})
+    assert adapter.calls[-1] == ("takeoff", (2.5,))
+
+
+def test_bridge_move_clamps_distance(loop):
+    adapter = FakeAdapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    _call(bridge, "body_move", {"forward_m": 9999, "right_m": -9999, "up_m": 0})
+    name, (f, r, u) = adapter.calls[-1]
+    assert name == "move"
+    assert f == bridge.body_max_move_m
+    assert r == -bridge.body_max_move_m
+    assert u == 0.0
+
+
+def test_bridge_capability_gate_blocks_uncapable_calls(loop):
+    adapter = FakeAdapter({"move"})
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    result = _call(bridge, "body_takeoff", {"altitude_m": 2})
+    assert "error" in result
+    assert adapter.calls == []
+
+
+def test_bridge_goto_requires_coordinates(loop):
+    adapter = FakeAdapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    result = _call(bridge, "body_goto", {"latitude_deg": 47.4})
+    assert "error" in result
+
+
+def test_bridge_body_error_is_reported_not_raised(loop):
+    class ExplodingAdapter(FakeAdapter):
+        async def stop(self) -> dict:
+            raise RuntimeError("link down")
+
+    bridge = GptmeToolBridge(body_adapter=ExplodingAdapter())
+    result = _call(bridge, "body_stop")
+    assert "body_stop failed" in result["error"]
+
+
+def test_bridge_turn_clamps_yaw(loop):
+    adapter = FakeAdapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+    _call(bridge, "body_turn", {"yaw_deg": 720})
+    assert adapter.calls[-1] == ("turn", (180.0,))
+
+
+# --- null adapter -------------------------------------------------------
+
+
+def test_null_adapter_motion_reports_unsupported(loop):
+    null = NullAdapter()
+    result = asyncio.get_event_loop().run_until_complete(null.stop())
+    assert "error" in result
+    assert null.telemetry()["mobile"] is False
+
+
+# --- env factory --------------------------------------------------------
+
+
+def test_adapter_from_env_unset(monkeypatch):
+    monkeypatch.delenv("GPTME_VOICE_BODY_URL", raising=False)
+    assert body_adapter_from_env() is None
+
+
+def test_adapter_from_env_null(monkeypatch):
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    adapter = body_adapter_from_env()
+    assert isinstance(adapter, NullAdapter)
+
+
+def test_adapter_from_env_unknown_scheme(monkeypatch):
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "carrier-pigeon://coop")
+    assert body_adapter_from_env() is None
+
+
+def test_adapter_from_env_mavsdk(monkeypatch):
+    pytest.importorskip("mavsdk")
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "mavsdk://udpin://0.0.0.0:14540")
+    adapter = body_adapter_from_env()
+    assert adapter is not None
+    assert adapter.name == "mavsdk"
+    assert adapter.system_address == "udpin://0.0.0.0:14540"
+
+
+# --- mavsdk geometry helpers (pure math, no mavsdk import needed) -------
+
+
+def test_body_to_ned_facing_north():
+    north, east = body_to_ned(10, 0, 0)
+    assert north == pytest.approx(10)
+    assert east == pytest.approx(0)
+
+
+def test_body_to_ned_facing_east():
+    north, east = body_to_ned(10, 0, 90)
+    assert north == pytest.approx(0, abs=1e-9)
+    assert east == pytest.approx(10)
+
+
+def test_body_to_ned_right_component():
+    # Facing north, moving right 5 m => 5 m east
+    north, east = body_to_ned(0, 5, 0)
+    assert north == pytest.approx(0)
+    assert east == pytest.approx(5)
+
+
+def test_offset_latlon_north():
+    lat, lon = offset_latlon(47.0, 8.0, 111_320.0, 0.0)
+    assert lat == pytest.approx(48.0)
+    assert lon == pytest.approx(8.0)
+
+
+def test_offset_latlon_east_scales_with_latitude():
+    _, lon_equator = offset_latlon(0.0, 8.0, 0.0, 1000.0)
+    _, lon_north = offset_latlon(60.0, 8.0, 0.0, 1000.0)
+    # Same eastward meters => larger longitude delta at higher latitude
+    assert (lon_north - 8.0) > (lon_equator - 8.0)

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -1,6 +1,7 @@
 """Tests for the body adapter layer and its tool-bridge routing."""
 
 import asyncio
+import builtins
 from typing import Any
 
 import pytest
@@ -18,18 +19,29 @@ class FakeAdapter:
 
     name = "fake"
 
-    def __init__(self, capabilities: set[str] | None = None):
+    def __init__(
+        self,
+        capabilities: set[str] | None = None,
+        *,
+        relative_altitude_m: float | None = None,
+    ):
         self.capabilities = (
             capabilities if capabilities is not None else {"move", "rotate", "altitude"}
         )
         self.calls: list[tuple[str, tuple]] = []
         self.connect_calls = 0
+        self.relative_altitude_m = relative_altitude_m
 
     async def ensure_connected(self) -> None:
         self.connect_calls += 1
 
     def telemetry(self) -> dict[str, Any]:
-        return {"body": "fake", "in_air": False}
+        position = (
+            {"relative_altitude_m": self.relative_altitude_m}
+            if self.relative_altitude_m is not None
+            else None
+        )
+        return {"body": "fake", "in_air": False, "position": position}
 
     async def takeoff(self, altitude_m: float) -> dict:
         self.calls.append(("takeoff", (altitude_m,)))
@@ -142,6 +154,15 @@ def test_bridge_takeoff_clamps_altitude(loop, monkeypatch):
     assert adapter.calls[-1] == ("takeoff", (2.5,))
 
 
+@pytest.mark.parametrize("value", ["", "abc", "nan", "inf", "0", "-1"])
+def test_bridge_invalid_body_limits_fall_back(loop, monkeypatch, value):
+    monkeypatch.setenv("GPTME_VOICE_BODY_MAX_ALT_M", value)
+    monkeypatch.setenv("GPTME_VOICE_BODY_MAX_MOVE_M", value)
+    bridge = GptmeToolBridge(body_adapter=FakeAdapter())
+    assert bridge.body_max_altitude_m == 30.0
+    assert bridge.body_max_move_m == 50.0
+
+
 def test_bridge_move_clamps_distance(loop):
     adapter = FakeAdapter()
     bridge = GptmeToolBridge(body_adapter=adapter)
@@ -151,6 +172,19 @@ def test_bridge_move_clamps_distance(loop):
     assert f == bridge.body_max_move_m
     assert r == -bridge.body_max_move_m
     assert u == 0.0
+
+
+def test_bridge_move_clamps_resulting_absolute_altitude(loop, monkeypatch):
+    monkeypatch.setenv("GPTME_VOICE_BODY_MAX_ALT_M", "30")
+    adapter = FakeAdapter(relative_altitude_m=25.0)
+    bridge = GptmeToolBridge(body_adapter=adapter)
+
+    _call(bridge, "body_move", {"up_m": 30})
+    assert adapter.calls[-1] == ("move", (0.0, 0.0, 5.0))
+
+    adapter.relative_altitude_m = 2.0
+    _call(bridge, "body_move", {"up_m": -30})
+    assert adapter.calls[-1] == ("move", (0.0, 0.0, -1.0))
 
 
 def test_bridge_capability_gate_blocks_uncapable_calls(loop):
@@ -223,6 +257,19 @@ def test_adapter_from_env_mavsdk(monkeypatch):
     assert adapter.system_address == "udpin://0.0.0.0:14540"
 
 
+def test_adapter_from_env_mavsdk_missing_dependency(monkeypatch):
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "mavsdk://udpin://0.0.0.0:14540")
+    original_import = builtins.__import__
+
+    def import_without_mavsdk(name, *args, **kwargs):
+        if name == "mavsdk":
+            raise ModuleNotFoundError(name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_mavsdk)
+    assert body_adapter_from_env() is None
+
+
 # --- mavsdk geometry helpers (pure math, no mavsdk import needed) -------
 
 
@@ -256,3 +303,93 @@ def test_offset_latlon_east_scales_with_latitude():
     _, lon_north = offset_latlon(60.0, 8.0, 0.0, 1000.0)
     # Same eastward meters => larger longitude delta at higher latitude
     assert (lon_north - 8.0) > (lon_equator - 8.0)
+
+
+# --- MAVSDK safety behavior --------------------------------------------
+
+
+def test_mavsdk_move_never_targets_below_home(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    class Action:
+        def __init__(self):
+            self.goto_args = None
+
+        async def goto_location(self, *args):
+            self.goto_args = args
+
+    action = Action()
+    adapter = MavsdkAdapter("unused")
+    adapter._system = type("System", (), {"action": action})()
+    adapter._position = {
+        "latitude_deg": 47.0,
+        "longitude_deg": 8.0,
+        "absolute_altitude_m": 502.0,
+        "relative_altitude_m": 2.0,
+    }
+
+    result = loop.run_until_complete(adapter.move(0.0, 0.0, -30.0))
+
+    assert result["target"]["altitude_m"] == 1.0
+    assert action.goto_args[2] == 501.0
+
+
+def test_mavsdk_serializes_action_commands(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    class Action:
+        def __init__(self):
+            self.active = 0
+            self.max_active = 0
+
+        async def hold(self):
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            await asyncio.sleep(0)
+            self.active -= 1
+
+    async def run() -> int:
+        action = Action()
+        adapter = MavsdkAdapter("unused")
+        adapter._system = type("System", (), {"action": action})()
+        await asyncio.gather(adapter.stop(), adapter.stop())
+        return action.max_active
+
+    assert loop.run_until_complete(run()) == 1
+
+
+def test_mavsdk_telemetry_failure_marks_disconnected(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    async def broken_stream():
+        if False:
+            yield None
+        raise ConnectionError("link lost")
+
+    async def waiting_stream():
+        while True:
+            await asyncio.sleep(10)
+            yield None
+
+    class Telemetry:
+        position = staticmethod(broken_stream)
+        heading = staticmethod(waiting_stream)
+        battery = staticmethod(waiting_stream)
+        in_air = staticmethod(waiting_stream)
+        flight_mode = staticmethod(waiting_stream)
+        armed = staticmethod(waiting_stream)
+
+    async def run() -> tuple[bool, dict[str, Any], list[asyncio.Task]]:
+        adapter = MavsdkAdapter("unused")
+        adapter._system = type("System", (), {"telemetry": Telemetry()})()
+        adapter._connected = True
+        adapter._position = {"relative_altitude_m": 2.0}
+        adapter._start_telemetry_cache()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return adapter._connected, adapter._position, adapter._telemetry_tasks
+
+    connected, position, tasks = loop.run_until_complete(run())
+    assert connected is False
+    assert position == {}
+    assert tasks == []

--- a/packages/gptme-voice/tests/test_mavsdk_sitl_integration.py
+++ b/packages/gptme-voice/tests/test_mavsdk_sitl_integration.py
@@ -21,7 +21,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.timeout(180)
 def test_full_flight_via_bridge():
     pytest.importorskip("mavsdk")
     from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
@@ -74,4 +73,4 @@ def test_full_flight_via_bridge():
 
         await adapter.close()
 
-    asyncio.run(scenario())
+    asyncio.run(asyncio.wait_for(scenario(), timeout=180))

--- a/packages/gptme-voice/tests/test_mavsdk_sitl_integration.py
+++ b/packages/gptme-voice/tests/test_mavsdk_sitl_integration.py
@@ -1,0 +1,77 @@
+"""Live SITL integration test for MavsdkAdapter.
+
+Skipped unless BODY_SITL_URL is set (e.g. udpin://0.0.0.0:14540 with a
+running PX4 SITL such as jonasvautherin/px4-gazebo-headless). Exercises
+the full voice-tool path: bridge -> adapter -> simulated PX4 vehicle.
+
+    docker run -d -t --name px4-sitl jonasvautherin/px4-gazebo-headless:1.15.0
+    BODY_SITL_URL=udpin://0.0.0.0:14540 uv run pytest \
+        packages/gptme-voice/tests/test_mavsdk_sitl_integration.py -v
+"""
+
+import asyncio
+import os
+
+import pytest
+
+SITL_URL = os.environ.get("BODY_SITL_URL")
+
+pytestmark = pytest.mark.skipif(
+    not SITL_URL, reason="BODY_SITL_URL not set (needs a running PX4 SITL)"
+)
+
+
+@pytest.mark.timeout(180)
+def test_full_flight_via_bridge():
+    pytest.importorskip("mavsdk")
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+    from gptme_voice.realtime.tool_bridge import GptmeToolBridge
+
+    async def scenario() -> None:
+        adapter = MavsdkAdapter(SITL_URL)
+        bridge = GptmeToolBridge(body_adapter=adapter)
+
+        async def call(name: str, args: dict | None = None) -> dict:
+            return await bridge.handle_function_call(name, args or {})
+
+        # status: wait for a position fix
+        for _ in range(60):
+            status = await call("body_status")
+            assert status["status"] == "ok"
+            if status["telemetry"]["position"]:
+                break
+            await asyncio.sleep(1)
+        assert status["telemetry"]["position"], "no position fix from SITL"
+
+        # takeoff
+        result = await call("body_takeoff", {"altitude_m": 2.5})
+        assert result["status"] == "taking_off"
+        for _ in range(60):
+            await asyncio.sleep(1)
+            telemetry = (await call("body_status"))["telemetry"]
+            if (telemetry["position"] or {}).get("relative_altitude_m", 0) > 2.0:
+                break
+        assert telemetry["position"]["relative_altitude_m"] > 2.0
+
+        # relative move: forward 5 m
+        result = await call("body_move", {"forward_m": 5.0})
+        assert result["status"] == "en_route"
+        await asyncio.sleep(5)
+
+        # stop (hold)
+        result = await call("body_stop")
+        assert result["status"] == "holding"
+
+        # land
+        result = await call("body_land")
+        assert result["status"] == "landing"
+        for _ in range(90):
+            await asyncio.sleep(1)
+            telemetry = (await call("body_status"))["telemetry"]
+            if telemetry["in_air"] is False:
+                break
+        assert telemetry["in_air"] is False
+
+        await adapter.close()
+
+    asyncio.run(scenario())

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -246,6 +246,120 @@ def test_twilio_body_grant_pins_until_revoke_after_first_consume(monkeypatch) ->
     assert server._consume_twilio_body_grant(token) is None
 
 
+def test_twilio_body_grant_idle_revoke_without_reconnect(monkeypatch) -> None:
+    """Pinned grants must not live forever if stop/hangup never arrive."""
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    server._twilio_body_grant_idle_s = 0.05
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
+    assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+
+    async def _run() -> None:
+        server._schedule_twilio_body_grant_idle_revoke("CA123")
+        assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+        await asyncio.sleep(0.2)
+        assert server._consume_twilio_body_grant(token) is None
+
+    asyncio.run(_run())
+
+
+def test_twilio_body_grant_idle_revoke_cancelled_if_call_reconnects(
+    monkeypatch,
+) -> None:
+    """A reconnect inside the idle window must keep body_stop."""
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    server._twilio_body_grant_idle_s = 0.05
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
+    assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+
+    async def _run() -> None:
+        server._schedule_twilio_body_grant_idle_revoke("CA123")
+        server._connections["CA123"] = (object(), object())
+        server._cancel_twilio_body_grant_idle_revoke("CA123")
+        await asyncio.sleep(0.2)
+        assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+        server._revoke_twilio_body_grants_for_call("CA123")
+
+    asyncio.run(_run())
+
+
+def test_twilio_body_grant_idle_revoke_after_websocket_drop_without_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """handle_twilio_websocket finally must idle-revoke when stop never comes."""
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    captured: list[object] = []
+
+    class _CapturingBridge(_DummyToolBridge):
+        def __init__(self, *args, **kwargs) -> None:
+            captured.append(kwargs.get("body_adapter"))
+
+    server = VoiceServer()
+    server._twilio_body_grant_idle_s = 0.05
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
+    custom = {"from_number": "+15551212", "body_grant": token}
+
+    def _start_only() -> _DummyTwilioWebSocket:
+        return _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": "CA123",
+                        "customParameters": custom,
+                    },
+                },
+            ]
+        )
+
+    fake_client = _FakeRealtimeClient()
+
+    async def _fake_build_session_bootstrap(
+        *,
+        caller_id: str,
+        from_number: str = "",
+        handoff_id: str | None = None,
+        standup_brief: str | None = None,
+    ) -> SessionBootstrap:
+        return SessionBootstrap("You are Bob.")
+
+    def _fake_make_client(_session_cfg, **_kwargs):
+        return fake_client
+
+    async def _fake_on_call_end(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        server, "_build_session_bootstrap", _fake_build_session_bootstrap
+    )
+    monkeypatch.setattr(server, "_make_client", _fake_make_client)
+    monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _CapturingBridge)
+
+    async def _run() -> None:
+        await server.handle_twilio_websocket(_start_only())
+        assert captured[0] is not None
+        assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+        await asyncio.sleep(0.2)
+        assert server._consume_twilio_body_grant(token) is None
+
+    asyncio.run(_run())
+
+
 def test_twilio_body_grant_survives_reconnect_start_then_revokes_on_stop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -227,6 +227,25 @@ def test_twilio_body_grant_is_reusable_for_same_call_and_fail_closed(
     assert server._consume_twilio_body_grant(token) is None
 
 
+def test_twilio_body_grant_pins_until_revoke_after_first_consume(monkeypatch) -> None:
+    """Mint TTL is only for first start. After consume, the grant must survive
+    a call longer than 120s so a late Twilio reconnect still has body_stop.
+    """
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
+    assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+    from_number, call_sid, expires = server._twilio_body_grants[token]
+    assert from_number == "+15551212"
+    assert call_sid == "CA123"
+    assert expires == float("inf")
+    server._twilio_body_grant_ttl_s = 0.0
+    server._expire_twilio_body_grants()
+    assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
+    server._revoke_twilio_body_grants_for_call("CA123")
+    assert server._consume_twilio_body_grant(token) is None
+
+
 def test_twilio_body_grant_survives_reconnect_start_then_revokes_on_stop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -207,14 +207,121 @@ def test_twilio_body_tools_require_allowlisted_caller(monkeypatch) -> None:
     assert server._body_adapter_for_websocket(remote, transport="twilio") is None
 
 
-def test_twilio_body_grant_is_single_use_and_fail_closed(monkeypatch) -> None:
+def test_twilio_body_grant_is_reusable_for_same_call_and_fail_closed(
+    monkeypatch,
+) -> None:
+    """Twilio reconnects resend the same start customParameters.
+
+    Popping the grant on first consume leaves an airborne vehicle with no
+    body_stop. The grant stays live for the CallSid until revoke/TTL.
+    Unknown tokens still fail closed.
+    """
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     server = VoiceServer()
     token = server._mint_twilio_body_grant("+15551212", "CA123")
     assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
-    assert server._consume_twilio_body_grant(token) is None
+    assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
     assert server._consume_twilio_body_grant(None) is None
     assert server._consume_twilio_body_grant("invented") is None
+    server._revoke_twilio_body_grants_for_call("CA123")
+    assert server._consume_twilio_body_grant(token) is None
+
+
+def test_twilio_body_grant_survives_reconnect_start_then_revokes_on_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second start event with the same grant (Twilio reconnect) keeps body tools.
+
+    Twilio ``stop`` is the real call end and must revoke the grant so a later
+    replay of the stolen customParameters cannot re-attach motion tools.
+    """
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    captured: list[object] = []
+
+    class _CapturingBridge(_DummyToolBridge):
+        def __init__(self, *args, **kwargs) -> None:
+            captured.append(kwargs.get("body_adapter"))
+
+    server = VoiceServer()
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
+    custom = {"from_number": "+15551212", "body_grant": token}
+
+    def _start_only() -> _DummyTwilioWebSocket:
+        return _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": "CA123",
+                        "customParameters": custom,
+                    },
+                },
+            ]
+        )
+
+    def _start_then_stop() -> _DummyTwilioWebSocket:
+        return _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ456",
+                        "callSid": "CA123",
+                        "customParameters": custom,
+                    },
+                },
+                {"event": "stop"},
+            ]
+        )
+
+    fake_client = _FakeRealtimeClient()
+
+    async def _fake_build_session_bootstrap(
+        *,
+        caller_id: str,
+        from_number: str = "",
+        handoff_id: str | None = None,
+        standup_brief: str | None = None,
+    ) -> SessionBootstrap:
+        return SessionBootstrap("You are Bob.")
+
+    def _fake_make_client(_session_cfg, **_kwargs):
+        return fake_client
+
+    async def _fake_on_call_end(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        server, "_build_session_bootstrap", _fake_build_session_bootstrap
+    )
+    monkeypatch.setattr(server, "_make_client", _fake_make_client)
+    monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _CapturingBridge)
+
+    async def _run() -> None:
+        await server.handle_twilio_websocket(_start_only())
+        await server.handle_twilio_websocket(_start_then_stop())
+        await server.handle_twilio_websocket(_start_only())
+
+    asyncio.run(_run())
+    assert captured[0] is not None  # first start consumes live grant
+    assert captured[1] is not None  # reconnect start reuses the same grant
+    assert captured[2] is None  # after stop, replay fails closed
+    assert server._consume_twilio_body_grant(token) is None
 
 
 def test_twilio_body_grant_expires(monkeypatch) -> None:
@@ -339,7 +446,7 @@ def test_twilio_websocket_does_not_grant_body_tools_from_spoofed_from_number(
 ) -> None:
     """Raw /twilio start events can invent customParameters.from_number.
 
-    Body tools must require the one-shot grant minted by signed /incoming.
+    Body tools must require the call-scoped grant minted by signed /incoming.
     """
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     import gptme_voice.realtime.server as server_mod

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -207,6 +207,172 @@ def test_twilio_body_tools_require_allowlisted_caller(monkeypatch) -> None:
     assert server._body_adapter_for_websocket(remote, transport="twilio") is None
 
 
+def test_twilio_body_grant_is_single_use_and_fail_closed(monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    token = server._mint_twilio_body_grant("+15551212")
+    assert server._consume_twilio_body_grant(token) == "+15551212"
+    assert server._consume_twilio_body_grant(token) is None
+    assert server._consume_twilio_body_grant(None) is None
+    assert server._consume_twilio_body_grant("invented") is None
+
+
+def test_twilio_body_grant_expires(monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    server._twilio_body_grant_ttl_s = 0.0
+    token = server._mint_twilio_body_grant("+15551212")
+    assert server._consume_twilio_body_grant(token) is None
+
+
+def test_twilio_websocket_does_not_grant_body_tools_from_spoofed_from_number(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw /twilio start events can invent customParameters.from_number.
+
+    Body tools must require the one-shot grant minted by signed /incoming.
+    """
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    captured: dict[str, object] = {}
+
+    class _CapturingBridge(_DummyToolBridge):
+        def __init__(self, *args, **kwargs) -> None:
+            captured["body_adapter"] = kwargs.get("body_adapter")
+
+    async def _exercise(*, grant: bool) -> None:
+        captured.clear()
+        server = VoiceServer()
+        custom: dict[str, str] = {"from_number": "+15551212"}
+        if grant:
+            custom["body_grant"] = server._mint_twilio_body_grant("+15551212")
+        websocket = _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": "CA123",
+                        "customParameters": custom,
+                    },
+                },
+                {"event": "stop"},
+            ]
+        )
+        fake_client = _FakeRealtimeClient()
+
+        async def _fake_build_session_bootstrap(
+            *,
+            caller_id: str,
+            from_number: str = "",
+            handoff_id: str | None = None,
+            standup_brief: str | None = None,
+        ) -> SessionBootstrap:
+            return SessionBootstrap("You are Bob.")
+
+        def _fake_make_client(_session_cfg, **_kwargs):
+            return fake_client
+
+        async def _fake_on_call_end(*_args, **_kwargs) -> None:
+            return None
+
+        monkeypatch.setattr(
+            server, "_build_session_bootstrap", _fake_build_session_bootstrap
+        )
+        monkeypatch.setattr(server, "_make_client", _fake_make_client)
+        monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server.GptmeToolBridge", _CapturingBridge
+        )
+        await server.handle_twilio_websocket(websocket)
+
+    asyncio.run(_exercise(grant=False))
+    assert captured.get("body_adapter") is None
+
+    asyncio.run(_exercise(grant=True))
+    assert captured.get("body_adapter") is not None
+
+
+def test_twilio_spoof_cannot_steal_body_capable_prewarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    claimed: list[str] = []
+
+    async def _exercise() -> None:
+        server = VoiceServer()
+        websocket = _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": "CA123",
+                        "customParameters": {"from_number": "+15551212"},
+                    },
+                },
+                {"event": "stop"},
+            ]
+        )
+        fake_client = _FakeRealtimeClient()
+
+        def _fake_claim(from_number: str):
+            claimed.append(from_number)
+            return fake_client
+
+        async def _fake_on_call_end(*_args, **_kwargs) -> None:
+            return None
+
+        async def _fake_build_session_bootstrap(
+            *,
+            caller_id: str,
+            from_number: str = "",
+            handoff_id: str | None = None,
+            standup_brief: str | None = None,
+        ) -> SessionBootstrap:
+            return SessionBootstrap("You are Bob.")
+
+        def _fake_make_client(_session_cfg, **_kwargs):
+            return fake_client
+
+        monkeypatch.setattr(server, "_claim_prewarm", _fake_claim)
+        monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+        monkeypatch.setattr(
+            server, "_build_session_bootstrap", _fake_build_session_bootstrap
+        )
+        monkeypatch.setattr(server, "_make_client", _fake_make_client)
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge
+        )
+        await server.handle_twilio_websocket(websocket)
+
+    asyncio.run(_exercise())
+    assert claimed == []
+
+
 def test_untrusted_sessions_do_not_advertise_body_tools(monkeypatch) -> None:
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     server = VoiceServer()

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -210,8 +210,8 @@ def test_twilio_body_tools_require_allowlisted_caller(monkeypatch) -> None:
 def test_twilio_body_grant_is_single_use_and_fail_closed(monkeypatch) -> None:
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     server = VoiceServer()
-    token = server._mint_twilio_body_grant("+15551212")
-    assert server._consume_twilio_body_grant(token) == "+15551212"
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
+    assert server._consume_twilio_body_grant(token) == ("+15551212", "CA123")
     assert server._consume_twilio_body_grant(token) is None
     assert server._consume_twilio_body_grant(None) is None
     assert server._consume_twilio_body_grant("invented") is None
@@ -223,6 +223,115 @@ def test_twilio_body_grant_expires(monkeypatch) -> None:
     server._twilio_body_grant_ttl_s = 0.0
     token = server._mint_twilio_body_grant("+15551212")
     assert server._consume_twilio_body_grant(token) is None
+
+
+def test_incoming_does_not_mint_body_grant_without_auth_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsigned /incoming must not mint body grants from a spoofable From."""
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        if name == "TWILIO_AUTH_TOKEN":
+            return None
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    class _Req:
+        headers = {"host": "voice.example"}
+
+        async def form(self) -> dict[str, str]:
+            return {"From": "+15551212", "CallSid": "CA123"}
+
+    async def _run() -> tuple[str, dict]:
+        server = VoiceServer()
+
+        async def _noop(_from_number: str) -> None:
+            return None
+
+        monkeypatch.setattr(server, "_prewarm_for_inbound", _noop)
+        response = await server.handle_incoming_call(_Req())
+        body = (
+            response.body.decode()
+            if isinstance(response.body, bytes)
+            else str(response.body)
+        )
+        return body, dict(server._twilio_body_grants)
+
+    twiml, grants = asyncio.run(_run())
+    assert "body_grant" not in twiml
+    assert grants == {}
+
+
+def test_incoming_mints_body_grant_only_when_signature_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        if name == "TWILIO_AUTH_TOKEN":
+            return "secret"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    class _Validator:
+        def __init__(self, token: str) -> None:
+            self.token = token
+
+        def validate(self, _url: str, _params: dict, signature: str) -> bool:
+            return signature == "good"
+
+    monkeypatch.setattr(
+        "twilio.request_validator.RequestValidator",
+        _Validator,
+    )
+
+    class _Req:
+        def __init__(self, signature: str) -> None:
+            self.headers = {
+                "host": "voice.example",
+                "X-Twilio-Signature": signature,
+            }
+
+        async def form(self) -> dict[str, str]:
+            return {"From": "+15551212", "CallSid": "CA123"}
+
+    async def _run(signature: str) -> tuple[int, str, int]:
+        server = VoiceServer()
+
+        async def _noop(_from_number: str) -> None:
+            return None
+
+        monkeypatch.setattr(server, "_prewarm_for_inbound", _noop)
+        response = await server.handle_incoming_call(_Req(signature))
+        body = (
+            response.body.decode()
+            if isinstance(response.body, bytes)
+            else str(response.body)
+        )
+        return response.status_code, body, len(server._twilio_body_grants)
+
+    forbidden_code, forbidden_body, forbidden_grants = asyncio.run(_run("bad"))
+    assert forbidden_code == 403
+    assert "body_grant" not in forbidden_body
+    assert forbidden_grants == 0
+
+    ok_code, ok_body, ok_grants = asyncio.run(_run("good"))
+    assert ok_code == 200
+    assert "body_grant" in ok_body
+    assert ok_grants == 1
 
 
 def test_twilio_websocket_does_not_grant_body_tools_from_spoofed_from_number(
@@ -301,6 +410,108 @@ def test_twilio_websocket_does_not_grant_body_tools_from_spoofed_from_number(
     assert captured.get("body_adapter") is None
 
     asyncio.run(_exercise(grant=True))
+    assert captured.get("body_adapter") is not None
+
+
+def test_twilio_body_grant_requires_matching_from_and_call_sid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212,+15559999"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    captured: dict[str, object] = {}
+
+    class _CapturingBridge(_DummyToolBridge):
+        def __init__(self, *args, **kwargs) -> None:
+            captured["body_adapter"] = kwargs.get("body_adapter")
+
+    async def _exercise(
+        *, from_number: str, call_sid: str, grant_from: str, grant_sid: str
+    ) -> None:
+        captured.clear()
+        server = VoiceServer()
+        custom = {
+            "from_number": from_number,
+            "body_grant": server._mint_twilio_body_grant(grant_from, grant_sid),
+        }
+        websocket = _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": call_sid,
+                        "customParameters": custom,
+                    },
+                },
+                {"event": "stop"},
+            ]
+        )
+        fake_client = _FakeRealtimeClient()
+
+        async def _fake_build_session_bootstrap(
+            *,
+            caller_id: str,
+            from_number: str = "",
+            handoff_id: str | None = None,
+            standup_brief: str | None = None,
+        ) -> SessionBootstrap:
+            return SessionBootstrap("You are Bob.")
+
+        def _fake_make_client(_session_cfg, **_kwargs):
+            return fake_client
+
+        async def _fake_on_call_end(*_args, **_kwargs) -> None:
+            return None
+
+        monkeypatch.setattr(
+            server, "_build_session_bootstrap", _fake_build_session_bootstrap
+        )
+        monkeypatch.setattr(server, "_make_client", _fake_make_client)
+        monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server.GptmeToolBridge", _CapturingBridge
+        )
+        await server.handle_twilio_websocket(websocket)
+
+    asyncio.run(
+        _exercise(
+            from_number="+15559999",
+            call_sid="CA123",
+            grant_from="+15551212",
+            grant_sid="CA123",
+        )
+    )
+    assert captured.get("body_adapter") is None
+
+    asyncio.run(
+        _exercise(
+            from_number="+15551212",
+            call_sid="CA999",
+            grant_from="+15551212",
+            grant_sid="CA123",
+        )
+    )
+    assert captured.get("body_adapter") is None
+
+    asyncio.run(
+        _exercise(
+            from_number="+15551212",
+            call_sid="CA123",
+            grant_from="+15551212",
+            grant_sid="CA123",
+        )
+    )
     assert captured.get("body_adapter") is not None
 
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -142,15 +142,26 @@ class _DummyToolBridge:
 def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     server = VoiceServer()
-    remote_client = type("Client", (), {"host": "203.0.113.1"})()
-    local_client = type("Client", (), {"host": "127.0.0.1"})()
-    remote = type("WebSocket", (), {"client": remote_client})()
-    loopback = type("WebSocket", (), {"client": local_client})()
+    # Starlette's websocket.client is Address(host, port) — a (host, port) tuple.
+    remote = type("WebSocket", (), {"client": ("203.0.113.1", 443)})()
+    loopback = type("WebSocket", (), {"client": ("127.0.0.1", 12345)})()
+    ipv6 = type("WebSocket", (), {"client": ("::1", 12345)})()
+    named = type(
+        "WebSocket", (), {"client": type("Client", (), {"host": "127.0.0.1"})()}
+    )()
 
     assert server._body_adapter_for_websocket(remote, transport="local") is None
     assert server._body_adapter_for_websocket(remote, transport="browser") is None
     assert (
         server._body_adapter_for_websocket(loopback, transport="local")
+        is server.body_adapter
+    )
+    assert (
+        server._body_adapter_for_websocket(ipv6, transport="browser")
+        is server.body_adapter
+    )
+    assert (
+        server._body_adapter_for_websocket(named, transport="local")
         is server.body_adapter
     )
     # Twilio is fail-closed: no allowlist means no body tools, even though

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -139,6 +139,51 @@ class _DummyToolBridge:
         return []
 
 
+def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    remote_client = type("Client", (), {"host": "203.0.113.1"})()
+    local_client = type("Client", (), {"host": "127.0.0.1"})()
+    remote = type("WebSocket", (), {"client": remote_client})()
+    loopback = type("WebSocket", (), {"client": local_client})()
+
+    assert server._body_adapter_for_websocket(remote, transport="local") is None
+    assert server._body_adapter_for_websocket(remote, transport="browser") is None
+    assert (
+        server._body_adapter_for_websocket(loopback, transport="local")
+        is server.body_adapter
+    )
+    assert (
+        server._body_adapter_for_websocket(remote, transport="twilio")
+        is server.body_adapter
+    )
+
+
+def test_server_lifespan_closes_body_adapter(monkeypatch) -> None:
+    class Adapter:
+        name = "fake"
+        capabilities: set[str] = set()
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    adapter = Adapter()
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server.body_adapter_from_env", lambda: adapter
+    )
+    server = VoiceServer()
+
+    async def run_lifespan() -> None:
+        async with server._lifespan(server.app):
+            pass
+
+    asyncio.run(run_lifespan())
+    assert adapter.closed is True
+
+
 def test_build_caller_instructions_no_number() -> None:
     base = "You are Bob."
     result = _build_caller_instructions(base, "", None)

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -153,10 +153,47 @@ def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
         server._body_adapter_for_websocket(loopback, transport="local")
         is server.body_adapter
     )
+    # Twilio is fail-closed: no allowlist means no body tools, even though
+    # the request may have a valid Twilio signature.
+    assert server._body_adapter_for_websocket(remote, transport="twilio") is None
     assert (
-        server._body_adapter_for_websocket(remote, transport="twilio")
+        server._body_adapter_for_websocket(
+            remote, transport="twilio", caller_id="+15551212"
+        )
+        is None
+    )
+
+
+def test_twilio_body_tools_require_allowlisted_caller(monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212,+15559999"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+    server = VoiceServer()
+    remote = type(
+        "WebSocket", (), {"client": type("Client", (), {"host": "203.0.113.1"})()}
+    )()
+
+    assert (
+        server._body_adapter_for_websocket(
+            remote, transport="twilio", caller_id="+15551212"
+        )
         is server.body_adapter
     )
+    assert (
+        server._body_adapter_for_websocket(
+            remote, transport="twilio", caller_id="+15550000"
+        )
+        is None
+    )
+    assert server._body_adapter_for_websocket(remote, transport="twilio") is None
 
 
 def test_untrusted_sessions_do_not_advertise_body_tools(monkeypatch) -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -159,6 +159,17 @@ def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
     )
 
 
+def test_untrusted_sessions_do_not_advertise_body_tools(monkeypatch) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+
+    denied = server._build_session_config("You are Bob.", include_body_tools=False)
+    allowed = server._build_session_config("You are Bob.")
+
+    assert denied.extra_tools == []
+    assert [tool["name"] for tool in allowed.extra_tools] == ["body_status"]
+
+
 def test_server_lifespan_closes_body_adapter(monkeypatch) -> None:
     class Adapter:
         name = "fake"

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -347,8 +347,22 @@ def test_twilio_body_grant_expires(monkeypatch) -> None:
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     server = VoiceServer()
     server._twilio_body_grant_ttl_s = 0.0
-    token = server._mint_twilio_body_grant("+15551212")
+    token = server._mint_twilio_body_grant("+15551212", "CA123")
     assert server._consume_twilio_body_grant(token) is None
+
+
+def test_twilio_body_grant_refuses_empty_call_sid(monkeypatch) -> None:
+    """Empty CallSid skipped the start-event bind; mint must fail closed."""
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    server = VoiceServer()
+    assert server._mint_twilio_body_grant("+15551212", "") == ""
+    assert server._mint_twilio_body_grant("+15551212", "   ") == ""
+    assert server._mint_twilio_body_grant("", "CA123") == ""
+    assert server._twilio_body_grants == {}
+    # A leftover empty-sid grant must not consume.
+    server._twilio_body_grants["stale"] = ("+15551212", "", float("inf"))
+    assert server._consume_twilio_body_grant("stale") is None
+    assert "stale" not in server._twilio_body_grants
 
 
 def test_incoming_does_not_mint_body_grant_without_auth_token(
@@ -460,6 +474,65 @@ def test_incoming_mints_body_grant_only_when_signature_valid(
     assert ok_grants == 1
 
 
+def test_incoming_does_not_mint_body_grant_without_call_sid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Signed /incoming with empty CallSid must not mint a replayable grant."""
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
+    import gptme_voice.realtime.server as server_mod
+
+    real_get = server_mod._get_config_env
+
+    def fake_get(name: str) -> str | None:
+        if name == "TWILIO_CALLER_ALLOWLIST":
+            return "+15551212"
+        if name == "TWILIO_AUTH_TOKEN":
+            return "secret"
+        return real_get(name)
+
+    monkeypatch.setattr(server_mod, "_get_config_env", fake_get)
+
+    class _Validator:
+        def __init__(self, token: str) -> None:
+            self.token = token
+
+        def validate(self, _url: str, _params: dict, signature: str) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        "twilio.request_validator.RequestValidator",
+        _Validator,
+    )
+
+    class _Req:
+        headers = {
+            "host": "voice.example",
+            "X-Twilio-Signature": "good",
+        }
+
+        async def form(self) -> dict[str, str]:
+            return {"From": "+15551212", "CallSid": "   "}
+
+    async def _run() -> tuple[str, dict]:
+        server = VoiceServer()
+
+        async def _noop(_from_number: str) -> None:
+            return None
+
+        monkeypatch.setattr(server, "_prewarm_for_inbound", _noop)
+        response = await server.handle_incoming_call(_Req())
+        body = (
+            response.body.decode()
+            if isinstance(response.body, bytes)
+            else str(response.body)
+        )
+        return body, dict(server._twilio_body_grants)
+
+    twiml, grants = asyncio.run(_run())
+    assert "body_grant" not in twiml
+    assert grants == {}
+
+
 def test_twilio_websocket_does_not_grant_body_tools_from_spoofed_from_number(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -490,7 +563,7 @@ def test_twilio_websocket_does_not_grant_body_tools_from_spoofed_from_number(
         server = VoiceServer()
         custom: dict[str, str] = {"from_number": "+15551212"}
         if grant:
-            custom["body_grant"] = server._mint_twilio_body_grant("+15551212")
+            custom["body_grant"] = server._mint_twilio_body_grant("+15551212", "CA123")
         websocket = _DummyTwilioWebSocket(
             [
                 {"event": "connected"},

--- a/uv.lock
+++ b/uv.lock
@@ -2576,6 +2576,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+body = [
+    { name = "mavsdk" },
+]
 local = [
     { name = "pyaudio" },
 ]
@@ -2588,6 +2591,7 @@ requires-dist = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2" },
     { name = "click", specifier = ">=8.0" },
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "mavsdk", marker = "extra == 'body'", specifier = ">=2.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pyaudio", marker = "extra == 'local'", specifier = ">=0.2.13" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
@@ -2596,7 +2600,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["test", "local"]
+provides-extras = ["test", "local", "body"]
 
 [[package]]
 name = "gptme-warpgrep"
@@ -3520,6 +3524,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "mavsdk"
+version = "3.17.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/42/bf38eb788ed238dbfe0b54e2a3c8c6e73ca227bf48abf61171c6cf06162f/mavsdk-3.17.2-py3-none-linux_armv6l.whl", hash = "sha256:90ac3826e37dd70f5fdeea4c2d60b3681c22a54e78162d87955313f3deb77083", size = 16588500, upload-time = "2026-07-22T08:19:46.616Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9e/567b2957c1d12e15edf0837fbfcdbd43f139ca32490d848a095bbc55c3f3/mavsdk-3.17.2-py3-none-linux_armv7l.whl", hash = "sha256:1aa441c7c290c4e1df5cb43376aa776194ea80004ef156826dd60c5d8b13f2c0", size = 16588546, upload-time = "2026-07-22T08:19:43.234Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/91/2005f11804d277a4b599e97bef9c5021c949079ac2c992e5d4f44e304e3f/mavsdk-3.17.2-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:24c40b9f9fa0ce5cea4c05d300cafbb21dfc1483da7518de77c15356112f2c97", size = 12221440, upload-time = "2026-07-22T08:19:53.168Z" },
+    { url = "https://files.pythonhosted.org/packages/10/38/da962106d56d68e9290390ec7e1fbfa6d6914580c11673a89d0a8406241d/mavsdk-3.17.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:0247c9dcc0d4390b8734358ded178764efa4b83c304cb2f77162758b29cd6f57", size = 11684503, upload-time = "2026-07-22T08:19:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b6/72dc4499cb7172665c1e0c3af0b18f5d0ca0160b810c1e05ea6668dd5488/mavsdk-3.17.2-py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78ac2402306022bb6000e1fa02dfe4af7a634c803d4ca90673b1c7918a23c937", size = 15246122, upload-time = "2026-07-22T08:20:01.196Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/2b177c2350bbc0785bc3a74f770cfc7cdc134128ad566a4f759631b4e549/mavsdk-3.17.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:99e58f26705127986fa5e1358e3688aa4e4f8d006e719d2d39179d03368039f8", size = 18233585, upload-time = "2026-07-22T08:19:47.112Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3e/843a6bba46b3d442b870c02186003c27c1f7cbe57d9abcf4df35f855f6ba/mavsdk-3.17.2-py3-none-win32.whl", hash = "sha256:a5bb3618b044820c679f62a4d2b5b1fd4029c2145f53fd3ed80a62bf6768e8e2", size = 14342433, upload-time = "2026-07-22T08:20:16.778Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4e/6bbd365a6119be77d93d7d61d7f3bb54faa8cc026ddc4471fe204b652e80/mavsdk-3.17.2-py3-none-win_amd64.whl", hash = "sha256:b613775dbf9324b542e29814f530a5e361cad0234304cb48fe56da4054642fc1", size = 14342433, upload-time = "2026-07-22T08:20:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/81/209201c6e2420cc27c377b3bc6e38b7880af19ba8e93f15e082cd7554705/mavsdk-3.17.2-py3-none-win_arm64.whl", hash = "sha256:727b2047e326d64e698bfccb8ca77f7eaada0d4b4d562b57d7e7ac55fa579ac1", size = 14342433, upload-time = "2026-07-22T08:20:10.977Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements BobBrain milestones 3+4 (body adapter + SITL-verified flight tools) — see ErikBjare/bob#730 and the bobbrain spec in Bob's workspace.

## What

Voice sessions can now command a physical body (quadcopter, future wheelbase, tabletop puck) through **direct, low-latency tools** — motion goals must not round-trip through subagent dispatch (`body_stop` especially).

- **`gptme_voice.body`** — `BodyAdapter` protocol implementing the Brain↔Body contract: the brain emits *goals* (goto/move/turn/stop), the adapter owns translation and safety. `NullAdapter` = tabletop puck (registers `body_status` only — a session on a desk ornament exposes no motion tools at all). `MavsdkAdapter` = PX4 vehicles via the high-level Action API only (goto_location/takeoff/land/hold/RTL — no offboard loops; **PX4's own failsafes remain the safety authority**, so a dropped brain link always leaves the vehicle safe).
- **Capability gating** — `body_tool_schemas(adapter)` emits function schemas only for the adapter's advertised capabilities (`move`/`rotate`/`altitude`); `SessionConfig.extra_tools` appends them to the realtime session.
- **Bridge routing** — `body_*` calls in `GptmeToolBridge.handle_function_call` with conservative envelope clamps (`GPTME_VOICE_BODY_MAX_ALT_M` default 30, `GPTME_VOICE_BODY_MAX_MOVE_M` default 50, yaw ±180°); all body errors reported to the model, never raised.
- **Wiring** — `GPTME_VOICE_BODY_URL` env: `null` | `mavsdk://udpin://0.0.0.0:14540` (SITL) | `mavsdk://serial:///dev/ttyUSB0:57600` (SiK radio). Optional dep `gptme-voice[body]`.

## Testing

- 22 unit tests (schema gating, routing, clamps, capability gate, error paths, NED/latlon geometry).
- **Live SITL integration test PASSED** against PX4 1.15 (jonasvautherin/px4-gazebo-headless): position fix → takeoff → relative move 5 m → hold → land, driven entirely through `handle_function_call`. Skips unless `BODY_SITL_URL` is set, so CI stays green without a simulator.
- Full gptme-voice suite: 237 passed.

## Not in this PR

- Vision pipeline (`gptme-vision-node`, concurrent PR) and its `look` tool wiring.
- xAI/Grok client tool declaration (inherits the OpenAI session path; untested with body tools).