### PR TITLE
feat(vision-node): add gptme-vision-node — BobBrain vision pipeline v0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--config-file=mypy.ini, --explicit-package-bases]
     types: [python]
     pass_filenames: true
-    exclude: ^(packages/(bobutils|gptme-backoff|gptme-bob-status|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag|gptme-cc-memory)/|plugins/)
+    exclude: ^(packages/(bobutils|gptme-backoff|gptme-bob-status|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag|gptme-cc-memory|gptme-vision-node)/|plugins/)
 - repo: local
   hooks:
   - id: check-markdown-links

--- a/packages/gptme-vision-node/Makefile
+++ b/packages/gptme-vision-node/Makefile
@@ -1,0 +1,8 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+
+test:
+	uv run --extra test pytest tests/ -v
+
+typecheck:
+	uv run --with mypy mypy src/ --ignore-missing-imports

--- a/packages/gptme-vision-node/README.md
+++ b/packages/gptme-vision-node/README.md
@@ -1,0 +1,69 @@
+# gptme-vision-node
+
+Vision pipeline for the **BobBrain presence node** — the "eyes" half of the
+portable brain payload (see `bobbrain-spec.md`, ErikBjare/bob#730). Milestone 2
+(vision v0): periodic frame capture, cheap on-node detection reflexes, an
+on-demand LLM "look" tool, and GPS-free place recognition.
+
+Deliberately light dependencies: `opencv-python-headless`, `numpy`, `httpx`.
+No torch/ultralytics/CLIP — all heavy inference is remote (that's the
+architecture), and the on-node detectors are OpenCV built-ins.
+
+## Components
+
+| Module | What |
+|---|---|
+| `frame_source` | `FrameSource` protocol; `ImageFileSource` (file or dir round-robin), `OpenCVCameraSource` (V4L2 index / RTSP URL) |
+| `detect` | `PersonDetector` (OpenCV HOG, no model downloads), `MotionDetector` (frame differencing vs running-average background) |
+| `look` | `describe_frame(frame, prompt)` → vision LLM via any OpenAI-compatible endpoint (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `VISION_MODEL`) |
+| `place` | "Where am I?": `HistogramEmbedder` (HSV + spatial grid baseline), `WifiSignature` (nmcli BSSID/RSSI fingerprints), `PlaceRecognizer` (fused enroll/recognize, JSON gallery) |
+| `pipeline` | `VisionPipeline` — capture → detect → `VisionEvent` (person_appeared / person_left / motion) callback; keeps `latest_frame` for the look tool |
+| `cli` | `gptme-vision-node {detect,look,enroll,whereami}` |
+
+## Usage
+
+```bash
+# Detection on a webcam (or an image/dir for testing)
+gptme-vision-node detect --source camera:0
+gptme-vision-node detect --source photos/ --once
+
+# Ask a vision LLM what's in view (needs OPENAI_API_KEY)
+gptme-vision-node look --source camera:0 --prompt "Who is in the room?"
+
+# Place recognition: enroll a few samples per room, then ask
+gptme-vision-node enroll --place kitchen --source camera:0
+gptme-vision-node enroll --place office --source camera:0
+gptme-vision-node whereami --source camera:0
+```
+
+The place gallery defaults to `~/.config/gptme-vision-node/places.json`.
+WiFi fingerprints (visible BSSIDs + signal) are captured automatically when
+`nmcli` is available and fused with the visual score (`--no-wifi` to skip).
+
+```python
+from gptme_vision_node import VisionPipeline, ImageFileSource, PersonDetector, MotionDetector
+
+pipeline = VisionPipeline(
+    ImageFileSource("frames/"),
+    [PersonDetector(), MotionDetector()],
+    interval_s=1.0,
+    on_event=lambda e: print(e.kind, e.detections),
+)
+pipeline.start()
+```
+
+## Future (explicitly not v0)
+
+- **CLIP embeddings** for place recognition — a strict upgrade over the
+  histogram baseline (viewpoint/lighting invariance); would ship as an
+  optional extra implementing the same `Embedder` protocol.
+- On-demand live streaming (WebRTC/RTSP) to the host — vision v1 in the spec.
+
+## Tests
+
+```bash
+uv run pytest packages/gptme-vision-node -q
+```
+
+Fully offline: synthetic numpy images, no camera, no network (LLM calls
+mocked).

--- a/packages/gptme-vision-node/pyproject.toml
+++ b/packages/gptme-vision-node/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "gptme-vision-node"
+version = "0.1.0"
+description = "Vision pipeline for the BobBrain presence node — frame capture, person/motion detection, LLM look tool, and place recognition"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    # <5: OpenCV 5.0 removed the legacy objdetect API (HOGDescriptor) that
+    # PersonDetector relies on for a no-model-download people detector.
+    "opencv-python-headless>=4.8,<5",
+    "numpy>=1.24",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+]
+
+[project.scripts]
+gptme-vision-node = "gptme_vision_node.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_vision_node"]

--- a/packages/gptme-vision-node/pyproject.toml
+++ b/packages/gptme-vision-node/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "opencv-python-headless>=4.8,<5",
     "numpy>=1.24",
     "httpx>=0.27",
+    "click>=8.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/gptme-vision-node/src/gptme_vision_node/__init__.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/__init__.py
@@ -1,0 +1,31 @@
+"""Vision pipeline for the BobBrain presence node.
+
+Frame capture, person/motion detection, an LLM "look" tool, and
+place recognition (visual + WiFi fingerprints). See the BobBrain spec
+(ErikBjare/bob#730) — this is milestone 2 (vision v0).
+"""
+
+from .detect import Detection, Detector, MotionDetector, PersonDetector
+from .frame_source import FrameSource, ImageFileSource, OpenCVCameraSource
+from .look import describe_frame
+from .pipeline import VisionEvent, VisionPipeline
+from .place import Embedder, HistogramEmbedder, PlaceRecognizer, WifiSignature
+
+__all__ = [
+    "Detection",
+    "Detector",
+    "Embedder",
+    "FrameSource",
+    "HistogramEmbedder",
+    "ImageFileSource",
+    "MotionDetector",
+    "OpenCVCameraSource",
+    "PersonDetector",
+    "PlaceRecognizer",
+    "VisionEvent",
+    "VisionPipeline",
+    "WifiSignature",
+    "describe_frame",
+]
+
+__version__ = "0.1.0"

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -141,7 +141,12 @@ def enroll(source_spec: str, place_name: str, gallery: str, no_wifi: bool) -> No
     frame = _capture_frame(source_spec)
     wifi = {} if no_wifi else WifiSignature.scan()
     recognizer.enroll(place_name, frame, wifi_sig=wifi or None)
-    recognizer.save(gallery_path)
+    try:
+        recognizer.save(gallery_path)
+    except OSError as exc:
+        raise click.ClickException(
+            f"failed to save gallery at {gallery_path}: {exc}"
+        ) from exc
     n = len(recognizer.places[place_name])
     click.echo(
         f"enrolled '{place_name}' (sample {n}, wifi APs: {len(wifi)}) -> {gallery_path}"

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -34,15 +34,25 @@ source_option = click.option(
 
 def make_source(spec: str) -> FrameSource:
     """Parse a source spec: ``camera:N``, a stream URL, or an image path."""
-    if spec.startswith("camera:"):
-        return OpenCVCameraSource(int(spec.split(":", 1)[1]))
-    if "://" in spec:  # rtsp://, http://, ...
-        return OpenCVCameraSource(spec)
-    return ImageFileSource(spec)
+    try:
+        if spec.startswith("camera:"):
+            return OpenCVCameraSource(int(spec.split(":", 1)[1]))
+        if "://" in spec:  # rtsp://, http://, ...
+            return OpenCVCameraSource(spec)
+        return ImageFileSource(spec)
+    except ValueError as exc:
+        if spec.startswith("camera:"):
+            raise click.ClickException(f"invalid camera index: {spec!r}") from exc
+        raise click.ClickException(str(exc)) from exc
+    except OSError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _get_frame_or_die(source: FrameSource) -> np.ndarray:
-    frame = source.get_frame()
+    try:
+        frame = source.get_frame()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
     if frame is None:
         raise click.ClickException("source produced no frame")
     return frame
@@ -63,10 +73,11 @@ def detect(source_spec: str, once: bool, interval: float) -> None:
     detectors: list[Detector] = [PersonDetector(), MotionDetector()]
     try:
         while True:
-            frame = source.get_frame()
-            if frame is None:
-                break
-            detections = [d for det in detectors for d in det.detect(frame)]
+            frame = _get_frame_or_die(source)
+            try:
+                detections = [d for det in detectors for d in det.detect(frame)]
+            except (RuntimeError, ValueError) as exc:
+                raise click.ClickException(str(exc)) from exc
             for d in detections:
                 click.echo(f"{d.kind}\tbox={d.box}\tscore={d.score:.3f}")
             if not detections:

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -73,6 +73,13 @@ def _capture_frame(source_spec: str) -> np.ndarray:
         _release_source(source)
 
 
+def _load_gallery(path: Path) -> PlaceRecognizer:
+    try:
+        return PlaceRecognizer.from_file(path)
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(f"invalid gallery at {path}: {exc}") from exc
+
+
 @click.group()
 def main() -> None:
     """Vision pipeline for the BobBrain presence node."""
@@ -129,9 +136,7 @@ def enroll(source_spec: str, place_name: str, gallery: str, no_wifi: bool) -> No
     """Enroll a sample of a named place into the gallery."""
     gallery_path = Path(gallery)
     recognizer = (
-        PlaceRecognizer.from_file(gallery_path)
-        if gallery_path.exists()
-        else PlaceRecognizer()
+        _load_gallery(gallery_path) if gallery_path.exists() else PlaceRecognizer()
     )
     frame = _capture_frame(source_spec)
     wifi = {} if no_wifi else WifiSignature.scan()
@@ -155,7 +160,7 @@ def whereami(source_spec: str, gallery: str, no_wifi: bool, as_json: bool) -> No
         raise click.ClickException(
             f"no gallery at {gallery_path} (enroll some places first)"
         )
-    recognizer = PlaceRecognizer.from_file(gallery_path)
+    recognizer = _load_gallery(gallery_path)
     frame = _capture_frame(source_spec)
     wifi = {} if no_wifi else WifiSignature.scan()
     results = recognizer.recognize(frame, wifi_sig=wifi or None)

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -10,11 +10,12 @@ Subcommands:
 
 from __future__ import annotations
 
-import argparse
 import json
-import sys
 import time
 from pathlib import Path
+
+import click
+import numpy as np
 
 from .detect import Detector, MotionDetector, PersonDetector
 from .frame_source import FrameSource, ImageFileSource, OpenCVCameraSource
@@ -22,6 +23,13 @@ from .look import describe_frame
 from .place import PlaceRecognizer, WifiSignature
 
 DEFAULT_GALLERY = Path.home() / ".config" / "gptme-vision-node" / "places.json"
+
+source_option = click.option(
+    "--source",
+    "source_spec",
+    required=True,
+    help="image file/dir, camera:N, or a stream URL (rtsp://...)",
+)
 
 
 def make_source(spec: str) -> FrameSource:
@@ -33,16 +41,25 @@ def make_source(spec: str) -> FrameSource:
     return ImageFileSource(spec)
 
 
-def _get_frame_or_die(source: FrameSource):
+def _get_frame_or_die(source: FrameSource) -> np.ndarray:
     frame = source.get_frame()
     if frame is None:
-        print("error: source produced no frame", file=sys.stderr)
-        raise SystemExit(1)
+        raise click.ClickException("source produced no frame")
     return frame
 
 
-def cmd_detect(args: argparse.Namespace) -> int:
-    source = make_source(args.source)
+@click.group()
+def main() -> None:
+    """Vision pipeline for the BobBrain presence node."""
+
+
+@main.command()
+@source_option
+@click.option("--once", is_flag=True, help="single frame, then exit")
+@click.option("--interval", type=float, default=1.0, help="seconds between frames")
+def detect(source_spec: str, once: bool, interval: float) -> None:
+    """Run person/motion detection on a source."""
+    source = make_source(source_spec)
     detectors: list[Detector] = [PersonDetector(), MotionDetector()]
     try:
         while True:
@@ -51,124 +68,79 @@ def cmd_detect(args: argparse.Namespace) -> int:
                 break
             detections = [d for det in detectors for d in det.detect(frame)]
             for d in detections:
-                print(f"{d.kind}\tbox={d.box}\tscore={d.score:.3f}")
+                click.echo(f"{d.kind}\tbox={d.box}\tscore={d.score:.3f}")
             if not detections:
-                print("(no detections)")
-            if args.once:
+                click.echo("(no detections)")
+            if once:
                 break
-            time.sleep(args.interval)
+            time.sleep(interval)
     except KeyboardInterrupt:
         pass
     finally:
         release = getattr(source, "release", None)
         if release:
             release()
-    return 0
 
 
-def cmd_look(args: argparse.Namespace) -> int:
-    source = make_source(args.source)
-    frame = _get_frame_or_die(source)
-    print(describe_frame(frame, args.prompt, model=args.model))
-    return 0
+@main.command()
+@source_option
+@click.option("--prompt", default="Describe what you see, briefly.")
+@click.option("--model", default=None, help="override VISION_MODEL")
+def look(source_spec: str, prompt: str, model: str | None) -> None:
+    """Describe the current frame via a vision LLM (needs OPENAI_API_KEY)."""
+    frame = _get_frame_or_die(make_source(source_spec))
+    click.echo(describe_frame(frame, prompt, model=model))
 
 
-def _load_recognizer(gallery: Path) -> PlaceRecognizer:
-    if gallery.exists():
-        return PlaceRecognizer.from_file(gallery)
-    return PlaceRecognizer()
-
-
-def cmd_enroll(args: argparse.Namespace) -> int:
-    gallery = Path(args.gallery)
-    recognizer = _load_recognizer(gallery)
-    source = make_source(args.source)
-    frame = _get_frame_or_die(source)
-    wifi = {} if args.no_wifi else WifiSignature.scan()
-    recognizer.enroll(args.place, frame, wifi_sig=wifi or None)
-    recognizer.save(gallery)
-    n = len(recognizer.places[args.place])
-    print(
-        f"enrolled '{args.place}' (sample {n}, " f"wifi APs: {len(wifi)}) -> {gallery}"
+@main.command()
+@source_option
+@click.option("--place", "place_name", required=True, help="place name")
+@click.option("--gallery", default=str(DEFAULT_GALLERY), show_default=True)
+@click.option("--no-wifi", is_flag=True, help="skip the wifi scan")
+def enroll(source_spec: str, place_name: str, gallery: str, no_wifi: bool) -> None:
+    """Enroll a sample of a named place into the gallery."""
+    gallery_path = Path(gallery)
+    recognizer = (
+        PlaceRecognizer.from_file(gallery_path)
+        if gallery_path.exists()
+        else PlaceRecognizer()
     )
-    return 0
+    frame = _get_frame_or_die(make_source(source_spec))
+    wifi = {} if no_wifi else WifiSignature.scan()
+    recognizer.enroll(place_name, frame, wifi_sig=wifi or None)
+    recognizer.save(gallery_path)
+    n = len(recognizer.places[place_name])
+    click.echo(
+        f"enrolled '{place_name}' (sample {n}, wifi APs: {len(wifi)}) -> {gallery_path}"
+    )
 
 
-def cmd_whereami(args: argparse.Namespace) -> int:
-    gallery = Path(args.gallery)
-    if not gallery.exists():
-        print(
-            f"error: no gallery at {gallery} (enroll some places first)",
-            file=sys.stderr,
+@main.command()
+@source_option
+@click.option("--gallery", default=str(DEFAULT_GALLERY), show_default=True)
+@click.option("--no-wifi", is_flag=True, help="skip the wifi scan")
+@click.option("--json", "as_json", is_flag=True, help="JSON output")
+def whereami(source_spec: str, gallery: str, no_wifi: bool, as_json: bool) -> None:
+    """Rank enrolled places for the current view."""
+    gallery_path = Path(gallery)
+    if not gallery_path.exists():
+        raise click.ClickException(
+            f"no gallery at {gallery_path} (enroll some places first)"
         )
-        return 1
-    recognizer = PlaceRecognizer.from_file(gallery)
-    source = make_source(args.source)
-    frame = _get_frame_or_die(source)
-    wifi = {} if args.no_wifi else WifiSignature.scan()
+    recognizer = PlaceRecognizer.from_file(gallery_path)
+    frame = _get_frame_or_die(make_source(source_spec))
+    wifi = {} if no_wifi else WifiSignature.scan()
     results = recognizer.recognize(frame, wifi_sig=wifi or None)
     if not results:
-        print("no matches (gallery empty or no comparable signals)")
-        return 1
-    if args.json:
-        print(json.dumps([{"place": n, "score": s} for n, s in results]))
+        raise click.ClickException(
+            "no matches (gallery empty or no comparable signals)"
+        )
+    if as_json:
+        click.echo(json.dumps([{"place": n, "score": s} for n, s in results]))
     else:
         for name, score in results:
-            print(f"{score:.3f}\t{name}")
-    return 0
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="gptme-vision-node",
-        description="Vision pipeline for the BobBrain presence node",
-    )
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    def add_source(p: argparse.ArgumentParser) -> None:
-        p.add_argument(
-            "--source",
-            required=True,
-            help="image file/dir, camera:N, or a stream URL (rtsp://...)",
-        )
-
-    p_detect = sub.add_parser("detect", help="run person/motion detection")
-    add_source(p_detect)
-    p_detect.add_argument("--once", action="store_true", help="single frame, then exit")
-    p_detect.add_argument(
-        "--interval", type=float, default=1.0, help="seconds between frames"
-    )
-    p_detect.set_defaults(func=cmd_detect)
-
-    p_look = sub.add_parser("look", help="describe the current frame via a vision LLM")
-    add_source(p_look)
-    p_look.add_argument("--prompt", default="Describe what you see, briefly.")
-    p_look.add_argument("--model", default=None, help="override VISION_MODEL")
-    p_look.set_defaults(func=cmd_look)
-
-    p_enroll = sub.add_parser("enroll", help="enroll a sample of a named place")
-    add_source(p_enroll)
-    p_enroll.add_argument("--place", required=True, help="place name")
-    p_enroll.add_argument("--gallery", default=str(DEFAULT_GALLERY))
-    p_enroll.add_argument("--no-wifi", action="store_true", help="skip the wifi scan")
-    p_enroll.set_defaults(func=cmd_enroll)
-
-    p_where = sub.add_parser(
-        "whereami", help="rank enrolled places for the current view"
-    )
-    add_source(p_where)
-    p_where.add_argument("--gallery", default=str(DEFAULT_GALLERY))
-    p_where.add_argument("--no-wifi", action="store_true", help="skip the wifi scan")
-    p_where.add_argument("--json", action="store_true", help="JSON output")
-    p_where.set_defaults(func=cmd_whereami)
-
-    return parser
-
-
-def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    return int(args.func(args))
+            click.echo(f"{score:.3f}\t{name}")
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -76,7 +76,7 @@ def _capture_frame(source_spec: str) -> np.ndarray:
 def _load_gallery(path: Path) -> PlaceRecognizer:
     try:
         return PlaceRecognizer.from_file(path)
-    except (OSError, ValueError) as exc:
+    except (OSError, TypeError, ValueError) as exc:
         raise click.ClickException(f"invalid gallery at {path}: {exc}") from exc
 
 

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 
 import click
+import cv2
 import httpx
 import numpy as np
 
@@ -104,7 +105,7 @@ def detect(source_spec: str, once: bool, interval: float) -> None:
                 break
             try:
                 detections = [d for det in detectors for d in det.detect(frame)]
-            except (RuntimeError, ValueError) as exc:
+            except (cv2.error, RuntimeError, ValueError) as exc:
                 raise click.ClickException(str(exc)) from exc
             for d in detections:
                 click.echo(f"{d.kind}\tbox={d.box}\tscore={d.score:.3f}")

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -1,0 +1,174 @@
+"""CLI for the vision node.
+
+Subcommands:
+
+- ``detect``   — run detectors on a source, print detections
+- ``look``     — describe the current frame via a vision LLM
+- ``enroll``   — add sample(s) of a named place to the gallery
+- ``whereami`` — rank enrolled places for the current observation
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from .detect import Detector, MotionDetector, PersonDetector
+from .frame_source import FrameSource, ImageFileSource, OpenCVCameraSource
+from .look import describe_frame
+from .place import PlaceRecognizer, WifiSignature
+
+DEFAULT_GALLERY = Path.home() / ".config" / "gptme-vision-node" / "places.json"
+
+
+def make_source(spec: str) -> FrameSource:
+    """Parse a source spec: ``camera:N``, a stream URL, or an image path."""
+    if spec.startswith("camera:"):
+        return OpenCVCameraSource(int(spec.split(":", 1)[1]))
+    if "://" in spec:  # rtsp://, http://, ...
+        return OpenCVCameraSource(spec)
+    return ImageFileSource(spec)
+
+
+def _get_frame_or_die(source: FrameSource):
+    frame = source.get_frame()
+    if frame is None:
+        print("error: source produced no frame", file=sys.stderr)
+        raise SystemExit(1)
+    return frame
+
+
+def cmd_detect(args: argparse.Namespace) -> int:
+    source = make_source(args.source)
+    detectors: list[Detector] = [PersonDetector(), MotionDetector()]
+    try:
+        while True:
+            frame = source.get_frame()
+            if frame is None:
+                break
+            detections = [d for det in detectors for d in det.detect(frame)]
+            for d in detections:
+                print(f"{d.kind}\tbox={d.box}\tscore={d.score:.3f}")
+            if not detections:
+                print("(no detections)")
+            if args.once:
+                break
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        release = getattr(source, "release", None)
+        if release:
+            release()
+    return 0
+
+
+def cmd_look(args: argparse.Namespace) -> int:
+    source = make_source(args.source)
+    frame = _get_frame_or_die(source)
+    print(describe_frame(frame, args.prompt, model=args.model))
+    return 0
+
+
+def _load_recognizer(gallery: Path) -> PlaceRecognizer:
+    if gallery.exists():
+        return PlaceRecognizer.from_file(gallery)
+    return PlaceRecognizer()
+
+
+def cmd_enroll(args: argparse.Namespace) -> int:
+    gallery = Path(args.gallery)
+    recognizer = _load_recognizer(gallery)
+    source = make_source(args.source)
+    frame = _get_frame_or_die(source)
+    wifi = {} if args.no_wifi else WifiSignature.scan()
+    recognizer.enroll(args.place, frame, wifi_sig=wifi or None)
+    recognizer.save(gallery)
+    n = len(recognizer.places[args.place])
+    print(
+        f"enrolled '{args.place}' (sample {n}, " f"wifi APs: {len(wifi)}) -> {gallery}"
+    )
+    return 0
+
+
+def cmd_whereami(args: argparse.Namespace) -> int:
+    gallery = Path(args.gallery)
+    if not gallery.exists():
+        print(
+            f"error: no gallery at {gallery} (enroll some places first)",
+            file=sys.stderr,
+        )
+        return 1
+    recognizer = PlaceRecognizer.from_file(gallery)
+    source = make_source(args.source)
+    frame = _get_frame_or_die(source)
+    wifi = {} if args.no_wifi else WifiSignature.scan()
+    results = recognizer.recognize(frame, wifi_sig=wifi or None)
+    if not results:
+        print("no matches (gallery empty or no comparable signals)")
+        return 1
+    if args.json:
+        print(json.dumps([{"place": n, "score": s} for n, s in results]))
+    else:
+        for name, score in results:
+            print(f"{score:.3f}\t{name}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gptme-vision-node",
+        description="Vision pipeline for the BobBrain presence node",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_source(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--source",
+            required=True,
+            help="image file/dir, camera:N, or a stream URL (rtsp://...)",
+        )
+
+    p_detect = sub.add_parser("detect", help="run person/motion detection")
+    add_source(p_detect)
+    p_detect.add_argument("--once", action="store_true", help="single frame, then exit")
+    p_detect.add_argument(
+        "--interval", type=float, default=1.0, help="seconds between frames"
+    )
+    p_detect.set_defaults(func=cmd_detect)
+
+    p_look = sub.add_parser("look", help="describe the current frame via a vision LLM")
+    add_source(p_look)
+    p_look.add_argument("--prompt", default="Describe what you see, briefly.")
+    p_look.add_argument("--model", default=None, help="override VISION_MODEL")
+    p_look.set_defaults(func=cmd_look)
+
+    p_enroll = sub.add_parser("enroll", help="enroll a sample of a named place")
+    add_source(p_enroll)
+    p_enroll.add_argument("--place", required=True, help="place name")
+    p_enroll.add_argument("--gallery", default=str(DEFAULT_GALLERY))
+    p_enroll.add_argument("--no-wifi", action="store_true", help="skip the wifi scan")
+    p_enroll.set_defaults(func=cmd_enroll)
+
+    p_where = sub.add_parser(
+        "whereami", help="rank enrolled places for the current view"
+    )
+    add_source(p_where)
+    p_where.add_argument("--gallery", default=str(DEFAULT_GALLERY))
+    p_where.add_argument("--no-wifi", action="store_true", help="skip the wifi scan")
+    p_where.add_argument("--json", action="store_true", help="JSON output")
+    p_where.set_defaults(func=cmd_whereami)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 
 import click
+import httpx
 import numpy as np
 
 from .detect import Detector, MotionDetector, PersonDetector
@@ -58,6 +59,20 @@ def _get_frame_or_die(source: FrameSource) -> np.ndarray:
     return frame
 
 
+def _release_source(source: FrameSource) -> None:
+    release = getattr(source, "release", None)
+    if release:
+        release()
+
+
+def _capture_frame(source_spec: str) -> np.ndarray:
+    source = make_source(source_spec)
+    try:
+        return _get_frame_or_die(source)
+    finally:
+        _release_source(source)
+
+
 @click.group()
 def main() -> None:
     """Vision pipeline for the BobBrain presence node."""
@@ -88,9 +103,7 @@ def detect(source_spec: str, once: bool, interval: float) -> None:
     except KeyboardInterrupt:
         pass
     finally:
-        release = getattr(source, "release", None)
-        if release:
-            release()
+        _release_source(source)
 
 
 @main.command()
@@ -99,8 +112,12 @@ def detect(source_spec: str, once: bool, interval: float) -> None:
 @click.option("--model", default=None, help="override VISION_MODEL")
 def look(source_spec: str, prompt: str, model: str | None) -> None:
     """Describe the current frame via a vision LLM (needs OPENAI_API_KEY)."""
-    frame = _get_frame_or_die(make_source(source_spec))
-    click.echo(describe_frame(frame, prompt, model=model))
+    frame = _capture_frame(source_spec)
+    try:
+        description = describe_frame(frame, prompt, model=model)
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(description)
 
 
 @main.command()
@@ -116,7 +133,7 @@ def enroll(source_spec: str, place_name: str, gallery: str, no_wifi: bool) -> No
         if gallery_path.exists()
         else PlaceRecognizer()
     )
-    frame = _get_frame_or_die(make_source(source_spec))
+    frame = _capture_frame(source_spec)
     wifi = {} if no_wifi else WifiSignature.scan()
     recognizer.enroll(place_name, frame, wifi_sig=wifi or None)
     recognizer.save(gallery_path)
@@ -139,7 +156,7 @@ def whereami(source_spec: str, gallery: str, no_wifi: bool, as_json: bool) -> No
             f"no gallery at {gallery_path} (enroll some places first)"
         )
     recognizer = PlaceRecognizer.from_file(gallery_path)
-    frame = _get_frame_or_die(make_source(source_spec))
+    frame = _capture_frame(source_spec)
     wifi = {} if no_wifi else WifiSignature.scan()
     results = recognizer.recognize(frame, wifi_sig=wifi or None)
     if not results:

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -49,11 +49,15 @@ def make_source(spec: str) -> FrameSource:
         raise click.ClickException(str(exc)) from exc
 
 
-def _get_frame_or_die(source: FrameSource) -> np.ndarray:
+def _get_frame(source: FrameSource) -> np.ndarray | None:
     try:
-        frame = source.get_frame()
+        return source.get_frame()
     except (OSError, RuntimeError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+def _get_frame_or_die(source: FrameSource) -> np.ndarray:
+    frame = _get_frame(source)
     if frame is None:
         raise click.ClickException("source produced no frame")
     return frame
@@ -95,7 +99,9 @@ def detect(source_spec: str, once: bool, interval: float) -> None:
     detectors: list[Detector] = [PersonDetector(), MotionDetector()]
     try:
         while True:
-            frame = _get_frame_or_die(source)
+            frame = _get_frame(source)
+            if frame is None:
+                break
             try:
                 detections = [d for det in detectors for d in det.detect(frame)]
             except (RuntimeError, ValueError) as exc:

--- a/packages/gptme-vision-node/src/gptme_vision_node/cli.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/cli.py
@@ -53,7 +53,7 @@ def make_source(spec: str) -> FrameSource:
 def _get_frame(source: FrameSource) -> np.ndarray | None:
     try:
         return source.get_frame()
-    except (OSError, RuntimeError, ValueError) as exc:
+    except (cv2.error, OSError, RuntimeError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
 
 

--- a/packages/gptme-vision-node/src/gptme_vision_node/detect.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/detect.py
@@ -56,20 +56,30 @@ class PersonDetector:
         self.score_threshold = score_threshold
 
     def detect(self, frame: np.ndarray) -> list[Detection]:
-        # HOG needs a minimum window (64x128); upscale tiny frames.
-        h, w = frame.shape[:2]
-        if h < 128 or w < 64:
-            frame = cv2.resize(frame, (max(w, 64), max(h, 128)))
+        # HOG needs a minimum window (64x128); upscale tiny frames and map
+        # detections back to the caller's coordinate space.
+        original_h, original_w = frame.shape[:2]
+        input_h, input_w = max(original_h, 128), max(original_w, 64)
+        if (input_h, input_w) != (original_h, original_w):
+            frame = cv2.resize(frame, (input_w, input_h))
         boxes, weights = self._hog.detectMultiScale(
             frame, winStride=self.win_stride, scale=self.scale
         )
+        x_scale = original_w / input_w
+        y_scale = original_h / input_h
         detections = []
         for box, weight in zip(boxes, np.ravel(weights)):
             score = float(weight)
             if score < self.score_threshold:
                 continue
             x, y, bw, bh = (int(v) for v in box)
-            detections.append(Detection(kind="person", box=(x, y, bw, bh), score=score))
+            mapped_box = (
+                round(x * x_scale),
+                round(y * y_scale),
+                round(bw * x_scale),
+                round(bh * y_scale),
+            )
+            detections.append(Detection(kind="person", box=mapped_box, score=score))
         return detections
 
 
@@ -107,7 +117,7 @@ class MotionDetector:
 
     def detect(self, frame: np.ndarray) -> list[Detection]:
         gray = self._prepare(frame)
-        if self._background is None:
+        if self._background is None or self._background.shape != gray.shape:
             self._background = gray
             return []
 

--- a/packages/gptme-vision-node/src/gptme_vision_node/detect.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/detect.py
@@ -100,6 +100,8 @@ class MotionDetector:
         min_area_fraction: float = 0.005,
         blur_ksize: int = 5,
     ) -> None:
+        if blur_ksize <= 0 or blur_ksize % 2 == 0:
+            raise ValueError("blur_ksize must be a positive odd integer")
         self.alpha = alpha
         self.threshold = threshold
         self.min_area_fraction = min_area_fraction

--- a/packages/gptme-vision-node/src/gptme_vision_node/detect.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/detect.py
@@ -1,0 +1,136 @@
+"""Person and motion detection with plain OpenCV — no model downloads.
+
+``PersonDetector`` uses OpenCV's built-in HOG people detector.
+``MotionDetector`` uses frame differencing against a running-average
+background model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import cv2
+import numpy as np
+
+Box = tuple[int, int, int, int]  # x, y, w, h
+
+
+@dataclass(frozen=True)
+class Detection:
+    """One detection: what, where, and how confident."""
+
+    kind: str  # "person" | "motion"
+    box: Box
+    score: float
+
+
+@runtime_checkable
+class Detector(Protocol):
+    """Anything that can turn a frame into detections."""
+
+    def detect(self, frame: np.ndarray) -> list[Detection]: ...
+
+
+class PersonDetector:
+    """HOG + linear-SVM people detector (ships with OpenCV, no downloads).
+
+    Not state of the art, but dependency-free and fine for "someone is
+    here" presence events at v0. Swap for a real model later via the same
+    ``detect(frame) -> list[Detection]`` interface.
+    """
+
+    def __init__(
+        self,
+        *,
+        win_stride: tuple[int, int] = (8, 8),
+        scale: float = 1.05,
+        score_threshold: float = 0.0,
+    ) -> None:
+        self._hog = cv2.HOGDescriptor()
+        self._hog.setSVMDetector(
+            np.asarray(cv2.HOGDescriptor.getDefaultPeopleDetector(), dtype=np.float64)
+        )
+        self.win_stride = win_stride
+        self.scale = scale
+        self.score_threshold = score_threshold
+
+    def detect(self, frame: np.ndarray) -> list[Detection]:
+        # HOG needs a minimum window (64x128); upscale tiny frames.
+        h, w = frame.shape[:2]
+        if h < 128 or w < 64:
+            frame = cv2.resize(frame, (max(w, 64), max(h, 128)))
+        boxes, weights = self._hog.detectMultiScale(
+            frame, winStride=self.win_stride, scale=self.scale
+        )
+        detections = []
+        for box, weight in zip(boxes, np.ravel(weights)):
+            score = float(weight)
+            if score < self.score_threshold:
+                continue
+            x, y, bw, bh = (int(v) for v in box)
+            detections.append(Detection(kind="person", box=(x, y, bw, bh), score=score))
+        return detections
+
+
+class MotionDetector:
+    """Frame differencing against an exponentially averaged background.
+
+    The first frame primes the background and yields no detections.
+    Subsequent frames are diffed against the background; contiguous
+    changed regions above ``min_area`` become ``motion`` detections whose
+    score is the fraction of the frame that changed (capped at 1.0).
+    """
+
+    def __init__(
+        self,
+        *,
+        alpha: float = 0.1,
+        threshold: int = 25,
+        min_area_fraction: float = 0.005,
+        blur_ksize: int = 5,
+    ) -> None:
+        self.alpha = alpha
+        self.threshold = threshold
+        self.min_area_fraction = min_area_fraction
+        self.blur_ksize = blur_ksize
+        self._background: np.ndarray | None = None
+
+    def reset(self) -> None:
+        self._background = None
+
+    def _prepare(self, frame: np.ndarray) -> np.ndarray:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        if self.blur_ksize > 1:
+            gray = cv2.GaussianBlur(gray, (self.blur_ksize, self.blur_ksize), 0)
+        return gray.astype(np.float32)
+
+    def detect(self, frame: np.ndarray) -> list[Detection]:
+        gray = self._prepare(frame)
+        if self._background is None:
+            self._background = gray
+            return []
+
+        diff = cv2.absdiff(gray, self._background)
+        # Update the background after diffing so sustained change keeps firing
+        # for a while, then fades in as the new background.
+        cv2.accumulateWeighted(gray, self._background, self.alpha)
+
+        mask = (diff > self.threshold).astype(np.uint8) * 255
+        mask = np.asarray(
+            cv2.dilate(mask, np.ones((3, 3), np.uint8), iterations=2), dtype=np.uint8
+        )
+
+        frame_area = mask.shape[0] * mask.shape[1]
+        min_area = self.min_area_fraction * frame_area
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+        detections = []
+        for contour in contours:
+            area = cv2.contourArea(contour)
+            if area < min_area:
+                continue
+            x, y, w, h = cv2.boundingRect(contour)
+            score = min(1.0, float(area) / frame_area * 10.0)
+            detections.append(Detection(kind="motion", box=(x, y, w, h), score=score))
+        return detections

--- a/packages/gptme-vision-node/src/gptme_vision_node/frame_source.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/frame_source.py
@@ -1,0 +1,95 @@
+"""Frame sources: anything that can hand the pipeline a BGR frame.
+
+All frames are numpy arrays in OpenCV's BGR channel order.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import cv2
+import numpy as np
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".webp", ".tiff"}
+
+
+@runtime_checkable
+class FrameSource(Protocol):
+    """A source of BGR frames."""
+
+    def get_frame(self) -> np.ndarray | None:
+        """Return the next frame (BGR), or None if none is available."""
+        ...
+
+
+class ImageFileSource:
+    """Serve frames from a single image file or a directory of images.
+
+    A single file is returned on every call. A directory is served
+    round-robin in sorted filename order (wrapping unless ``loop=False``,
+    in which case ``get_frame`` returns None after one full pass).
+    """
+
+    def __init__(self, path: str | Path, *, loop: bool = True) -> None:
+        self.path = Path(path)
+        self.loop = loop
+        self._index = 0
+        if self.path.is_dir():
+            self._files = sorted(
+                p for p in self.path.iterdir() if p.suffix.lower() in IMAGE_EXTENSIONS
+            )
+            if not self._files:
+                raise ValueError(f"no images found in directory: {self.path}")
+        elif self.path.is_file():
+            self._files = [self.path]
+        else:
+            raise FileNotFoundError(f"no such file or directory: {self.path}")
+
+    def get_frame(self) -> np.ndarray | None:
+        if self._index >= len(self._files):
+            if not self.loop:
+                return None
+            self._index = 0
+        file = self._files[self._index]
+        self._index += 1
+        frame = cv2.imread(str(file), cv2.IMREAD_COLOR)
+        if frame is None:
+            raise ValueError(f"failed to decode image: {file}")
+        return frame
+
+    def release(self) -> None:  # symmetry with OpenCVCameraSource
+        pass
+
+
+class OpenCVCameraSource:
+    """Webcam (V4L2 index), Pi camera, or network stream (RTSP/HTTP URL).
+
+    The capture is opened lazily on first ``get_frame`` so constructing the
+    source is cheap and testable without hardware.
+    """
+
+    def __init__(self, source: int | str) -> None:
+        self.source = source
+        self._cap: cv2.VideoCapture | None = None
+
+    def _ensure_open(self) -> cv2.VideoCapture:
+        if self._cap is None:
+            self._cap = cv2.VideoCapture(self.source)
+            if not self._cap.isOpened():
+                cap, self._cap = self._cap, None
+                cap.release()
+                raise RuntimeError(f"failed to open capture source: {self.source!r}")
+        return self._cap
+
+    def get_frame(self) -> np.ndarray | None:
+        cap = self._ensure_open()
+        ok, frame = cap.read()
+        if not ok or frame is None:
+            return None
+        return frame
+
+    def release(self) -> None:
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None

--- a/packages/gptme-vision-node/src/gptme_vision_node/frame_source.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/frame_source.py
@@ -69,8 +69,11 @@ class OpenCVCameraSource:
     source is cheap and testable without hardware.
     """
 
-    def __init__(self, source: int | str) -> None:
+    def __init__(self, source: int | str, *, read_attempts: int = 3) -> None:
+        if read_attempts < 1:
+            raise ValueError("read_attempts must be at least 1")
         self.source = source
+        self.read_attempts = read_attempts
         self._cap: cv2.VideoCapture | None = None
 
     def _ensure_open(self) -> cv2.VideoCapture:
@@ -84,10 +87,11 @@ class OpenCVCameraSource:
 
     def get_frame(self) -> np.ndarray | None:
         cap = self._ensure_open()
-        ok, frame = cap.read()
-        if not ok or frame is None:
-            return None
-        return frame
+        for _ in range(self.read_attempts):
+            ok, frame = cap.read()
+            if ok and frame is not None:
+                return frame
+        return None
 
     def release(self) -> None:
         if self._cap is not None:

--- a/packages/gptme-vision-node/src/gptme_vision_node/look.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/look.py
@@ -1,0 +1,96 @@
+"""The LLM "look" tool: describe a frame via a vision-capable chat model.
+
+Talks to any OpenAI-compatible chat-completions endpoint. Configuration
+via env vars:
+
+- ``OPENAI_API_KEY`` — required (unless ``api_key`` is passed)
+- ``OPENAI_BASE_URL`` — default ``https://api.openai.com/v1``
+- ``VISION_MODEL`` — default ``gpt-4o-mini``
+
+This is the on-demand "see things" toolcall the voice bridge wires into
+the realtime session.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any
+
+import cv2
+import httpx
+import numpy as np
+
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_PROMPT = "Describe what you see in this image, briefly."
+
+
+def encode_frame_jpeg(frame: np.ndarray, *, quality: int = 85) -> bytes:
+    """JPEG-encode a BGR frame."""
+    ok, buf = cv2.imencode(".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), quality])
+    if not ok:
+        raise ValueError("failed to JPEG-encode frame")
+    return buf.tobytes()
+
+
+def build_request(
+    frame: np.ndarray,
+    prompt: str = DEFAULT_PROMPT,
+    *,
+    model: str | None = None,
+    max_tokens: int = 500,
+    jpeg_quality: int = 85,
+) -> dict[str, Any]:
+    """Build the chat-completions request body for a frame + prompt."""
+    jpeg = encode_frame_jpeg(frame, quality=jpeg_quality)
+    b64 = base64.b64encode(jpeg).decode("ascii")
+    return {
+        "model": model or os.environ.get("VISION_MODEL", DEFAULT_MODEL),
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def describe_frame(
+    frame: np.ndarray,
+    prompt: str = DEFAULT_PROMPT,
+    *,
+    model: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    timeout: float = 60.0,
+) -> str:
+    """Send a frame to a vision LLM and return its description."""
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is not set (and no api_key passed)")
+    url = (base_url or os.environ.get("OPENAI_BASE_URL", DEFAULT_BASE_URL)).rstrip("/")
+
+    body = build_request(frame, prompt, model=model)
+    response = httpx.post(
+        f"{url}/chat/completions",
+        json=body,
+        headers={"Authorization": f"Bearer {key}"},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    data = response.json()
+    try:
+        content = data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as e:
+        raise ValueError(f"unexpected response shape: {data!r}") from e
+    if not isinstance(content, str):
+        raise ValueError(f"unexpected response content type: {type(content)}")
+    return content

--- a/packages/gptme-vision-node/src/gptme_vision_node/look.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/look.py
@@ -85,8 +85,11 @@ def describe_frame(
         headers={"Authorization": f"Bearer {key}"},
         timeout=timeout,
     )
-    response.raise_for_status()
-    data = response.json()
+    try:
+        response.raise_for_status()
+        data = response.json()
+    finally:
+        response.close()
     try:
         content = data["choices"][0]["message"]["content"]
     except (KeyError, IndexError, TypeError) as e:

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -78,11 +78,8 @@ class VisionPipeline:
         except Exception:
             logger.exception("event callback failed for %s", event.kind)
 
-    def step(self) -> list[VisionEvent]:
-        """One iteration: capture, detect, emit. Returns emitted events."""
-        frame = self.source.get_frame()
-        if frame is None:
-            return []
+    def _process_frame(self, frame: np.ndarray) -> list[VisionEvent]:
+        """Run detectors and emit events for one captured frame."""
         self.latest_frame = frame
 
         detections: list[Detection] = []
@@ -114,13 +111,21 @@ class VisionPipeline:
             self._emit(event)
         return events
 
+    def step(self) -> list[VisionEvent]:
+        """One iteration: capture, detect, emit. Returns emitted events."""
+        frame = self.source.get_frame()
+        return [] if frame is None else self._process_frame(frame)
+
     # -- thread lifecycle --------------------------------------------------
 
     def _run(self) -> None:
         while not self._stop.is_set():
             started = time.monotonic()
             try:
-                self.step()
+                frame = self.source.get_frame()
+                if frame is None:
+                    break
+                self._process_frame(frame)
             except Exception:
                 logger.exception("pipeline step failed")
             elapsed = time.monotonic() - started

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -1,0 +1,142 @@
+"""The capture -> detect -> event loop.
+
+Thread-based (the node targets a Pi; one capture thread at ~1 Hz is
+plenty and keeps the package free of async plumbing at v0). The pipeline
+keeps ``latest_frame`` around so the LLM look tool can answer "what do
+you see right now?" without a second capture path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable
+
+import numpy as np
+
+from .detect import Detection, Detector
+
+logger = logging.getLogger(__name__)
+
+# Event kinds
+PERSON_APPEARED = "person_appeared"
+PERSON_LEFT = "person_left"
+MOTION = "motion"
+
+
+@dataclass(frozen=True)
+class VisionEvent:
+    """Something noteworthy the pipeline saw."""
+
+    kind: str  # person_appeared | person_left | motion
+    detections: tuple[Detection, ...] = ()
+    timestamp: float = field(default_factory=time.time)
+
+
+EventCallback = Callable[[VisionEvent], None]
+
+
+class VisionPipeline:
+    """Capture frames, run detectors, emit events.
+
+    - ``person_appeared`` / ``person_left``: edge-triggered on any
+      ``person`` detections being present, debounced by
+      ``absent_frames_for_left`` consecutive empty frames.
+    - ``motion``: emitted whenever any ``motion`` detections fire.
+    """
+
+    def __init__(
+        self,
+        source,
+        detectors: list[Detector],
+        *,
+        interval_s: float = 1.0,
+        on_event: EventCallback | None = None,
+        absent_frames_for_left: int = 3,
+    ) -> None:
+        self.source = source
+        self.detectors = detectors
+        self.interval_s = interval_s
+        self.on_event = on_event
+        self.absent_frames_for_left = absent_frames_for_left
+
+        self.latest_frame: np.ndarray | None = None
+        self._person_present = False
+        self._frames_without_person = 0
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    # -- core -------------------------------------------------------------
+
+    def _emit(self, event: VisionEvent) -> None:
+        if self.on_event is None:
+            return
+        try:
+            self.on_event(event)
+        except Exception:
+            logger.exception("event callback failed for %s", event.kind)
+
+    def step(self) -> list[VisionEvent]:
+        """One iteration: capture, detect, emit. Returns emitted events."""
+        frame = self.source.get_frame()
+        if frame is None:
+            return []
+        self.latest_frame = frame
+
+        detections: list[Detection] = []
+        for detector in self.detectors:
+            try:
+                detections.extend(detector.detect(frame))
+            except Exception:
+                logger.exception("detector %r failed", detector)
+
+        events: list[VisionEvent] = []
+        persons = tuple(d for d in detections if d.kind == "person")
+        motions = tuple(d for d in detections if d.kind == "motion")
+
+        if persons:
+            self._frames_without_person = 0
+            if not self._person_present:
+                self._person_present = True
+                events.append(VisionEvent(PERSON_APPEARED, persons))
+        elif self._person_present:
+            self._frames_without_person += 1
+            if self._frames_without_person >= self.absent_frames_for_left:
+                self._person_present = False
+                events.append(VisionEvent(PERSON_LEFT))
+
+        if motions:
+            events.append(VisionEvent(MOTION, motions))
+
+        for event in events:
+            self._emit(event)
+        return events
+
+    # -- thread lifecycle --------------------------------------------------
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            started = time.monotonic()
+            try:
+                self.step()
+            except Exception:
+                logger.exception("pipeline step failed")
+            elapsed = time.monotonic() - started
+            self._stop.wait(max(0.0, self.interval_s - elapsed))
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("pipeline already running")
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="vision-pipeline", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -142,7 +142,8 @@ class VisionPipeline:
 
     def stop(self, timeout: float = 5.0) -> None:
         self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=timeout)
-            if not self._thread.is_alive():
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+            if not thread.is_alive():
                 self._thread = None

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -144,4 +144,5 @@ class VisionPipeline:
         self._stop.set()
         if self._thread is not None:
             self._thread.join(timeout=timeout)
-            self._thread = None
+            if not self._thread.is_alive():
+                self._thread = None

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -135,6 +135,8 @@ class VisionPipeline:
         if self._thread is not None and self._thread.is_alive():
             raise RuntimeError("pipeline already running")
         self._stop.clear()
+        self._person_present = False
+        self._frames_without_person = 0
         self._thread = threading.Thread(
             target=self._run, name="vision-pipeline", daemon=True
         )

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -296,6 +296,8 @@ class PlaceRecognizer:
     def load(self, path: str | Path) -> None:
         """Load a gallery saved by :meth:`save` (replaces current places)."""
         payload = json.loads(Path(path).read_text())
+        if not isinstance(payload, dict):
+            raise ValueError("gallery file must contain a JSON object")
         saved_embedder = payload.get("embedder")
         if saved_embedder is not None and saved_embedder != self.embedder.embedder_id:
             raise ValueError(
@@ -330,6 +332,8 @@ class PlaceRecognizer:
         wifi_weight: float | None = None,
     ) -> PlaceRecognizer:
         payload = json.loads(Path(path).read_text())
+        if not isinstance(payload, dict):
+            raise ValueError("gallery file must contain a JSON object")
         recognizer = cls(
             embedder,
             wifi_weight=(

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -324,17 +324,24 @@ class PlaceRecognizer:
                 raise ValueError(
                     f"gallery place {name!r} samples must be a list of JSON objects"
                 )
-            places[name] = [
-                PlaceSample(
-                    embedding=(
-                        np.asarray(s["embedding"], dtype=np.float64)
-                        if s.get("embedding") is not None
-                        else None
-                    ),
-                    wifi={k: float(v) for k, v in (s.get("wifi") or {}).items()},
+            loaded_samples: list[PlaceSample] = []
+            for s in samples:
+                wifi_raw = s.get("wifi") or {}
+                if not isinstance(wifi_raw, dict):
+                    raise ValueError(
+                        f"gallery place {name!r} sample wifi must be a JSON object"
+                    )
+                loaded_samples.append(
+                    PlaceSample(
+                        embedding=(
+                            np.asarray(s["embedding"], dtype=np.float64)
+                            if s.get("embedding") is not None
+                            else None
+                        ),
+                        wifi={k: float(v) for k, v in wifi_raw.items()},
+                    )
                 )
-                for s in samples
-            ]
+            places[name] = loaded_samples
         self.wifi_weight = saved_wifi_weight
         self.places = places
 

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -51,6 +51,9 @@ class HistogramEmbedder:
     """
 
     def __init__(self, *, h_bins: int = 24, s_bins: int = 8, grid: int = 2) -> None:
+        for name, value in (("h_bins", h_bins), ("s_bins", s_bins), ("grid", grid)):
+            if value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
         self.h_bins = h_bins
         self.s_bins = s_bins
         self.grid = grid
@@ -307,8 +310,11 @@ class PlaceRecognizer:
         saved_wifi_weight = float(payload.get("wifi_weight", self.wifi_weight))
         if not 0.0 <= saved_wifi_weight <= 1.0:
             raise ValueError("wifi_weight must be in [0, 1]")
+        saved_places = payload.get("places", {})
+        if not isinstance(saved_places, dict):
+            raise ValueError("gallery places must be a JSON object")
         places: dict[str, list[PlaceSample]] = {}
-        for name, samples in payload.get("places", {}).items():
+        for name, samples in saved_places.items():
             places[name] = [
                 PlaceSample(
                     embedding=(

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -302,6 +302,9 @@ class PlaceRecognizer:
                 "embedder mismatch: gallery uses "
                 f"{saved_embedder!r}, current embedder is {self.embedder.embedder_id!r}"
             )
+        saved_wifi_weight = float(payload.get("wifi_weight", self.wifi_weight))
+        if not 0.0 <= saved_wifi_weight <= 1.0:
+            raise ValueError("wifi_weight must be in [0, 1]")
         places: dict[str, list[PlaceSample]] = {}
         for name, samples in payload.get("places", {}).items():
             places[name] = [
@@ -315,6 +318,7 @@ class PlaceRecognizer:
                 )
                 for s in samples
             ]
+        self.wifi_weight = saved_wifi_weight
         self.places = places
 
     @classmethod

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -1,0 +1,324 @@
+"""Place recognition: "where am I?" without GPS.
+
+Two complementary signals, each optional:
+
+- **Visual**: an ``Embedder`` maps a frame to a vector; the default
+  ``HistogramEmbedder`` is a dependency-free HSV-histogram + spatial-grid
+  baseline that separates visually distinct rooms. A CLIP embedder would
+  be a strict upgrade (much better invariance to viewpoint/lighting) and
+  can be added later as an optional extra (e.g. ``open-clip-torch``)
+  implementing the same ``Embedder`` protocol — deliberately NOT a hard
+  dependency at v0.
+- **WiFi**: the set of visible BSSIDs + signal strengths is a strong
+  indoor location fingerprint. ``WifiSignature.scan()`` uses ``nmcli``
+  and degrades to an empty dict when unavailable.
+
+``PlaceRecognizer`` fuses both: enroll a few samples per place, then
+``recognize`` returns ranked ``(name, score)`` candidates.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import cv2
+import numpy as np
+
+WifiSig = dict[str, float]  # BSSID -> signal strength (0..100, nmcli SIGNAL)
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """Maps a BGR frame to a fixed-size embedding vector."""
+
+    def embed(self, frame: np.ndarray) -> np.ndarray: ...
+
+
+class HistogramEmbedder:
+    """HSV color histogram + coarse spatial grid, L2-normalized.
+
+    Global hue/saturation histogram concatenated with per-cell
+    hue histograms over a ``grid x grid`` layout, so both overall color
+    mood and rough spatial arrangement contribute. Cheap, deterministic,
+    dependency-free — a baseline that distinguishes visually distinct
+    rooms, not a general scene embedding.
+    """
+
+    def __init__(self, *, h_bins: int = 24, s_bins: int = 8, grid: int = 2) -> None:
+        self.h_bins = h_bins
+        self.s_bins = s_bins
+        self.grid = grid
+
+    def embed(self, frame: np.ndarray) -> np.ndarray:
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        parts: list[np.ndarray] = []
+
+        # Global H+S 2D histogram.
+        global_hist = cv2.calcHist(
+            [hsv], [0, 1], None, [self.h_bins, self.s_bins], [0, 180, 0, 256]
+        )
+        parts.append(global_hist.flatten())
+
+        # Per-cell H+S histograms (coarse spatial layout).
+        h, w = hsv.shape[:2]
+        for gy in range(self.grid):
+            for gx in range(self.grid):
+                cell = hsv[
+                    gy * h // self.grid : (gy + 1) * h // self.grid,
+                    gx * w // self.grid : (gx + 1) * w // self.grid,
+                ]
+                # H+S (not hue alone): hue is meaningless at zero saturation,
+                # so a hue-only cell histogram cannot tell e.g. black from red.
+                cell_hist = cv2.calcHist(
+                    [cell], [0, 1], None, [self.h_bins, self.s_bins], [0, 180, 0, 256]
+                )
+                parts.append(cell_hist.flatten())
+
+        vec = np.concatenate(parts).astype(np.float64)
+        norm = np.linalg.norm(vec)
+        if norm > 0:
+            vec /= norm
+        return vec
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Cosine similarity in [-1, 1] (0.0 if either vector is zero)."""
+    na, nb = np.linalg.norm(a), np.linalg.norm(b)
+    if na == 0 or nb == 0:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+class WifiSignature:
+    """WiFi BSSID/RSSI fingerprints via nmcli."""
+
+    @staticmethod
+    def scan(interface: str | None = None) -> WifiSig:
+        """Scan visible access points -> {bssid: signal 0..100}.
+
+        Returns an empty dict on any failure (no nmcli, no wifi device,
+        permission denied) — WiFi is an optional signal.
+        """
+        cmd = ["nmcli", "-t", "-f", "BSSID,SIGNAL", "dev", "wifi", "list"]
+        if interface:
+            cmd += ["ifname", interface]
+        try:
+            out = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=15, check=True
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            return {}
+        return WifiSignature.parse_nmcli(out)
+
+    @staticmethod
+    def parse_nmcli(output: str) -> WifiSig:
+        """Parse `nmcli -t -f BSSID,SIGNAL` output.
+
+        BSSIDs contain colons which nmcli escapes as ``\\:`` in terse
+        mode; the last unescaped-colon field is the signal.
+        """
+        sig: WifiSig = {}
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # Split on the last unescaped colon.
+            idx = None
+            for i in range(len(line) - 1, -1, -1):
+                if line[i] == ":" and (i == 0 or line[i - 1] != "\\"):
+                    idx = i
+                    break
+            if idx is None:
+                continue
+            bssid = line[:idx].replace("\\:", ":").upper()
+            try:
+                signal = float(line[idx + 1 :])
+            except ValueError:
+                continue
+            if bssid:
+                sig[bssid] = signal
+        return sig
+
+    @staticmethod
+    def similarity(sig_a: WifiSig, sig_b: WifiSig) -> float:
+        """Overlap-weighted signal-strength similarity in [0, 1].
+
+        For BSSIDs seen in both scans, compare signal strengths; weight by
+        the fraction of overlap (Jaccard), so seeing mostly the same APs at
+        similar strengths scores high, and disjoint AP sets score 0.
+        """
+        if not sig_a or not sig_b:
+            return 0.0
+        keys_a, keys_b = set(sig_a), set(sig_b)
+        common = keys_a & keys_b
+        if not common:
+            return 0.0
+        jaccard = len(common) / len(keys_a | keys_b)
+        # Mean signal agreement over common APs (signals are 0..100).
+        diffs = [abs(sig_a[k] - sig_b[k]) for k in common]
+        agreement = 1.0 - min(1.0, float(np.mean(diffs)) / 100.0)
+        return jaccard * agreement
+
+
+@dataclass
+class PlaceSample:
+    """One enrolled observation of a place."""
+
+    embedding: np.ndarray | None = None
+    wifi: WifiSig = field(default_factory=dict)
+
+
+class PlaceRecognizer:
+    """Enroll named places, then rank candidates for a new observation.
+
+    Scores combine visual cosine similarity and WiFi fingerprint
+    similarity. ``wifi_weight`` (default 0.5) applies when both signals
+    are present for a comparison; otherwise whichever signal exists is
+    used alone.
+    """
+
+    def __init__(
+        self,
+        embedder: Embedder | None = None,
+        *,
+        wifi_weight: float = 0.5,
+    ) -> None:
+        if not 0.0 <= wifi_weight <= 1.0:
+            raise ValueError("wifi_weight must be in [0, 1]")
+        self.embedder = embedder if embedder is not None else HistogramEmbedder()
+        self.wifi_weight = wifi_weight
+        self.places: dict[str, list[PlaceSample]] = {}
+
+    def enroll(
+        self,
+        name: str,
+        frame: np.ndarray | None = None,
+        wifi_sig: WifiSig | None = None,
+    ) -> PlaceSample:
+        """Add one sample for a place. Multiple samples per place welcome."""
+        if frame is None and not wifi_sig:
+            raise ValueError("enroll needs a frame, a wifi signature, or both")
+        sample = PlaceSample(
+            embedding=self.embedder.embed(frame) if frame is not None else None,
+            wifi=dict(wifi_sig) if wifi_sig else {},
+        )
+        self.places.setdefault(name, []).append(sample)
+        return sample
+
+    def _sample_score(
+        self,
+        sample: PlaceSample,
+        embedding: np.ndarray | None,
+        wifi_sig: WifiSig | None,
+    ) -> float | None:
+        vis: float | None = None
+        wifi: float | None = None
+        if embedding is not None and sample.embedding is not None:
+            # Histogram embeddings are non-negative, so cosine is in [0, 1].
+            vis = max(0.0, cosine_similarity(embedding, sample.embedding))
+        if wifi_sig and sample.wifi:
+            wifi = WifiSignature.similarity(wifi_sig, sample.wifi)
+        if vis is not None and wifi is not None:
+            return (1.0 - self.wifi_weight) * vis + self.wifi_weight * wifi
+        if vis is not None:
+            return vis
+        if wifi is not None:
+            return wifi
+        return None
+
+    def recognize(
+        self,
+        frame: np.ndarray | None = None,
+        wifi_sig: WifiSig | None = None,
+    ) -> list[tuple[str, float]]:
+        """Rank enrolled places for an observation, best first.
+
+        Each place's score is the max over its enrolled samples. Places
+        with no comparable signal are omitted.
+        """
+        if frame is None and not wifi_sig:
+            raise ValueError("recognize needs a frame, a wifi signature, or both")
+        embedding = self.embedder.embed(frame) if frame is not None else None
+
+        results: list[tuple[str, float]] = []
+        for name, samples in self.places.items():
+            scores = [
+                s
+                for s in (
+                    self._sample_score(sample, embedding, wifi_sig)
+                    for sample in samples
+                )
+                if s is not None
+            ]
+            if scores:
+                results.append((name, max(scores)))
+        results.sort(key=lambda item: item[1], reverse=True)
+        return results
+
+    # -- persistence ------------------------------------------------------
+
+    def save(self, path: str | Path) -> None:
+        """Persist the gallery as JSON (embeddings as float lists)."""
+        payload = {
+            "version": 1,
+            "wifi_weight": self.wifi_weight,
+            "places": {
+                name: [
+                    {
+                        "embedding": (
+                            sample.embedding.tolist()
+                            if sample.embedding is not None
+                            else None
+                        ),
+                        "wifi": sample.wifi,
+                    }
+                    for sample in samples
+                ]
+                for name, samples in self.places.items()
+            },
+        }
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
+
+    def load(self, path: str | Path) -> None:
+        """Load a gallery saved by :meth:`save` (replaces current places)."""
+        payload = json.loads(Path(path).read_text())
+        places: dict[str, list[PlaceSample]] = {}
+        for name, samples in payload.get("places", {}).items():
+            places[name] = [
+                PlaceSample(
+                    embedding=(
+                        np.asarray(s["embedding"], dtype=np.float64)
+                        if s.get("embedding") is not None
+                        else None
+                    ),
+                    wifi={k: float(v) for k, v in (s.get("wifi") or {}).items()},
+                )
+                for s in samples
+            ]
+        self.places = places
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        embedder: Embedder | None = None,
+        *,
+        wifi_weight: float | None = None,
+    ) -> PlaceRecognizer:
+        payload = json.loads(Path(path).read_text())
+        recognizer = cls(
+            embedder,
+            wifi_weight=(
+                wifi_weight
+                if wifi_weight is not None
+                else float(payload.get("wifi_weight", 0.5))
+            ),
+        )
+        recognizer.load(path)
+        return recognizer

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -83,6 +83,9 @@ class HistogramEmbedder:
                 ]
                 # H+S (not hue alone): hue is meaningless at zero saturation,
                 # so a hue-only cell histogram cannot tell e.g. black from red.
+                if cell.size == 0:
+                    parts.append(np.zeros(self.h_bins * self.s_bins))
+                    continue
                 cell_hist = cv2.calcHist(
                     [cell], [0, 1], None, [self.h_bins, self.s_bins], [0, 180, 0, 256]
                 )
@@ -315,6 +318,12 @@ class PlaceRecognizer:
             raise ValueError("gallery places must be a JSON object")
         places: dict[str, list[PlaceSample]] = {}
         for name, samples in saved_places.items():
+            if not isinstance(samples, list) or not all(
+                isinstance(sample, dict) for sample in samples
+            ):
+                raise ValueError(
+                    f"gallery place {name!r} samples must be a list of JSON objects"
+                )
             places[name] = [
                 PlaceSample(
                     embedding=(

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -35,6 +35,8 @@ WifiSig = dict[str, float]  # BSSID -> signal strength (0..100, nmcli SIGNAL)
 class Embedder(Protocol):
     """Maps a BGR frame to a fixed-size embedding vector."""
 
+    embedder_id: str
+
     def embed(self, frame: np.ndarray) -> np.ndarray: ...
 
 
@@ -52,6 +54,11 @@ class HistogramEmbedder:
         self.h_bins = h_bins
         self.s_bins = s_bins
         self.grid = grid
+
+    @property
+    def embedder_id(self) -> str:
+        """Stable identifier for persisted embedding compatibility."""
+        return f"histogram-h{self.h_bins}-s{self.s_bins}-grid{self.grid}-v1"
 
     def embed(self, frame: np.ndarray) -> np.ndarray:
         hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
@@ -265,6 +272,7 @@ class PlaceRecognizer:
         """Persist the gallery as JSON (embeddings as float lists)."""
         payload = {
             "version": 1,
+            "embedder": self.embedder.embedder_id,
             "wifi_weight": self.wifi_weight,
             "places": {
                 name: [
@@ -288,6 +296,12 @@ class PlaceRecognizer:
     def load(self, path: str | Path) -> None:
         """Load a gallery saved by :meth:`save` (replaces current places)."""
         payload = json.loads(Path(path).read_text())
+        saved_embedder = payload.get("embedder")
+        if saved_embedder is not None and saved_embedder != self.embedder.embedder_id:
+            raise ValueError(
+                "embedder mismatch: gallery uses "
+                f"{saved_embedder!r}, current embedder is {self.embedder.embedder_id!r}"
+            )
         places: dict[str, list[PlaceSample]] = {}
         for name, samples in payload.get("places", {}).items():
             places[name] = [

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -339,4 +339,6 @@ class PlaceRecognizer:
             ),
         )
         recognizer.load(path)
+        if wifi_weight is not None:
+            recognizer.wifi_weight = wifi_weight
         return recognizer

--- a/packages/gptme-vision-node/tests/conftest.py
+++ b/packages/gptme-vision-node/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared synthetic-image helpers for the vision-node tests."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def solid_frame(
+    color: tuple[int, int, int], size: tuple[int, int] = (240, 320)
+) -> np.ndarray:
+    """A solid BGR frame."""
+    frame = np.zeros((*size, 3), dtype=np.uint8)
+    frame[:] = color
+    return frame
+
+
+def scene_frame(seed: int, size: tuple[int, int] = (240, 320)) -> np.ndarray:
+    """A deterministic 'room': colored background + a few rectangles."""
+    rng = np.random.default_rng(seed)
+    frame = solid_frame(tuple(int(c) for c in rng.integers(0, 256, 3)), size)
+    h, w = size
+    for _ in range(4):
+        x0, y0 = int(rng.integers(0, w // 2)), int(rng.integers(0, h // 2))
+        x1, y1 = x0 + int(rng.integers(20, w // 2)), y0 + int(rng.integers(20, h // 2))
+        color = tuple(int(c) for c in rng.integers(0, 256, 3))
+        frame[y0:y1, x0:x1] = color
+    return frame
+
+
+@pytest.fixture
+def gray_frame() -> np.ndarray:
+    return solid_frame((128, 128, 128))

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import cv2
+from click.testing import CliRunner
 from gptme_vision_node import cli
 from gptme_vision_node.frame_source import ImageFileSource, OpenCVCameraSource
 
@@ -25,23 +26,25 @@ def test_make_source_parsing(tmp_path):
     assert isinstance(rtsp, OpenCVCameraSource) and rtsp.source == "rtsp://host/stream"
 
 
-def test_cli_detect_once(tmp_path, capsys):
+def test_cli_detect_once(tmp_path):
     img = _write_scene(tmp_path / "a.png", 2)
-    assert cli.main(["detect", "--source", str(img), "--once"]) == 0
-    out = capsys.readouterr().out
-    assert out.strip()  # printed detections or "(no detections)"
+    result = CliRunner().invoke(cli.main, ["detect", "--source", str(img), "--once"])
+    assert result.exit_code == 0
+    assert result.output.strip()  # printed detections or "(no detections)"
 
 
-def test_cli_enroll_and_whereami(tmp_path, capsys, monkeypatch):
+def test_cli_enroll_and_whereami(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli.WifiSignature, "scan", staticmethod(lambda interface=None: {})
     )
+    runner = CliRunner()
     gallery = tmp_path / "places.json"
     kitchen = _write_scene(tmp_path / "kitchen.png", 101)
     office = _write_scene(tmp_path / "office.png", 202)
 
     for place, img in (("kitchen", kitchen), ("office", office)):
-        code = cli.main(
+        result = runner.invoke(
+            cli.main,
             [
                 "enroll",
                 "--place",
@@ -50,24 +53,26 @@ def test_cli_enroll_and_whereami(tmp_path, capsys, monkeypatch):
                 str(img),
                 "--gallery",
                 str(gallery),
-            ]
+            ],
         )
-        assert code == 0
+        assert result.exit_code == 0, result.output
     assert gallery.exists()
 
-    code = cli.main(
-        ["whereami", "--source", str(kitchen), "--gallery", str(gallery), "--json"]
+    result = runner.invoke(
+        cli.main,
+        ["whereami", "--source", str(kitchen), "--gallery", str(gallery), "--json"],
     )
-    assert code == 0
-    out = capsys.readouterr().out
-    results = json.loads(out.splitlines()[-1])
+    assert result.exit_code == 0, result.output
+    results = json.loads(result.output.splitlines()[-1])
     assert results[0]["place"] == "kitchen"
     assert results[0]["score"] > results[-1]["score"]
 
 
-def test_cli_whereami_missing_gallery(tmp_path, capsys):
+def test_cli_whereami_missing_gallery(tmp_path):
     img = _write_scene(tmp_path / "a.png", 3)
-    code = cli.main(
-        ["whereami", "--source", str(img), "--gallery", str(tmp_path / "none.json")]
+    result = CliRunner().invoke(
+        cli.main,
+        ["whereami", "--source", str(img), "--gallery", str(tmp_path / "none.json")],
     )
-    assert code == 1
+    assert result.exit_code != 0
+    assert "no gallery" in result.output

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -139,6 +139,22 @@ def test_cli_detect_opencv_failure_is_clean_error(monkeypatch):
     assert "Traceback" not in result.output
 
 
+def test_cli_opencv_source_read_failure_is_clean_error(monkeypatch):
+    class BrokenSource:
+        def get_frame(self):
+            raise cv2.error("capture disconnected")
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(cli, "make_source", lambda spec: BrokenSource())
+    result = CliRunner().invoke(cli.main, ["look", "--source", "camera:9"])
+
+    assert result.exit_code != 0
+    assert "capture disconnected" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_cli_enroll_and_whereami(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli.WifiSignature, "scan", staticmethod(lambda interface=None: {})
@@ -242,6 +258,24 @@ def test_cli_whereami_malformed_sample_is_clean_error(tmp_path):
 
     assert result.exit_code != 0
     assert "samples must be a list of JSON objects" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_whereami_non_object_wifi_is_clean_error(tmp_path):
+    img = _write_scene(tmp_path / "a.png", 11)
+    gallery = tmp_path / "places.json"
+    gallery.write_text(
+        json.dumps({"places": {"kitchen": [{"embedding": [1.0], "wifi": "AA"}]}})
+    )
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["whereami", "--source", str(img), "--gallery", str(gallery)],
+    )
+
+    assert result.exit_code != 0
+    assert "invalid gallery" in result.output
+    assert "sample wifi must be a JSON object" in result.output
     assert "Traceback" not in result.output
 
 

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -146,3 +146,18 @@ def test_cli_whereami_missing_gallery(tmp_path):
     )
     assert result.exit_code != 0
     assert "no gallery" in result.output
+
+
+def test_cli_whereami_corrupt_gallery_is_clean_error(tmp_path):
+    img = _write_scene(tmp_path / "a.png", 6)
+    gallery = tmp_path / "places.json"
+    gallery.write_text("not JSON")
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["whereami", "--source", str(img), "--gallery", str(gallery)],
+    )
+
+    assert result.exit_code != 0
+    assert "invalid gallery" in result.output
+    assert "Traceback" not in result.output

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -119,6 +119,26 @@ def test_cli_detect_exhausted_source_exits_cleanly(monkeypatch):
     assert result.output.strip()
 
 
+def test_cli_detect_opencv_failure_is_clean_error(monkeypatch):
+    class Source:
+        def get_frame(self):
+            return scene_frame(3)
+
+    class BrokenDetector:
+        def detect(self, frame):
+            raise cv2.error("invalid frame")
+
+    monkeypatch.setattr(cli, "make_source", lambda spec: Source())
+    monkeypatch.setattr(cli, "PersonDetector", BrokenDetector)
+    monkeypatch.setattr(cli, "MotionDetector", BrokenDetector)
+
+    result = CliRunner().invoke(cli.main, ["detect", "--source", "broken", "--once"])
+
+    assert result.exit_code != 0
+    assert "invalid frame" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_cli_enroll_and_whereami(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli.WifiSignature, "scan", staticmethod(lambda interface=None: {})
@@ -207,6 +227,21 @@ def test_cli_whereami_invalid_wifi_weight_is_clean_error(tmp_path, wifi_weight):
 
     assert result.exit_code != 0
     assert "invalid gallery" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_whereami_malformed_sample_is_clean_error(tmp_path):
+    img = _write_scene(tmp_path / "a.png", 10)
+    gallery = tmp_path / "places.json"
+    gallery.write_text(json.dumps({"places": {"kitchen": [1]}}))
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["whereami", "--source", str(img), "--gallery", str(gallery)],
+    )
+
+    assert result.exit_code != 0
+    assert "samples must be a list of JSON objects" in result.output
     assert "Traceback" not in result.output
 
 

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -26,6 +26,25 @@ def test_make_source_parsing(tmp_path):
     assert isinstance(rtsp, OpenCVCameraSource) and rtsp.source == "rtsp://host/stream"
 
 
+def test_cli_invalid_camera_index_is_clean_error():
+    result = CliRunner().invoke(cli.main, ["detect", "--source", "camera:nope"])
+    assert result.exit_code != 0
+    assert "invalid camera index" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_capture_failure_is_clean_error(monkeypatch):
+    class BrokenSource:
+        def get_frame(self):
+            raise RuntimeError("camera unavailable")
+
+    monkeypatch.setattr(cli, "make_source", lambda spec: BrokenSource())
+    result = CliRunner().invoke(cli.main, ["look", "--source", "camera:9"])
+    assert result.exit_code != 0
+    assert "camera unavailable" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_cli_detect_once(tmp_path):
     img = _write_scene(tmp_path / "a.png", 2)
     result = CliRunner().invoke(cli.main, ["detect", "--source", str(img), "--once"])

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -161,3 +161,45 @@ def test_cli_whereami_corrupt_gallery_is_clean_error(tmp_path):
     assert result.exit_code != 0
     assert "invalid gallery" in result.output
     assert "Traceback" not in result.output
+
+
+def test_cli_whereami_non_object_gallery_is_clean_error(tmp_path):
+    img = _write_scene(tmp_path / "a.png", 7)
+    gallery = tmp_path / "places.json"
+    gallery.write_text("[]")
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["whereami", "--source", str(img), "--gallery", str(gallery)],
+    )
+
+    assert result.exit_code != 0
+    assert "gallery file must contain a JSON object" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_enroll_save_failure_is_clean_error(tmp_path, monkeypatch):
+    img = _write_scene(tmp_path / "a.png", 8)
+
+    def fail_save(self, path):
+        raise OSError("gallery is read-only")
+
+    monkeypatch.setattr(cli.PlaceRecognizer, "save", fail_save)
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "enroll",
+            "--place",
+            "office",
+            "--source",
+            str(img),
+            "--gallery",
+            str(tmp_path / "places.json"),
+            "--no-wifi",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "failed to save gallery" in result.output
+    assert "gallery is read-only" in result.output
+    assert "Traceback" not in result.output

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -1,0 +1,73 @@
+"""Tests for the CLI (offline; sources are image files, LLM/wifi mocked)."""
+
+from __future__ import annotations
+
+import json
+
+import cv2
+from gptme_vision_node import cli
+from gptme_vision_node.frame_source import ImageFileSource, OpenCVCameraSource
+
+from .conftest import scene_frame
+
+
+def _write_scene(path, seed):
+    assert cv2.imwrite(str(path), scene_frame(seed))
+    return path
+
+
+def test_make_source_parsing(tmp_path):
+    img = _write_scene(tmp_path / "a.png", 1)
+    assert isinstance(cli.make_source(str(img)), ImageFileSource)
+    cam = cli.make_source("camera:2")
+    assert isinstance(cam, OpenCVCameraSource) and cam.source == 2
+    rtsp = cli.make_source("rtsp://host/stream")
+    assert isinstance(rtsp, OpenCVCameraSource) and rtsp.source == "rtsp://host/stream"
+
+
+def test_cli_detect_once(tmp_path, capsys):
+    img = _write_scene(tmp_path / "a.png", 2)
+    assert cli.main(["detect", "--source", str(img), "--once"]) == 0
+    out = capsys.readouterr().out
+    assert out.strip()  # printed detections or "(no detections)"
+
+
+def test_cli_enroll_and_whereami(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli.WifiSignature, "scan", staticmethod(lambda interface=None: {})
+    )
+    gallery = tmp_path / "places.json"
+    kitchen = _write_scene(tmp_path / "kitchen.png", 101)
+    office = _write_scene(tmp_path / "office.png", 202)
+
+    for place, img in (("kitchen", kitchen), ("office", office)):
+        code = cli.main(
+            [
+                "enroll",
+                "--place",
+                place,
+                "--source",
+                str(img),
+                "--gallery",
+                str(gallery),
+            ]
+        )
+        assert code == 0
+    assert gallery.exists()
+
+    code = cli.main(
+        ["whereami", "--source", str(kitchen), "--gallery", str(gallery), "--json"]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    results = json.loads(out.splitlines()[-1])
+    assert results[0]["place"] == "kitchen"
+    assert results[0]["score"] > results[-1]["score"]
+
+
+def test_cli_whereami_missing_gallery(tmp_path, capsys):
+    img = _write_scene(tmp_path / "a.png", 3)
+    code = cli.main(
+        ["whereami", "--source", str(img), "--gallery", str(tmp_path / "none.json")]
+    )
+    assert code == 1

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -103,6 +103,22 @@ def test_cli_detect_once(tmp_path):
     assert result.output.strip()  # printed detections or "(no detections)"
 
 
+def test_cli_detect_exhausted_source_exits_cleanly(monkeypatch):
+    class FiniteSource:
+        def __init__(self):
+            self.frames = [scene_frame(3)]
+
+        def get_frame(self):
+            return self.frames.pop() if self.frames else None
+
+    monkeypatch.setattr(cli, "make_source", lambda spec: FiniteSource())
+    result = CliRunner().invoke(cli.main, ["detect", "--source", "finite"])
+
+    assert result.exit_code == 0
+    assert "source produced no frame" not in result.output
+    assert result.output.strip()
+
+
 def test_cli_enroll_and_whereami(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli.WifiSignature, "scan", staticmethod(lambda interface=None: {})

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 
 import cv2
+import httpx
+import pytest
 from click.testing import CliRunner
 from gptme_vision_node import cli
 from gptme_vision_node.frame_source import ImageFileSource, OpenCVCameraSource
@@ -42,6 +44,55 @@ def test_cli_capture_failure_is_clean_error(monkeypatch):
     result = CliRunner().invoke(cli.main, ["look", "--source", "camera:9"])
     assert result.exit_code != 0
     assert "camera unavailable" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_capture_frame_releases_source(monkeypatch):
+    class TrackingSource:
+        released = False
+
+        def get_frame(self):
+            return scene_frame(4)
+
+        def release(self):
+            self.released = True
+
+    source = TrackingSource()
+    monkeypatch.setattr(cli, "make_source", lambda spec: source)
+
+    assert cli._capture_frame("camera:4").shape == scene_frame(4).shape
+    assert source.released
+
+
+def test_capture_frame_releases_source_after_failure(monkeypatch):
+    class BrokenSource:
+        released = False
+
+        def get_frame(self):
+            raise RuntimeError("camera unavailable")
+
+        def release(self):
+            self.released = True
+
+    source = BrokenSource()
+    monkeypatch.setattr(cli, "make_source", lambda spec: source)
+
+    with pytest.raises(cli.click.ClickException, match="camera unavailable"):
+        cli._capture_frame("camera:9")
+    assert source.released
+
+
+def test_cli_look_endpoint_failure_is_clean_error(tmp_path, monkeypatch):
+    img = _write_scene(tmp_path / "a.png", 5)
+
+    def timeout(*args, **kwargs):
+        raise httpx.TimeoutException("vision endpoint timed out")
+
+    monkeypatch.setattr(cli, "describe_frame", timeout)
+    result = CliRunner().invoke(cli.main, ["look", "--source", str(img)])
+
+    assert result.exit_code != 0
+    assert "vision endpoint timed out" in result.output
     assert "Traceback" not in result.output
 
 

--- a/packages/gptme-vision-node/tests/test_cli.py
+++ b/packages/gptme-vision-node/tests/test_cli.py
@@ -178,6 +178,22 @@ def test_cli_whereami_non_object_gallery_is_clean_error(tmp_path):
     assert "Traceback" not in result.output
 
 
+@pytest.mark.parametrize("wifi_weight", [None, "not-a-number"])
+def test_cli_whereami_invalid_wifi_weight_is_clean_error(tmp_path, wifi_weight):
+    img = _write_scene(tmp_path / "a.png", 9)
+    gallery = tmp_path / "places.json"
+    gallery.write_text(json.dumps({"wifi_weight": wifi_weight, "places": {}}))
+
+    result = CliRunner().invoke(
+        cli.main,
+        ["whereami", "--source", str(img), "--gallery", str(gallery)],
+    )
+
+    assert result.exit_code != 0
+    assert "invalid gallery" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_cli_enroll_save_failure_is_clean_error(tmp_path, monkeypatch):
     img = _write_scene(tmp_path / "a.png", 8)
 

--- a/packages/gptme-vision-node/tests/test_detect.py
+++ b/packages/gptme-vision-node/tests/test_detect.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 from gptme_vision_node.detect import Detection, MotionDetector, PersonDetector
 
@@ -35,6 +37,16 @@ def test_motion_detector_quiet_on_static_scene(gray_frame):
         assert detector.detect(gray_frame.copy()) == []
 
 
+def test_motion_detector_reprimes_when_frame_size_changes(gray_frame):
+    detector = MotionDetector()
+    detector.detect(gray_frame)
+
+    resized = solid_frame((200, 200, 200), size=(120, 160))
+    assert detector.detect(resized) == []
+    assert detector._background is not None
+    assert detector._background.shape == resized.shape[:2]
+
+
 def test_person_detector_no_crash_on_synthetic(gray_frame):
     """HOG must run without error; fake scenes may legitimately yield nothing."""
     detector = PersonDetector()
@@ -49,6 +61,17 @@ def test_person_detector_no_crash_on_synthetic(gray_frame):
 def test_person_detector_handles_tiny_frame():
     tiny = solid_frame((50, 50, 50), size=(32, 32))
     assert isinstance(PersonDetector().detect(tiny), list)
+
+
+def test_person_detector_maps_tiny_frame_boxes_to_input_coordinates():
+    detector = PersonDetector()
+    detector._hog = SimpleNamespace(
+        detectMultiScale=lambda frame, **kwargs: ([(16, 32, 32, 64)], [0.9])
+    )
+
+    detections = detector.detect(solid_frame((50, 50, 50), size=(32, 32)))
+
+    assert detections == [Detection(kind="person", box=(8, 8, 16, 16), score=0.9)]
 
 
 def test_detection_dataclass():

--- a/packages/gptme-vision-node/tests/test_detect.py
+++ b/packages/gptme-vision-node/tests/test_detect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 from gptme_vision_node.detect import Detection, MotionDetector, PersonDetector
 
 from .conftest import scene_frame, solid_frame
@@ -45,6 +46,12 @@ def test_motion_detector_reprimes_when_frame_size_changes(gray_frame):
     assert detector.detect(resized) == []
     assert detector._background is not None
     assert detector._background.shape == resized.shape[:2]
+
+
+@pytest.mark.parametrize("blur_ksize", [0, -1, 2, 4])
+def test_motion_detector_rejects_invalid_blur_kernel(blur_ksize):
+    with pytest.raises(ValueError, match="positive odd integer"):
+        MotionDetector(blur_ksize=blur_ksize)
 
 
 def test_person_detector_no_crash_on_synthetic(gray_frame):

--- a/packages/gptme-vision-node/tests/test_detect.py
+++ b/packages/gptme-vision-node/tests/test_detect.py
@@ -1,0 +1,58 @@
+"""Tests for person/motion detection on synthetic frames."""
+
+from __future__ import annotations
+
+import numpy as np
+from gptme_vision_node.detect import Detection, MotionDetector, PersonDetector
+
+from .conftest import scene_frame, solid_frame
+
+
+def test_motion_detector_first_frame_primes(gray_frame):
+    detector = MotionDetector()
+    assert detector.detect(gray_frame) == []
+
+
+def test_motion_detector_fires_on_change(gray_frame):
+    detector = MotionDetector()
+    detector.detect(gray_frame)  # prime background
+
+    moved = gray_frame.copy()
+    moved[80:160, 100:220] = (255, 255, 255)  # a bright object appears
+    detections = detector.detect(moved)
+
+    assert detections, "expected motion detections on a large change"
+    assert all(d.kind == "motion" for d in detections)
+    x, y, w, h = detections[0].box
+    assert w > 0 and h > 0
+    assert 0.0 < detections[0].score <= 1.0
+
+
+def test_motion_detector_quiet_on_static_scene(gray_frame):
+    detector = MotionDetector()
+    detector.detect(gray_frame)
+    for _ in range(3):
+        assert detector.detect(gray_frame.copy()) == []
+
+
+def test_person_detector_no_crash_on_synthetic(gray_frame):
+    """HOG must run without error; fake scenes may legitimately yield nothing."""
+    detector = PersonDetector()
+    for frame in (gray_frame, scene_frame(1), scene_frame(2)):
+        detections = detector.detect(frame)
+        assert isinstance(detections, list)
+        for d in detections:
+            assert isinstance(d, Detection)
+            assert d.kind == "person"
+
+
+def test_person_detector_handles_tiny_frame():
+    tiny = solid_frame((50, 50, 50), size=(32, 32))
+    assert isinstance(PersonDetector().detect(tiny), list)
+
+
+def test_detection_dataclass():
+    d = Detection(kind="person", box=(1, 2, 3, 4), score=0.5)
+    assert (d.kind, d.box, d.score) == ("person", (1, 2, 3, 4), 0.5)
+    assert d == Detection(kind="person", box=(1, 2, 3, 4), score=0.5)
+    assert isinstance(np.asarray(d.box), np.ndarray)  # plain tuple, numpy-friendly

--- a/packages/gptme-vision-node/tests/test_frame_source.py
+++ b/packages/gptme-vision-node/tests/test_frame_source.py
@@ -1,0 +1,57 @@
+"""Tests for frame sources (offline: temp image files only)."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+from gptme_vision_node.frame_source import FrameSource, ImageFileSource
+
+from .conftest import solid_frame
+
+
+def _write(path, color):
+    assert cv2.imwrite(str(path), solid_frame(color))
+
+
+def test_single_file_source_repeats(tmp_path):
+    img = tmp_path / "a.png"
+    _write(img, (255, 0, 0))
+    source = ImageFileSource(img)
+    for _ in range(3):
+        frame = source.get_frame()
+        assert frame is not None
+        assert frame.shape == (240, 320, 3)
+        assert (frame[0, 0] == np.array([255, 0, 0])).all()
+
+
+def test_directory_round_robin(tmp_path):
+    _write(tmp_path / "a.png", (255, 0, 0))
+    _write(tmp_path / "b.png", (0, 255, 0))
+    _write(tmp_path / "c.png", (0, 0, 255))
+    source = ImageFileSource(tmp_path)
+    colors = [tuple(source.get_frame()[0, 0]) for _ in range(6)]
+    expected = [(255, 0, 0), (0, 255, 0), (0, 0, 255)] * 2  # sorted order, wraps
+    assert colors == expected
+
+
+def test_directory_no_loop_exhausts(tmp_path):
+    _write(tmp_path / "a.png", (10, 10, 10))
+    source = ImageFileSource(tmp_path, loop=False)
+    assert source.get_frame() is not None
+    assert source.get_frame() is None
+
+
+def test_missing_path_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        ImageFileSource(tmp_path / "nope.png")
+
+
+def test_empty_directory_raises(tmp_path):
+    with pytest.raises(ValueError):
+        ImageFileSource(tmp_path)
+
+
+def test_satisfies_protocol(tmp_path):
+    _write(tmp_path / "a.png", (1, 2, 3))
+    assert isinstance(ImageFileSource(tmp_path), FrameSource)

--- a/packages/gptme-vision-node/tests/test_frame_source.py
+++ b/packages/gptme-vision-node/tests/test_frame_source.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import cv2
 import numpy as np
 import pytest
-from gptme_vision_node.frame_source import FrameSource, ImageFileSource
+from gptme_vision_node.frame_source import (
+    FrameSource,
+    ImageFileSource,
+    OpenCVCameraSource,
+)
 
 from .conftest import solid_frame
 
@@ -55,3 +59,44 @@ def test_empty_directory_raises(tmp_path):
 def test_satisfies_protocol(tmp_path):
     _write(tmp_path / "a.png", (1, 2, 3))
     assert isinstance(ImageFileSource(tmp_path), FrameSource)
+
+
+def test_camera_retries_transient_read_failure(monkeypatch):
+    expected = solid_frame((1, 2, 3))
+
+    class FakeCapture:
+        def __init__(self):
+            self.reads = iter([(False, None), (True, expected)])
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            return next(self.reads)
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(cv2, "VideoCapture", lambda source: FakeCapture())
+    source = OpenCVCameraSource(0)
+
+    frame = source.get_frame()
+
+    assert frame is expected
+
+
+def test_camera_returns_none_after_retry_budget(monkeypatch):
+    class FailedCapture:
+        def isOpened(self):
+            return True
+
+        def read(self):
+            return False, None
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(cv2, "VideoCapture", lambda source: FailedCapture())
+    source = OpenCVCameraSource(0, read_attempts=2)
+
+    assert source.get_frame() is None

--- a/packages/gptme-vision-node/tests/test_look.py
+++ b/packages/gptme-vision-node/tests/test_look.py
@@ -36,24 +36,25 @@ def test_build_request_model_env(monkeypatch):
     assert build_request(FRAME, model="explicit-wins")["model"] == "explicit-wins"
 
 
-def test_describe_frame_posts_and_parses(monkeypatch):
+def test_describe_frame_posts_parses_and_closes_response(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://llm.example/v1/")
     captured = {}
+    response = httpx.Response(
+        200,
+        json={"choices": [{"message": {"content": "a synthetic room"}}]},
+        request=httpx.Request("POST", "https://llm.example/v1/chat/completions"),
+    )
 
     def fake_post(url, *, json=None, headers=None, timeout=None):
         captured.update(url=url, body=json, headers=headers)
-        request = httpx.Request("POST", url)
-        return httpx.Response(
-            200,
-            json={"choices": [{"message": {"content": "a synthetic room"}}]},
-            request=request,
-        )
+        return response
 
     monkeypatch.setattr(look.httpx, "post", fake_post)
     result = describe_frame(FRAME, "describe", model="test-model")
 
     assert result == "a synthetic room"
+    assert response.is_closed
     assert captured["url"] == "https://llm.example/v1/chat/completions"
     assert captured["headers"]["Authorization"] == "Bearer sk-test"
     assert captured["body"]["model"] == "test-model"

--- a/packages/gptme-vision-node/tests/test_look.py
+++ b/packages/gptme-vision-node/tests/test_look.py
@@ -1,0 +1,89 @@
+"""Tests for the LLM look tool (httpx mocked, no network)."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import pytest
+from gptme_vision_node import look
+from gptme_vision_node.look import build_request, describe_frame
+
+from .conftest import scene_frame
+
+FRAME = scene_frame(42)
+
+
+def test_build_request_shape(monkeypatch):
+    monkeypatch.delenv("VISION_MODEL", raising=False)
+    body = build_request(FRAME, "what is this?")
+    assert body["model"] == "gpt-4o-mini"
+    (message,) = body["messages"]
+    assert message["role"] == "user"
+    text_part, image_part = message["content"]
+    assert text_part == {"type": "text", "text": "what is this?"}
+    url = image_part["image_url"]["url"]
+    assert url.startswith("data:image/jpeg;base64,")
+    # The payload must be valid base64 of a JPEG (SOI marker).
+    jpeg = base64.b64decode(url.split(",", 1)[1])
+    assert jpeg[:2] == b"\xff\xd8"
+
+
+def test_build_request_model_env(monkeypatch):
+    monkeypatch.setenv("VISION_MODEL", "some-vlm")
+    assert build_request(FRAME)["model"] == "some-vlm"
+    assert build_request(FRAME, model="explicit-wins")["model"] == "explicit-wins"
+
+
+def test_describe_frame_posts_and_parses(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm.example/v1/")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured.update(url=url, body=json, headers=headers)
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "a synthetic room"}}]},
+            request=request,
+        )
+
+    monkeypatch.setattr(look.httpx, "post", fake_post)
+    result = describe_frame(FRAME, "describe", model="test-model")
+
+    assert result == "a synthetic room"
+    assert captured["url"] == "https://llm.example/v1/chat/completions"
+    assert captured["headers"]["Authorization"] == "Bearer sk-test"
+    assert captured["body"]["model"] == "test-model"
+    # Request body must be JSON-serializable end to end.
+    json.dumps(captured["body"])
+
+
+def test_describe_frame_requires_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        describe_frame(FRAME)
+
+
+def test_describe_frame_bad_response_shape(monkeypatch):
+    def fake_post(url, **kwargs):
+        return httpx.Response(
+            200, json={"weird": True}, request=httpx.Request("POST", url)
+        )
+
+    monkeypatch.setattr(look.httpx, "post", fake_post)
+    with pytest.raises(ValueError, match="unexpected response"):
+        describe_frame(FRAME, api_key="sk-test")
+
+
+def test_describe_frame_http_error(monkeypatch):
+    def fake_post(url, **kwargs):
+        return httpx.Response(
+            401, json={"error": "nope"}, request=httpx.Request("POST", url)
+        )
+
+    monkeypatch.setattr(look.httpx, "post", fake_post)
+    with pytest.raises(httpx.HTTPStatusError):
+        describe_frame(FRAME, api_key="sk-bad")

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -162,6 +162,32 @@ def test_thread_stops_when_source_is_exhausted():
     pipeline.stop()
 
 
+def test_start_resets_presence_state_after_restart():
+    appeared = threading.Event()
+    pipeline = VisionPipeline(
+        ListSource(_frames(1)),
+        [ScriptedPersonDetector([True])],
+        interval_s=0.01,
+        on_event=lambda event: appeared.set()
+        if event.kind == PERSON_APPEARED
+        else None,
+    )
+    pipeline.start()
+    assert appeared.wait(timeout=1)
+    first_thread = pipeline._thread
+    assert first_thread is not None
+    first_thread.join(timeout=1)
+    assert not first_thread.is_alive()
+
+    appeared.clear()
+    pipeline.source = ListSource(_frames(1))
+    pipeline.detectors = [ScriptedPersonDetector([True])]
+    pipeline.start()
+
+    assert appeared.wait(timeout=1)
+    pipeline.stop()
+
+
 def test_stop_keeps_reference_to_blocked_thread():
     unblock = threading.Event()
 

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -106,6 +106,32 @@ def test_callback_receives_events_and_errors_are_contained():
     assert received == events
 
 
+def test_callback_can_stop_pipeline():
+    stopped = threading.Event()
+    pipeline = None
+
+    def stop_on_person(event):
+        assert pipeline is not None
+        pipeline.stop()
+        stopped.set()
+
+    pipeline = VisionPipeline(
+        ListSource(_frames(100)),
+        [ScriptedPersonDetector([True])],
+        interval_s=0.01,
+        on_event=stop_on_person,
+    )
+    pipeline.start()
+
+    assert stopped.wait(timeout=1)
+    thread = pipeline._thread
+    assert thread is not None
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    pipeline.stop()
+    assert pipeline._thread is None
+
+
 def test_exhausted_source_yields_no_events():
     pipeline = VisionPipeline(ListSource([]), [MotionDetector()])
     assert pipeline.step() == []
@@ -129,9 +155,10 @@ def test_thread_lifecycle():
 def test_thread_stops_when_source_is_exhausted():
     pipeline = VisionPipeline(ListSource(_frames(1)), [], interval_s=0.01)
     pipeline.start()
-    assert pipeline._thread is not None
-    pipeline._thread.join(timeout=1)
-    assert not pipeline._thread.is_alive()
+    thread = pipeline._thread
+    assert thread is not None
+    thread.join(timeout=1)
+    assert not thread.is_alive()
     pipeline.stop()
 
 

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -1,0 +1,123 @@
+"""Tests for the vision pipeline event loop (synthetic source/detectors)."""
+
+from __future__ import annotations
+
+import numpy as np
+from gptme_vision_node.detect import Detection, MotionDetector
+from gptme_vision_node.pipeline import (
+    MOTION,
+    PERSON_APPEARED,
+    PERSON_LEFT,
+    VisionPipeline,
+)
+
+from .conftest import solid_frame
+
+
+class ListSource:
+    """Feeds a scripted list of frames, then None."""
+
+    def __init__(self, frames):
+        self.frames = list(frames)
+
+    def get_frame(self):
+        return self.frames.pop(0) if self.frames else None
+
+
+class ScriptedPersonDetector:
+    """Returns a person detection when the script says so."""
+
+    def __init__(self, script):
+        self.script = list(script)
+
+    def detect(self, frame):
+        present = self.script.pop(0) if self.script else False
+        if present:
+            return [Detection(kind="person", box=(10, 10, 40, 80), score=1.0)]
+        return []
+
+
+def _frames(n):
+    return [solid_frame((100, 100, 100)) for _ in range(n)]
+
+
+def test_person_appeared_and_left_events():
+    script = [
+        False,
+        True,
+        True,
+        False,
+        False,
+        False,
+    ]  # left after 3 absent (debounce=2)
+    pipeline = VisionPipeline(
+        ListSource(_frames(len(script))),
+        [ScriptedPersonDetector(script)],
+        absent_frames_for_left=2,
+    )
+    events = []
+    for _ in range(len(script)):
+        events.extend(pipeline.step())
+    kinds = [e.kind for e in events]
+    assert kinds == [PERSON_APPEARED, PERSON_LEFT]
+
+
+def test_person_appeared_only_once_while_present():
+    script = [True, True, True]
+    pipeline = VisionPipeline(ListSource(_frames(3)), [ScriptedPersonDetector(script)])
+    events = []
+    for _ in range(3):
+        events.extend(pipeline.step())
+    assert [e.kind for e in events] == [PERSON_APPEARED]
+    assert events[0].detections[0].kind == "person"
+
+
+def test_motion_events_and_latest_frame():
+    still = solid_frame((60, 60, 60))
+    moved = still.copy()
+    moved[50:150, 50:250] = (255, 255, 255)
+    pipeline = VisionPipeline(ListSource([still, moved]), [MotionDetector()])
+
+    assert pipeline.latest_frame is None
+    assert pipeline.step() == []  # primes background
+    events = pipeline.step()
+    assert [e.kind for e in events] == [MOTION]
+    assert pipeline.latest_frame is not None
+    assert np.array_equal(pipeline.latest_frame, moved)
+
+
+def test_callback_receives_events_and_errors_are_contained():
+    received = []
+
+    def flaky_callback(event):
+        received.append(event)
+        raise RuntimeError("subscriber bug must not kill the pipeline")
+
+    pipeline = VisionPipeline(
+        ListSource(_frames(1)),
+        [ScriptedPersonDetector([True])],
+        on_event=flaky_callback,
+    )
+    events = pipeline.step()  # must not raise
+    assert len(events) == 1
+    assert received == events
+
+
+def test_exhausted_source_yields_no_events():
+    pipeline = VisionPipeline(ListSource([]), [MotionDetector()])
+    assert pipeline.step() == []
+
+
+def test_thread_lifecycle():
+    pipeline = VisionPipeline(
+        ListSource(_frames(100)), [MotionDetector()], interval_s=0.01
+    )
+    pipeline.start()
+    try:
+        import time
+
+        time.sleep(0.1)
+        assert pipeline.latest_frame is not None
+    finally:
+        pipeline.stop()
+    assert pipeline._thread is None

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import threading
+
 import numpy as np
+import pytest
 from gptme_vision_node.detect import Detection, MotionDetector
 from gptme_vision_node.pipeline import (
     MOTION,
@@ -130,3 +133,30 @@ def test_thread_stops_when_source_is_exhausted():
     pipeline._thread.join(timeout=1)
     assert not pipeline._thread.is_alive()
     pipeline.stop()
+
+
+def test_stop_keeps_reference_to_blocked_thread():
+    unblock = threading.Event()
+
+    class BlockingSource:
+        def get_frame(self):
+            unblock.wait()
+            return None
+
+    pipeline = VisionPipeline(BlockingSource(), [])
+    pipeline.start()
+    thread = pipeline._thread
+    assert thread is not None
+
+    try:
+        pipeline.stop(timeout=0.01)
+        assert pipeline._thread is thread
+        assert thread.is_alive()
+        with pytest.raises(RuntimeError, match="already running"):
+            pipeline.start()
+    finally:
+        unblock.set()
+        thread.join(timeout=1)
+        pipeline.stop()
+
+    assert pipeline._thread is None

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -121,3 +121,12 @@ def test_thread_lifecycle():
     finally:
         pipeline.stop()
     assert pipeline._thread is None
+
+
+def test_thread_stops_when_source_is_exhausted():
+    pipeline = VisionPipeline(ListSource(_frames(1)), [], interval_s=0.01)
+    pipeline.start()
+    assert pipeline._thread is not None
+    pipeline._thread.join(timeout=1)
+    assert not pipeline._thread.is_alive()
+    pipeline.stop()

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -1,0 +1,161 @@
+"""Tests for place recognition: embedder, wifi similarity, recognizer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from gptme_vision_node.place import (
+    HistogramEmbedder,
+    PlaceRecognizer,
+    WifiSignature,
+    cosine_similarity,
+)
+
+from .conftest import scene_frame, solid_frame
+
+KITCHEN = scene_frame(101)
+KITCHEN_2 = scene_frame(101).copy()
+OFFICE = scene_frame(202)
+
+
+def _noisy(frame, seed=0, amount=6):
+    rng = np.random.default_rng(seed)
+    noise = rng.integers(-amount, amount + 1, frame.shape)
+    return np.clip(frame.astype(int) + noise, 0, 255).astype(np.uint8)
+
+
+# -- HistogramEmbedder -----------------------------------------------------
+
+
+def test_embedder_output_is_normalized():
+    vec = HistogramEmbedder().embed(KITCHEN)
+    assert vec.ndim == 1
+    assert vec.dtype == np.float64
+    assert np.linalg.norm(vec) == pytest.approx(1.0)
+
+
+def test_embedder_discriminates_scenes():
+    emb = HistogramEmbedder()
+    kitchen = emb.embed(KITCHEN)
+    kitchen_again = emb.embed(_noisy(KITCHEN, seed=7))
+    office = emb.embed(OFFICE)
+
+    same = cosine_similarity(kitchen, kitchen_again)
+    different = cosine_similarity(kitchen, office)
+    assert same > 0.95, f"near-identical scenes should score high, got {same}"
+    assert same > different + 0.1, f"distinct scenes too close: {same} vs {different}"
+
+
+def test_embedder_spatial_grid_matters():
+    """Same colors, different layout -> distinguishable via the grid cells."""
+    emb = HistogramEmbedder()
+    left = solid_frame((0, 0, 0))
+    left[:, :160] = (0, 0, 255)  # red on the left
+    right = solid_frame((0, 0, 0))
+    right[:, 160:] = (0, 0, 255)  # red on the right
+    sim = cosine_similarity(emb.embed(left), emb.embed(right))
+    assert sim < 0.999  # global histograms alone would be ~identical
+
+
+# -- WifiSignature ---------------------------------------------------------
+
+
+def test_wifi_parse_nmcli():
+    out = "AA\\:BB\\:CC\\:DD\\:EE\\:FF:82\n11\\:22\\:33\\:44\\:55\\:66:47\n\nbad-line\n"
+    sig = WifiSignature.parse_nmcli(out)
+    assert sig == {"AA:BB:CC:DD:EE:FF": 82.0, "11:22:33:44:55:66": 47.0}
+
+
+def test_wifi_similarity_math():
+    a = {"AA": 80.0, "BB": 60.0, "CC": 40.0}
+    assert WifiSignature.similarity(a, dict(a)) == pytest.approx(1.0)
+    assert WifiSignature.similarity(a, {"XX": 80.0, "YY": 60.0}) == 0.0
+    assert WifiSignature.similarity(a, {}) == 0.0
+    assert WifiSignature.similarity({}, {}) == 0.0
+
+    # Partial overlap with similar strengths beats disjoint, loses to identical.
+    partial = WifiSignature.similarity(a, {"AA": 78.0, "BB": 62.0})
+    assert 0.0 < partial < 1.0
+
+    # Same APs but very different strengths scores lower than same strengths.
+    shifted = WifiSignature.similarity(a, {"AA": 10.0, "BB": 5.0, "CC": 99.0})
+    assert shifted < WifiSignature.similarity(a, dict(a))
+
+
+def test_wifi_scan_graceful_on_failure(monkeypatch):
+    import subprocess
+
+    def boom(*args, **kwargs):
+        raise FileNotFoundError("nmcli not installed")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert WifiSignature.scan() == {}
+
+
+# -- PlaceRecognizer -------------------------------------------------------
+
+KITCHEN_WIFI = {"AA": 80.0, "BB": 60.0}
+OFFICE_WIFI = {"CC": 70.0, "DD": 50.0}
+
+
+def test_recognize_vision_only():
+    rec = PlaceRecognizer()
+    rec.enroll("kitchen", KITCHEN)
+    rec.enroll("office", OFFICE)
+    results = rec.recognize(_noisy(KITCHEN, seed=3))
+    assert results[0][0] == "kitchen"
+    assert results[0][1] > results[-1][1]
+
+
+def test_recognize_wifi_only():
+    rec = PlaceRecognizer()
+    rec.enroll("kitchen", wifi_sig=KITCHEN_WIFI)
+    rec.enroll("office", wifi_sig=OFFICE_WIFI)
+    results = rec.recognize(wifi_sig={"AA": 78.0, "BB": 63.0})
+    assert results[0][0] == "kitchen"
+    assert results[0][1] > 0.5
+
+
+def test_recognize_combined_wifi_disambiguates():
+    """Two visually similar places separated by their wifi fingerprints."""
+    rec = PlaceRecognizer(wifi_weight=0.5)
+    rec.enroll("kitchen", KITCHEN, wifi_sig=KITCHEN_WIFI)
+    rec.enroll("kitchen-clone", KITCHEN_2, wifi_sig=OFFICE_WIFI)
+    results = dict(rec.recognize(_noisy(KITCHEN, seed=5), wifi_sig=KITCHEN_WIFI))
+    assert results["kitchen"] > results["kitchen-clone"]
+
+
+def test_multiple_samples_per_place():
+    rec = PlaceRecognizer()
+    rec.enroll("kitchen", KITCHEN)
+    rec.enroll("kitchen", _noisy(KITCHEN, seed=11))
+    assert len(rec.places["kitchen"]) == 2
+    assert rec.recognize(KITCHEN)[0][0] == "kitchen"
+
+
+def test_enroll_requires_signal():
+    rec = PlaceRecognizer()
+    with pytest.raises(ValueError):
+        rec.enroll("nowhere")
+    with pytest.raises(ValueError):
+        rec.recognize()
+
+
+def test_save_load_roundtrip(tmp_path):
+    gallery = tmp_path / "places.json"
+    rec = PlaceRecognizer(wifi_weight=0.3)
+    rec.enroll("kitchen", KITCHEN, wifi_sig=KITCHEN_WIFI)
+    rec.enroll("office", OFFICE, wifi_sig=OFFICE_WIFI)
+    rec.enroll("hallway", wifi_sig={"EE": 40.0})  # wifi-only sample
+    rec.save(gallery)
+
+    loaded = PlaceRecognizer.from_file(gallery)
+    assert loaded.wifi_weight == pytest.approx(0.3)
+    assert set(loaded.places) == {"kitchen", "office", "hallway"}
+    assert loaded.places["hallway"][0].embedding is None
+
+    original = rec.recognize(_noisy(KITCHEN, seed=9), wifi_sig=KITCHEN_WIFI)
+    reloaded = loaded.recognize(_noisy(KITCHEN, seed=9), wifi_sig=KITCHEN_WIFI)
+    assert [name for name, _ in original] == [name for name, _ in reloaded]
+    for (_, s1), (_, s2) in zip(original, reloaded):
+        assert s1 == pytest.approx(s2)

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -36,6 +36,13 @@ def test_embedder_output_is_normalized():
     assert np.linalg.norm(vec) == pytest.approx(1.0)
 
 
+def test_embedder_handles_frames_smaller_than_grid():
+    vec = HistogramEmbedder(grid=2).embed(np.zeros((1, 1, 3), dtype=np.uint8))
+
+    assert vec.shape == (24 * 8 * 5,)
+    assert np.isfinite(vec).all()
+
+
 @pytest.mark.parametrize(
     ("kwargs", "parameter"),
     [({"h_bins": 0}, "h_bins"), ({"s_bins": 0}, "s_bins"), ({"grid": 0}, "grid")],
@@ -212,6 +219,18 @@ def test_load_rejects_non_object_places(tmp_path, places):
     gallery.write_text(json.dumps({"places": places}))
 
     with pytest.raises(ValueError, match="places must be a JSON object"):
+        PlaceRecognizer().load(gallery)
+
+
+@pytest.mark.parametrize(
+    "samples",
+    [{"embedding": [1.0]}, [1], ["sample"], [[1.0]]],
+)
+def test_load_rejects_malformed_place_samples(tmp_path, samples):
+    gallery = tmp_path / "places.json"
+    gallery.write_text(json.dumps({"places": {"kitchen": samples}}))
+
+    with pytest.raises(ValueError, match="samples must be a list of JSON objects"):
         PlaceRecognizer().load(gallery)
 
 

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -161,6 +161,18 @@ def test_save_load_roundtrip(tmp_path):
         assert s1 == pytest.approx(s2)
 
 
+def test_load_restores_wifi_weight(tmp_path):
+    gallery = tmp_path / "places.json"
+    saved = PlaceRecognizer(wifi_weight=0.7)
+    saved.enroll("kitchen", KITCHEN, wifi_sig=KITCHEN_WIFI)
+    saved.save(gallery)
+
+    loaded = PlaceRecognizer(wifi_weight=0.2)
+    loaded.load(gallery)
+
+    assert loaded.wifi_weight == pytest.approx(0.7)
+
+
 class CustomEmbedder:
     embedder_id = "test-custom-v1"
 

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -184,6 +184,17 @@ def test_from_file_explicit_wifi_weight_overrides_saved_value(tmp_path):
     assert loaded.wifi_weight == pytest.approx(0.2)
 
 
+@pytest.mark.parametrize("payload", ["[]", '"gallery"', "null"])
+def test_load_rejects_non_object_payload(tmp_path, payload):
+    gallery = tmp_path / "places.json"
+    gallery.write_text(payload)
+
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        PlaceRecognizer().load(gallery)
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        PlaceRecognizer.from_file(gallery)
+
+
 class CustomEmbedder:
     embedder_id = "test-custom-v1"
 

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 from gptme_vision_node.place import (
@@ -32,6 +34,15 @@ def test_embedder_output_is_normalized():
     assert vec.ndim == 1
     assert vec.dtype == np.float64
     assert np.linalg.norm(vec) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "parameter"),
+    [({"h_bins": 0}, "h_bins"), ({"s_bins": 0}, "s_bins"), ({"grid": 0}, "grid")],
+)
+def test_embedder_rejects_non_positive_dimensions(kwargs, parameter):
+    with pytest.raises(ValueError, match=parameter):
+        HistogramEmbedder(**kwargs)
 
 
 def test_embedder_discriminates_scenes():
@@ -193,6 +204,15 @@ def test_load_rejects_non_object_payload(tmp_path, payload):
         PlaceRecognizer().load(gallery)
     with pytest.raises(ValueError, match="must contain a JSON object"):
         PlaceRecognizer.from_file(gallery)
+
+
+@pytest.mark.parametrize("places", [[], "kitchen", None])
+def test_load_rejects_non_object_places(tmp_path, places):
+    gallery = tmp_path / "places.json"
+    gallery.write_text(json.dumps({"places": places}))
+
+    with pytest.raises(ValueError, match="places must be a JSON object"):
+        PlaceRecognizer().load(gallery)
 
 
 class CustomEmbedder:

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -234,6 +234,19 @@ def test_load_rejects_malformed_place_samples(tmp_path, samples):
         PlaceRecognizer().load(gallery)
 
 
+@pytest.mark.parametrize("wifi", ["kitchen-ap", [1, 2], 3])
+def test_load_rejects_non_object_wifi(tmp_path, wifi):
+    gallery = tmp_path / "places.json"
+    gallery.write_text(
+        json.dumps({"places": {"kitchen": [{"embedding": [1.0], "wifi": wifi}]}})
+    )
+
+    with pytest.raises(ValueError, match="sample wifi must be a JSON object"):
+        PlaceRecognizer().load(gallery)
+    with pytest.raises(ValueError, match="sample wifi must be a JSON object"):
+        PlaceRecognizer.from_file(gallery)
+
+
 class CustomEmbedder:
     embedder_id = "test-custom-v1"
 

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -159,3 +159,23 @@ def test_save_load_roundtrip(tmp_path):
     assert [name for name, _ in original] == [name for name, _ in reloaded]
     for (_, s1), (_, s2) in zip(original, reloaded):
         assert s1 == pytest.approx(s2)
+
+
+class CustomEmbedder:
+    embedder_id = "test-custom-v1"
+
+    def embed(self, frame):
+        return np.asarray([1.0, 0.0])
+
+
+def test_from_file_rejects_mismatched_embedder(tmp_path):
+    gallery = tmp_path / "places.json"
+    rec = PlaceRecognizer(CustomEmbedder())
+    rec.enroll("kitchen", KITCHEN)
+    rec.save(gallery)
+
+    with pytest.raises(ValueError, match="embedder mismatch"):
+        PlaceRecognizer.from_file(gallery)
+
+    loaded = PlaceRecognizer.from_file(gallery, CustomEmbedder())
+    assert set(loaded.places) == {"kitchen"}

--- a/packages/gptme-vision-node/tests/test_place.py
+++ b/packages/gptme-vision-node/tests/test_place.py
@@ -173,6 +173,17 @@ def test_load_restores_wifi_weight(tmp_path):
     assert loaded.wifi_weight == pytest.approx(0.7)
 
 
+def test_from_file_explicit_wifi_weight_overrides_saved_value(tmp_path):
+    gallery = tmp_path / "places.json"
+    saved = PlaceRecognizer(wifi_weight=0.7)
+    saved.enroll("kitchen", KITCHEN, wifi_sig=KITCHEN_WIFI)
+    saved.save(gallery)
+
+    loaded = PlaceRecognizer.from_file(gallery, wifi_weight=0.2)
+
+    assert loaded.wifi_weight == pytest.approx(0.2)
+
+
 class CustomEmbedder:
     embedder_id = "test-custom-v1"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2566,6 +2566,7 @@ name = "gptme-vision-node"
 version = "0.1.0"
 source = { editable = "packages/gptme-vision-node" }
 dependencies = [
+    { name = "click" },
     { name = "httpx" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -2580,6 +2581,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "numpy", specifier = ">=1.24", index = "https://pypi.org/simple" },
     { name = "opencv-python-headless", specifier = ">=4.8,<5" },

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,7 @@ members = [
     "gptme-tts",
     "gptme-usage",
     "gptme-user-memories",
+    "gptme-vision-node",
     "gptme-voice",
     "gptme-warpgrep",
     "gptme-whatsapp",
@@ -2561,6 +2562,32 @@ requires-dist = [
 provides-extras = ["test"]
 
 [[package]]
+name = "gptme-vision-node"
+version = "0.1.0"
+source = { editable = "packages/gptme-vision-node" }
+dependencies = [
+    { name = "httpx" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "opencv-python-headless" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "numpy", specifier = ">=1.24", index = "https://pypi.org/simple" },
+    { name = "opencv-python-headless", specifier = ">=4.8,<5" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
 name = "gptme-voice"
 version = "0.1.0"
 source = { editable = "packages/gptme-voice" }
@@ -4236,6 +4263,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/9a/8c75e8c8a5b407a0586faeb2afac91674ff955c191ecc1d6d3b6669f6788/openai-2.54.0.tar.gz", hash = "sha256:e3e6f8bc1ba30ddf381ace1a14340eed381cb984a1a59bd0f34b5be3b5d49cfa", size = 1100285, upload-time = "2026-08-11T18:46:59.035Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/a8/bb76c7356de8ad57f59d5ff993d434df0607f07f08bcc9c9a5c275e399c0/openai-2.54.0-py3-none-any.whl", hash = "sha256:89089789197ccdb87f173a03145ed1598d00795220c93e96cf712b1cbf5e5f2b", size = 1660351, upload-time = "2026-08-11T18:46:56.684Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.14.0.94"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/8a/51ff1c6287be0b6cd3070cf095875da4ff7d6eda38507e6ada5608786a78/opencv_python_headless-4.14.0.94.tar.gz", hash = "sha256:4afa2ea1214453648be88259f035712454faa9039b686de7753569ba8eec1577", size = 96405664, upload-time = "2026-07-28T19:23:48.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/56/12f9b05628cf4ab6aad54479b9124f7c1f2f92b6a4e47c071beb63d926a2/opencv_python_headless-4.14.0.94-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:bc7db37dc234f7bb3190a158fd9dd750357246fc7d8adb23698843ef721a993b", size = 46491231, upload-time = "2026-07-29T03:52:11.902Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/2f9c42466f62aa27e97aaf6c9d914008895ecde28013ba4beed7f541f593/opencv_python_headless-4.14.0.94-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1777f43c9fa064f54b916ad70d944b4fde0a644a17e49f04a966bb24a4b5f1e1", size = 33084176, upload-time = "2026-07-28T20:05:59.902Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/91/83c51e3fe000b5dfce4f3be5c5d320e07ebab5c1742abc4e45674503f90f/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:29714d7716dbfddf9fec20ffb878765e94ccaecd7d3ebd6750877420296e2dc5", size = 35405458, upload-time = "2026-07-28T19:19:29.997Z" },
+    { url = "https://files.pythonhosted.org/packages/de/06/14c8c5d331bc72738683a9b227966aceaa4c6d08752f33d64578aebcb6f8/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5e02669eac0ba67b2a22d7245af1e8ee1a2ef1185ee526a063d8f0555224bd52", size = 57534165, upload-time = "2026-07-28T19:19:52.742Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0e/0b98bd582582253f61c4506f9b465cf5a8aa7fa4f7237dd99e1b5151a159/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:97c6e818c6f71c0cfa214e12293b1d0266d679c38f4e086de08357c8ac6ece0d", size = 38104309, upload-time = "2026-07-28T19:20:08.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ce/7f538891722a4f06921419d55bac6f41729258d54442861edb2de0dbdf5e/opencv_python_headless-4.14.0.94-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:211e581f5a4670acbbe08fff36a35e9946039d2eea28b80394632d036d1be527", size = 61960165, upload-time = "2026-07-28T19:20:33.074Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/91/ded03abad74d7264fa6bc7c923d7cade6f94a9023eeb372cfad54c2d0334/opencv_python_headless-4.14.0.94-cp37-abi3-win32.whl", hash = "sha256:f70296aa7ac9d7ade0d925c43fdc006c83e20a23f30e2f40f1b82c74a7a54460", size = 33030271, upload-time = "2026-07-28T18:32:39.447Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8d/db8673846ee53cbb5de4c2b4decc11cf733e203eb7d5146297869f69bd48/opencv_python_headless-4.14.0.94-cp37-abi3-win_amd64.whl", hash = "sha256:cbed65415b8f6a9541c705afe3e64795840524d0ff3bc58f507826284a1dc64b", size = 41028030, upload-time = "2026-07-28T18:32:36.724Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements **BobBrain milestone 2 (vision v0)** per `bobbrain-spec.md` — the vision half of the portable presence node. Ref: ErikBjare/bob#730.

New package `packages/gptme-vision-node/` (module `gptme_vision_node`), deliberately light deps: `opencv-python-headless` (<5 — OpenCV 5 removed the legacy HOG objdetect API), `numpy`, `httpx`, `click`. No torch/ultralytics/CLIP — remote inference is the architecture.

## What's in it

- **Frame sources** (`frame_source.py`): `FrameSource` protocol; `ImageFileSource` (single file or directory round-robin), `OpenCVCameraSource` (V4L2 webcam index / Pi camera / RTSP URL, lazy-open).
- **Detection** (`detect.py`): `PersonDetector` — OpenCV's built-in HOG people detector (no model downloads); `MotionDetector` — frame differencing against a running-average background. Shared `Detection {kind, box, score}` dataclass + `Detector` protocol.
- **LLM look tool** (`look.py`): `describe_frame(frame, prompt)` — JPEG+base64 → any OpenAI-compatible chat-completions endpoint (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `VISION_MODEL`). This is the on-demand "see things" toolcall the voice bridge wires in (concurrent PR #1524 territory — no file overlap beyond uv.lock/pre-commit config).
- **Place recognition** (`place.py`) — "where am I?" without GPS (Erik's ask 2026-08-27):
  - `Embedder` protocol with `HistogramEmbedder` default (HSV histogram + coarse spatial grid, L2-normalized). CLIP documented as a future optional extra, not a dep.
  - `WifiSignature.scan()` via `nmcli` (graceful empty dict on failure) + overlap-weighted RSSI similarity (Jaccard × signal agreement → 0..1).
  - `PlaceRecognizer`: multi-sample enroll per place, fused visual+wifi scoring (`wifi_weight` configurable, 0.5 default when both present), JSON gallery persistence.
- **Pipeline** (`pipeline.py`): `VisionPipeline(source, detectors, interval_s)` — capture → detect → `VisionEvent` (`person_appeared`/`person_left` edge-triggered with debounce, `motion`) via callback; keeps `latest_frame` for the look tool. Thread-based, callback exceptions contained.
- **CLI** (`gptme-vision-node`): `detect`, `look`, `enroll --place`, `whereami` (gallery default `~/.config/gptme-vision-node/places.json`). Click, per repo convention.

## Tests

40 tests, fully offline (synthetic numpy frames, mocked httpx/nmcli/wifi): frame-source round-robin, motion fires-on-change/quiet-on-static, HOG no-crash on synthetic frames, histogram embedder discrimination (near-identical vs distinct scenes, spatial-grid sensitivity), wifi parse+similarity math, recognizer enroll/recognize/save/load roundtrips (vision-only, wifi-only, combined disambiguation), look request-building + error paths, pipeline event edge/debounce logic, CLI end-to-end via CliRunner.

`uv run pytest packages/gptme-vision-node -q` → 40 passed. mypy clean; package added to the root-mypy exclude list (it has its own `make typecheck`, same as the other packages) and picked up by the CI package matrix via its Makefile.
