### PR TITLE
perf(rag): cache scan_lessons() by mtime+size to skip YAML re-parse

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -733,15 +733,27 @@ def clear_scan_cache() -> None:
     _disk_dirty = False
 
 
+_LESSON_LIST_FIELDS = (
+    "keywords",
+    "patterns",
+    "tags",
+    "harness_restrict",
+    "session_categories",
+)
+
+
+def _valid_cached_lesson(lesson: object) -> bool:
+    """Return whether a persisted lesson has the shape cloning requires."""
+    return isinstance(lesson, dict) and all(
+        isinstance(lesson.get(field), list) for field in _LESSON_LIST_FIELDS
+    )
+
+
 def _clone_lesson(lesson: dict[str, Any]) -> dict[str, Any]:
     """Shallow-copy a lesson dict so callers cannot mutate the cache."""
     return {
         **lesson,
-        "keywords": list(lesson["keywords"]),
-        "patterns": list(lesson["patterns"]),
-        "tags": list(lesson["tags"]),
-        "harness_restrict": list(lesson["harness_restrict"]),
-        "session_categories": list(lesson["session_categories"]),
+        **{field: list(lesson[field]) for field in _LESSON_LIST_FIELDS},
     }
 
 
@@ -770,7 +782,7 @@ def _load_disk_cache() -> None:
         lesson = entry.get("lesson")
         if not isinstance(mtime_ns, int) or not isinstance(size, int):
             continue
-        if lesson is not None and not isinstance(lesson, dict):
+        if lesson is not None and not _valid_cached_lesson(lesson):
             continue
         _parse_cache[path] = (mtime_ns, size, lesson)
 

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -740,12 +740,19 @@ _LESSON_LIST_FIELDS = (
     "harness_restrict",
     "session_categories",
 )
+_LESSON_STRING_FIELDS = ("path", "title", "description", "when_to_use", "body")
 
 
 def _valid_cached_lesson(lesson: object) -> bool:
-    """Return whether a persisted lesson has the shape cloning requires."""
-    return isinstance(lesson, dict) and all(
-        isinstance(lesson.get(field), list) for field in _LESSON_LIST_FIELDS
+    """Return whether a persisted lesson has the shape downstream consumers require."""
+    return (
+        isinstance(lesson, dict)
+        and all(isinstance(lesson.get(field), list) for field in _LESSON_LIST_FIELDS)
+        and all(isinstance(lesson.get(field), str) for field in _LESSON_STRING_FIELDS)
+        and (lesson.get("id") is None or isinstance(lesson.get("id"), str))
+        and (lesson.get("skill_name") is None or isinstance(lesson.get("skill_name"), str))
+        and isinstance(lesson.get("is_skill"), bool)
+        and isinstance(lesson.get("n_keywords"), int)
     )
 
 
@@ -1007,7 +1014,6 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
             resolved = str(f.resolve())
             if resolved in seen_paths:
                 continue
-            seen_paths.add(resolved)
 
             relative_path = f.relative_to(lesson_dir)
             is_skill_file = f.name == "SKILL.md"
@@ -1026,6 +1032,7 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
             if not is_skill_file and f.name in seen_names:
                 continue
 
+            seen_paths.add(resolved)
             readable, lesson = _cached_parse_lesson_file(f)
             if not readable:
                 continue

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -31,8 +31,11 @@ Public API::
 
 from __future__ import annotations
 
+import json
 import math
+import os
 import re
+import tempfile
 from pathlib import Path
 from collections.abc import Sequence
 from typing import Any
@@ -678,6 +681,254 @@ def _score_skill_descriptor(lesson: dict[str, Any], prompt_lower: str) -> tuple[
 # Lesson scanning
 # ---------------------------------------------------------------------------
 
+#: On-disk cache schema. Bump when the lesson dict shape changes.
+_CACHE_VERSION = 1
+
+# resolved path -> (mtime_ns, size, lesson_or_None). None means parsed-but-skipped.
+_parse_cache: dict[str, tuple[int, int, dict[str, Any] | None]] = {}
+_disk_loaded = False
+_disk_dirty = False
+
+
+def _xdg_cache_home() -> Path:
+    raw = os.environ.get("XDG_CACHE_HOME")
+    if raw:
+        return Path(raw)
+    return Path.home() / ".cache"
+
+
+def _scan_cache_dir() -> Path | None:
+    """Return the on-disk cache directory, or ``None`` if disk cache is disabled.
+
+    ``GPTME_LESSON_SCAN_CACHE`` overrides the default
+    ``$XDG_CACHE_HOME/gptme/lesson-scan``. Set it to ``off``/``0``/``false`` to
+    keep only the in-memory cache (useful when the caller already isolates
+    processes, or in tests that want a purely ephemeral cache).
+    """
+    raw = os.environ.get("GPTME_LESSON_SCAN_CACHE")
+    if raw is not None:
+        lowered = raw.strip().lower()
+        if lowered in {"", "0", "off", "false", "none"}:
+            return None
+        return Path(raw)
+    return _xdg_cache_home() / "gptme" / "lesson-scan"
+
+
+def _scan_cache_file() -> Path | None:
+    cache_dir = _scan_cache_dir()
+    if cache_dir is None:
+        return None
+    return cache_dir / "scan-v1.json"
+
+
+def clear_scan_cache() -> None:
+    """Drop the in-memory parse cache so the next scan reloads from disk.
+
+    Disk contents are left in place. Tests use this to simulate a fresh
+    process without deleting the on-disk artifact.
+    """
+    global _disk_loaded, _disk_dirty
+    _parse_cache.clear()
+    _disk_loaded = False
+    _disk_dirty = False
+
+
+def _clone_lesson(lesson: dict[str, Any]) -> dict[str, Any]:
+    """Shallow-copy a lesson dict so callers cannot mutate the cache."""
+    return {
+        **lesson,
+        "keywords": list(lesson["keywords"]),
+        "patterns": list(lesson["patterns"]),
+        "tags": list(lesson["tags"]),
+        "harness_restrict": list(lesson["harness_restrict"]),
+        "session_categories": list(lesson["session_categories"]),
+    }
+
+
+def _load_disk_cache() -> None:
+    global _disk_loaded
+    if _disk_loaded:
+        return
+    _disk_loaded = True
+    cache_file = _scan_cache_file()
+    if cache_file is None:
+        return
+    try:
+        raw = json.loads(cache_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return
+    if not isinstance(raw, dict) or raw.get("version") != _CACHE_VERSION:
+        return
+    files = raw.get("files")
+    if not isinstance(files, dict):
+        return
+    for path, entry in files.items():
+        if not isinstance(path, str) or not isinstance(entry, dict):
+            continue
+        mtime_ns = entry.get("mtime_ns")
+        size = entry.get("size")
+        lesson = entry.get("lesson")
+        if not isinstance(mtime_ns, int) or not isinstance(size, int):
+            continue
+        if lesson is not None and not isinstance(lesson, dict):
+            continue
+        _parse_cache[path] = (mtime_ns, size, lesson)
+
+
+def _save_disk_cache() -> None:
+    global _disk_dirty
+    if not _disk_dirty:
+        return
+    cache_file = _scan_cache_file()
+    if cache_file is None:
+        _disk_dirty = False
+        return
+    payload = {
+        "version": _CACHE_VERSION,
+        "files": {
+            path: {"mtime_ns": mtime_ns, "size": size, "lesson": lesson}
+            for path, (mtime_ns, size, lesson) in _parse_cache.items()
+        },
+    }
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(cache_file.parent), prefix=".scan-v1.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+            os.replace(tmp_name, cache_file)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+        _disk_dirty = False
+    except OSError:
+        # Cache is a speed-up, never a correctness requirement.
+        pass
+
+
+def _stat_key(path: Path) -> tuple[int, int] | None:
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _parse_lesson_file(path: Path) -> dict[str, Any] | None:
+    """Parse one lesson file. Return the lesson dict, or ``None`` if skipped.
+
+    ``None`` means the file was readable but inactive / has no match data.
+    Unreadable files raise (caller treats that as "not seen").
+    """
+    content = path.read_text(encoding="utf-8")
+    fm, body = extract_frontmatter(content)
+
+    if effective_status(fm) != "active":
+        return None
+
+    match_data = fm.get("match", {})
+    if isinstance(match_data, dict):
+        raw_keywords = match_data.get("keywords", [])
+        raw_patterns = match_data.get("patterns", [])
+    else:
+        raw_keywords = []
+        raw_patterns = []
+
+    if isinstance(raw_keywords, str):
+        raw_keywords = [raw_keywords]
+    keywords = _dedupe_strings([*raw_keywords, *_string_list(fm.get("keywords"))])
+
+    if isinstance(raw_patterns, str):
+        raw_patterns = [raw_patterns]
+    patterns = _dedupe_strings([*raw_patterns, *_string_list(fm.get("patterns"))])
+
+    skill_name = fm.get("name") if isinstance(fm.get("name"), str) else None
+    lesson_id = fm.get("id") if isinstance(fm.get("id"), str) else None
+    description = fm.get("description") if isinstance(fm.get("description"), str) else ""
+    when_to_use = fm.get("when_to_use") if isinstance(fm.get("when_to_use"), str) else ""
+    metadata_value = fm.get("metadata")
+    metadata = metadata_value if isinstance(metadata_value, dict) else {}
+    tags = _string_list(metadata.get("tags"))
+    harness_restrict = _string_list(metadata.get("harness"))
+
+    _raw_sc = match_data.get("session_categories") or [] if isinstance(match_data, dict) else []
+    session_categories = _dedupe_strings(_string_list(_raw_sc))
+
+    if not keywords and not patterns and not skill_name:
+        return None
+
+    title_match = re.search(r"^#\s+(.+)$", body, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else path.stem
+
+    return {
+        "path": str(path),
+        "title": title,
+        "id": lesson_id,
+        "keywords": keywords,
+        "patterns": patterns,
+        "skill_name": skill_name,
+        "description": description,
+        "when_to_use": when_to_use,
+        "tags": tags,
+        "harness_restrict": harness_restrict,
+        "session_categories": session_categories,
+        "is_skill": path.name == "SKILL.md" or skill_name is not None,
+        "body": body,
+        "n_keywords": len(keywords),
+    }
+
+
+def _cached_parse_lesson_file(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    """Return ``(readable, lesson_or_none)`` using the mtime+size cache.
+
+    ``readable=False`` means the file could not be stat'd or read — the caller
+    must not register the filename for first-dir-wins dedup, matching the
+    previous uncached behaviour.
+    """
+    global _disk_dirty
+    _load_disk_cache()
+    try:
+        resolved = str(path.resolve())
+    except OSError:
+        return False, None
+    key = _stat_key(path)
+    if key is None:
+        return False, None
+    mtime_ns, size = key
+    cached = _parse_cache.get(resolved)
+    if cached is not None and cached[0] == mtime_ns and cached[1] == size:
+        lesson = cached[2]
+        return True, _clone_lesson(lesson) if lesson is not None else None
+    try:
+        lesson = _parse_lesson_file(path)
+    except Exception:
+        return False, None
+    stored = _clone_lesson(lesson) if lesson is not None else None
+    _parse_cache[resolved] = (mtime_ns, size, stored)
+    _disk_dirty = True
+    return True, _clone_lesson(stored) if stored is not None else None
+
+
+def _prune_missing_from_cache(scanned_roots: list[str], seen_paths: set[str]) -> None:
+    """Drop cache entries under *scanned_roots* that were not seen this scan."""
+    global _disk_dirty
+    stale = [
+        path
+        for path in _parse_cache
+        if path not in seen_paths
+        and any(path == root or path.startswith(root + os.sep) for root in scanned_roots)
+    ]
+    if not stale:
+        return
+    for path in stale:
+        del _parse_cache[path]
+    _disk_dirty = True
+
 
 def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
     """Scan *lesson_dirs* and return a list of parsed lesson dicts.
@@ -720,14 +971,26 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
     status is written top-level or as ``metadata.status`` (see
     :func:`effective_status`).
     Lessons with no keywords, patterns, or skill name are skipped.
+
+    Parsed files are cached in memory and on disk, keyed by
+    ``(resolved path, st_mtime_ns, st_size)``. The Claude Code
+    ``match-lessons`` hook is a fresh process per tool call, so the on-disk
+    layer is what actually avoids re-running ``yaml.safe_load`` across 800+
+    unchanged lesson files. A lesson written mid-session still matches on the
+    next call because its mtime/size miss the cache.
     """
     lessons: list[dict[str, Any]] = []
     seen_paths: set[str] = set()
     seen_names: set[str] = set()  # filename-based dedup: first dir wins
+    scanned_roots: list[str] = []
 
     for lesson_dir in lesson_dirs:
         if not lesson_dir.exists():
             continue
+        try:
+            scanned_roots.append(str(lesson_dir.resolve()))
+        except OSError:
+            scanned_roots.append(str(lesson_dir))
         for f in sorted(lesson_dir.rglob("*.md")):
             if f.name == "README.md":
                 continue
@@ -757,73 +1020,18 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
             if not is_skill_file and f.name in seen_names:
                 continue
 
-            try:
-                content = f.read_text(encoding="utf-8")
-            except Exception:
+            readable, lesson = _cached_parse_lesson_file(f)
+            if not readable:
                 continue
 
             if not is_skill_file:
                 seen_names.add(f.name)
 
-            fm, body = extract_frontmatter(content)
+            if lesson is not None:
+                lessons.append(lesson)
 
-            if effective_status(fm) != "active":
-                continue
-
-            match_data = fm.get("match", {})
-            if isinstance(match_data, dict):
-                raw_keywords = match_data.get("keywords", [])
-                raw_patterns = match_data.get("patterns", [])
-            else:
-                raw_keywords = []
-                raw_patterns = []
-
-            if isinstance(raw_keywords, str):
-                raw_keywords = [raw_keywords]
-            keywords = _dedupe_strings([*raw_keywords, *_string_list(fm.get("keywords"))])
-
-            if isinstance(raw_patterns, str):
-                raw_patterns = [raw_patterns]
-            patterns = _dedupe_strings([*raw_patterns, *_string_list(fm.get("patterns"))])
-
-            skill_name = fm.get("name") if isinstance(fm.get("name"), str) else None
-            lesson_id = fm.get("id") if isinstance(fm.get("id"), str) else None
-            description = fm.get("description") if isinstance(fm.get("description"), str) else ""
-            when_to_use = fm.get("when_to_use") if isinstance(fm.get("when_to_use"), str) else ""
-            metadata_value = fm.get("metadata")
-            metadata = metadata_value if isinstance(metadata_value, dict) else {}
-            tags = _string_list(metadata.get("tags"))
-            harness_restrict = _string_list(metadata.get("harness"))
-
-            _raw_sc = (
-                match_data.get("session_categories") or [] if isinstance(match_data, dict) else []
-            )
-            session_categories = _dedupe_strings(_string_list(_raw_sc))
-
-            if not keywords and not patterns and not skill_name:
-                continue
-
-            title_match = re.search(r"^#\s+(.+)$", body, re.MULTILINE)
-            title = title_match.group(1).strip() if title_match else f.stem
-
-            lessons.append(
-                {
-                    "path": str(f),
-                    "title": title,
-                    "id": lesson_id,
-                    "keywords": keywords,
-                    "patterns": patterns,
-                    "skill_name": skill_name,
-                    "description": description,
-                    "when_to_use": when_to_use,
-                    "tags": tags,
-                    "harness_restrict": harness_restrict,
-                    "session_categories": session_categories,
-                    "is_skill": f.name == "SKILL.md" or skill_name is not None,
-                    "body": body,
-                    "n_keywords": len(keywords),
-                }
-            )
+    _prune_missing_from_cache(scanned_roots, seen_paths)
+    _save_disk_cache()
     return lessons
 
 

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -1018,6 +1018,9 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
             relative_path = f.relative_to(lesson_dir)
             is_skill_file = f.name == "SKILL.md"
             if "archive" in relative_path.parts:
+                # Keep the archived target in path dedup so a differently named
+                # symlink from a later root cannot resurrect it.
+                seen_paths.add(resolved)
                 # An archived copy shadows later dirs unless this dir also
                 # carries an active (non-archived) lesson with the same name.
                 # rglob sorts ``archive/foo.md`` before ``foo.md`` so the

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -902,6 +902,10 @@ def _cached_parse_lesson_file(path: Path) -> tuple[bool, dict[str, Any] | None]:
     mtime_ns, size = key
     cached = _parse_cache.get(resolved)
     if cached is not None and cached[0] == mtime_ns and cached[1] == size:
+        if not os.access(path, os.R_OK):
+            del _parse_cache[resolved]
+            _disk_dirty = True
+            return False, None
         lesson = cached[2]
         return True, _clone_lesson(lesson) if lesson is not None else None
     try:
@@ -914,15 +918,10 @@ def _cached_parse_lesson_file(path: Path) -> tuple[bool, dict[str, Any] | None]:
     return True, _clone_lesson(stored) if stored is not None else None
 
 
-def _prune_missing_from_cache(scanned_roots: list[str], seen_paths: set[str]) -> None:
-    """Drop cache entries under *scanned_roots* that were not seen this scan."""
+def _prune_missing_from_cache(seen_paths: set[str]) -> None:
+    """Drop cache entries not present in the current scan corpus."""
     global _disk_dirty
-    stale = [
-        path
-        for path in _parse_cache
-        if path not in seen_paths
-        and any(path == root or path.startswith(root + os.sep) for root in scanned_roots)
-    ]
+    stale = [path for path in _parse_cache if path not in seen_paths]
     if not stale:
         return
     for path in stale:
@@ -982,15 +981,10 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
     lessons: list[dict[str, Any]] = []
     seen_paths: set[str] = set()
     seen_names: set[str] = set()  # filename-based dedup: first dir wins
-    scanned_roots: list[str] = []
 
     for lesson_dir in lesson_dirs:
         if not lesson_dir.exists():
             continue
-        try:
-            scanned_roots.append(str(lesson_dir.resolve()))
-        except OSError:
-            scanned_roots.append(str(lesson_dir))
         for f in sorted(lesson_dir.rglob("*.md")):
             if f.name == "README.md":
                 continue
@@ -1030,7 +1024,7 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict[str, Any]]:
             if lesson is not None:
                 lessons.append(lesson)
 
-    _prune_missing_from_cache(scanned_roots, seen_paths)
+    _prune_missing_from_cache(seen_paths)
     _save_disk_cache()
     return lessons
 

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import math
+import os
 import sys
 from pathlib import Path
 
+import pytest
 
+from gptme_rag import lesson_matcher as lesson_matcher_mod
 from gptme_rag.lesson_matcher import (
     BM25_MIN_Z,
     _extract_list_frontmatter_field,
     BM25_STANDOUT_FRACTION,
+    clear_scan_cache,
     effective_status,
     extract_frontmatter,
     filter_by_harness,
@@ -27,6 +31,16 @@ from gptme_rag.lesson_matcher import (
     _bm25_zscores,
     _build_bm25_index,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_lesson_scan_cache(tmp_path_factory, monkeypatch):
+    """Keep scan_lessons cache out of ~/.cache and reset between tests."""
+    cache_dir = tmp_path_factory.mktemp("lesson-scan-cache")
+    monkeypatch.setenv("GPTME_LESSON_SCAN_CACHE", str(cache_dir))
+    clear_scan_cache()
+    yield
+    clear_scan_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -960,6 +974,133 @@ class TestScanLessons:
             assert "valid-lesson" in keywords
         finally:
             bad_file.chmod(0o644)  # restore so tmp_path cleanup works
+
+
+# ---------------------------------------------------------------------------
+# scan_lessons cache (mtime + size, memory + disk)
+# ---------------------------------------------------------------------------
+
+
+def _count_parses(monkeypatch):
+    """Wrap _parse_lesson_file and return a mutable call counter."""
+    calls = {"n": 0}
+    real = lesson_matcher_mod._parse_lesson_file
+
+    def wrapped(path: Path):
+        calls["n"] += 1
+        return real(path)
+
+    monkeypatch.setattr(lesson_matcher_mod, "_parse_lesson_file", wrapped)
+    return calls
+
+
+def _bump_mtime(path: Path) -> None:
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+
+class TestScanLessonsCache:
+    def test_cold_start_parses_each_file_once(self, tmp_path, monkeypatch):
+        _write_lesson(tmp_path / "a.md", _basic_lesson(["alpha"]))
+        _write_lesson(tmp_path / "b.md", _basic_lesson(["beta"]))
+        calls = _count_parses(monkeypatch)
+        lessons = scan_lessons([tmp_path])
+        assert {kw for lesson in lessons for kw in lesson["keywords"]} == {"alpha", "beta"}
+        assert calls["n"] == 2
+
+    def test_unchanged_corpus_does_not_reparse(self, tmp_path, monkeypatch):
+        _write_lesson(tmp_path / "foo.md", _basic_lesson(["merge conflict"]))
+        scan_lessons([tmp_path])
+        calls = _count_parses(monkeypatch)
+        lessons = scan_lessons([tmp_path])
+        assert calls["n"] == 0
+        assert lessons[0]["keywords"] == ["merge conflict"]
+        assert lessons[0]["session_categories"] == []
+        assert "Body text." in lessons[0]["body"]
+
+    def test_modified_file_is_reparsed(self, tmp_path, monkeypatch):
+        path = tmp_path / "foo.md"
+        _write_lesson(path, _basic_lesson(["old-keyword"]))
+        scan_lessons([tmp_path])
+        _write_lesson(path, _basic_lesson(["new-keyword"]))
+        _bump_mtime(path)
+        calls = _count_parses(monkeypatch)
+        lessons = scan_lessons([tmp_path])
+        assert calls["n"] == 1
+        assert lessons[0]["keywords"] == ["new-keyword"]
+
+    def test_added_file_is_parsed(self, tmp_path, monkeypatch):
+        _write_lesson(tmp_path / "old.md", _basic_lesson(["old"]))
+        scan_lessons([tmp_path])
+        _write_lesson(tmp_path / "new.md", _basic_lesson(["brand-new"]))
+        calls = _count_parses(monkeypatch)
+        lessons = scan_lessons([tmp_path])
+        assert calls["n"] == 1
+        keywords = {kw for lesson in lessons for kw in lesson["keywords"]}
+        assert keywords == {"old", "brand-new"}
+
+    def test_deleted_file_disappears(self, tmp_path, monkeypatch):
+        gone = tmp_path / "gone.md"
+        _write_lesson(gone, _basic_lesson(["gone"]))
+        _write_lesson(tmp_path / "kept.md", _basic_lesson(["kept"]))
+        scan_lessons([tmp_path])
+        gone.unlink()
+        calls = _count_parses(monkeypatch)
+        lessons = scan_lessons([tmp_path])
+        assert calls["n"] == 0
+        assert [kw for lesson in lessons for kw in lesson["keywords"]] == ["kept"]
+
+    def test_mid_session_write_is_visible_on_next_scan(self, tmp_path):
+        """A lesson written after the first scan must match on the next call."""
+        _write_lesson(tmp_path / "existing.md", _basic_lesson(["existing"]))
+        first = scan_lessons([tmp_path])
+        assert [lesson["keywords"][0] for lesson in first] == ["existing"]
+        _write_lesson(
+            tmp_path / "fresh.md",
+            "---\nmatch:\n  keywords:\n    - freshly-written\n"
+            "  session_categories:\n    - code\n"
+            "status: active\n---\n# Fresh\nNew body.\n",
+        )
+        second = scan_lessons([tmp_path])
+        by_kw = {lesson["keywords"][0]: lesson for lesson in second}
+        assert "freshly-written" in by_kw
+        assert by_kw["freshly-written"]["session_categories"] == ["code"]
+        assert "New body." in by_kw["freshly-written"]["body"]
+
+    def test_disk_cache_survives_memory_reset(self, tmp_path, monkeypatch):
+        _write_lesson(tmp_path / "foo.md", _basic_lesson(["cached"]))
+        scan_lessons([tmp_path])  # persist to disk
+        clear_scan_cache()  # drop memory; disk stays (simulates a new process)
+        calls = _count_parses(monkeypatch)
+        lessons = scan_lessons([tmp_path])
+        assert calls["n"] == 0
+        assert lessons[0]["keywords"] == ["cached"]
+
+    def test_session_categories_round_trip_through_cache(self, tmp_path):
+        content = (
+            "---\nmatch:\n  keywords:\n    - foo\n"
+            "  session_categories:\n    - code\n    - infrastructure\n"
+            "status: active\n---\n# Title\n"
+        )
+        _write_lesson(tmp_path / "foo.md", content)
+        first = scan_lessons([tmp_path])
+        second = scan_lessons([tmp_path])
+        assert first[0]["session_categories"] == ["code", "infrastructure"]
+        assert second[0]["session_categories"] == ["code", "infrastructure"]
+
+    def test_inactive_file_is_cached_as_skip_not_reparsed(self, tmp_path, monkeypatch):
+        _write_lesson(tmp_path / "foo.md", _basic_lesson(["foo"], status="deprecated"))
+        assert scan_lessons([tmp_path]) == []
+        calls = _count_parses(monkeypatch)
+        assert scan_lessons([tmp_path]) == []
+        assert calls["n"] == 0
+
+    def test_caller_mutation_does_not_corrupt_cache(self, tmp_path):
+        _write_lesson(tmp_path / "foo.md", _basic_lesson(["original"]))
+        first = scan_lessons([tmp_path])
+        first[0]["keywords"].append("mutated")
+        second = scan_lessons([tmp_path])
+        assert second[0]["keywords"] == ["original"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import sys
@@ -1075,6 +1076,35 @@ class TestScanLessonsCache:
         lessons = scan_lessons([tmp_path])
         assert calls["n"] == 0
         assert lessons[0]["keywords"] == ["cached"]
+
+    def test_malformed_disk_entry_is_reparsed(self, tmp_path, monkeypatch):
+        path = tmp_path / "foo.md"
+        _write_lesson(path, _basic_lesson(["reparsed"]))
+        stat = path.stat()
+        cache_file = Path(os.environ["GPTME_LESSON_SCAN_CACHE"]) / "scan-v1.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "files": {
+                        str(path.resolve()): {
+                            "mtime_ns": stat.st_mtime_ns,
+                            "size": stat.st_size,
+                            "lesson": {"keywords": ["incomplete"]},
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        clear_scan_cache()
+        calls = _count_parses(monkeypatch)
+
+        lessons = scan_lessons([tmp_path])
+
+        assert calls["n"] == 1
+        assert lessons[0]["keywords"] == ["reparsed"]
 
     def test_session_categories_round_trip_through_cache(self, tmp_path):
         content = (

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -912,6 +912,16 @@ class TestScanLessons:
         lessons = scan_lessons([dir1, dir2])
         assert [sorted(lesson["keywords"]) for lesson in lessons] == [["active-in-a"]]
 
+    def test_symlink_to_archived_lesson_stays_excluded(self, tmp_path):
+        dir1 = tmp_path / "a"
+        dir2 = tmp_path / "b"
+        archived = dir1 / "archive" / "foo.md"
+        _write_lesson(archived, _basic_lesson(["old-archived"]))
+        dir2.mkdir(parents=True)
+        (dir2 / "renamed.md").symlink_to(archived)
+
+        assert scan_lessons([dir1, dir2]) == []
+
     def test_retired_status_in_dir1_shadows_same_name_in_dir2(self, tmp_path):
         # status: archived/deprecated/automated in an earlier dir suppresses a
         # same-named lesson in a later dir, regardless of category path.

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -1102,6 +1102,35 @@ class TestScanLessonsCache:
         second = scan_lessons([tmp_path])
         assert second[0]["keywords"] == ["original"]
 
+    def test_permission_change_invalidates_cached_lesson(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        cached_file = dir_a / "foo.md"
+        _write_lesson(cached_file, _basic_lesson(["cached-but-now-unreadable"]))
+        _write_lesson(dir_b / "foo.md", _basic_lesson(["readable-fallback"]))
+        assert scan_lessons([dir_a, dir_b])[0]["keywords"] == ["cached-but-now-unreadable"]
+
+        cached_file.chmod(0o000)
+        try:
+            assert scan_lessons([dir_a, dir_b])[0]["keywords"] == ["readable-fallback"]
+        finally:
+            cached_file.chmod(0o644)
+
+    def test_scan_evicts_entries_from_abandoned_roots(self, tmp_path):
+        old_root = tmp_path / "old"
+        current_root = tmp_path / "current"
+        old_file = old_root / "old.md"
+        current_file = current_root / "current.md"
+        _write_lesson(old_file, _basic_lesson(["old"]))
+        _write_lesson(current_file, _basic_lesson(["current"]))
+
+        scan_lessons([old_root])
+        assert str(old_file.resolve()) in lesson_matcher_mod._parse_cache
+
+        scan_lessons([current_root])
+        assert str(old_file.resolve()) not in lesson_matcher_mod._parse_cache
+        assert str(current_file.resolve()) in lesson_matcher_mod._parse_cache
+
 
 # ---------------------------------------------------------------------------
 # filter_by_session_category

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -1106,6 +1106,41 @@ class TestScanLessonsCache:
         assert calls["n"] == 1
         assert lessons[0]["keywords"] == ["reparsed"]
 
+    def test_disk_entry_missing_scalar_fields_is_reparsed(self, tmp_path, monkeypatch):
+        path = tmp_path / "foo.md"
+        _write_lesson(path, _basic_lesson(["reparsed"]))
+        stat = path.stat()
+        cache_file = Path(os.environ["GPTME_LESSON_SCAN_CACHE"]) / "scan-v1.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "files": {
+                        str(path.resolve()): {
+                            "mtime_ns": stat.st_mtime_ns,
+                            "size": stat.st_size,
+                            "lesson": {
+                                "keywords": ["stale"],
+                                "patterns": [],
+                                "tags": [],
+                                "harness_restrict": [],
+                                "session_categories": [],
+                            },
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        clear_scan_cache()
+        calls = _count_parses(monkeypatch)
+
+        lessons = scan_lessons([tmp_path])
+
+        assert calls["n"] == 1
+        assert lessons[0]["keywords"] == ["reparsed"]
+
     def test_session_categories_round_trip_through_cache(self, tmp_path):
         content = (
             "---\nmatch:\n  keywords:\n    - foo\n"
@@ -1132,7 +1167,7 @@ class TestScanLessonsCache:
         second = scan_lessons([tmp_path])
         assert second[0]["keywords"] == ["original"]
 
-    def test_permission_change_invalidates_cached_lesson(self, tmp_path):
+    def test_permission_change_invalidates_cached_lesson(self, tmp_path, monkeypatch):
         dir_a = tmp_path / "a"
         dir_b = tmp_path / "b"
         cached_file = dir_a / "foo.md"
@@ -1140,11 +1175,14 @@ class TestScanLessonsCache:
         _write_lesson(dir_b / "foo.md", _basic_lesson(["readable-fallback"]))
         assert scan_lessons([dir_a, dir_b])[0]["keywords"] == ["cached-but-now-unreadable"]
 
-        cached_file.chmod(0o000)
-        try:
-            assert scan_lessons([dir_a, dir_b])[0]["keywords"] == ["readable-fallback"]
-        finally:
-            cached_file.chmod(0o644)
+        real_access = os.access
+        monkeypatch.setattr(
+            os,
+            "access",
+            lambda path, mode: False if Path(path) == cached_file else real_access(path, mode),
+        )
+
+        assert scan_lessons([dir_a, dir_b])[0]["keywords"] == ["readable-fallback"]
 
     def test_scan_evicts_entries_from_abandoned_roots(self, tmp_path):
         old_root = tmp_path / "old"
@@ -1160,6 +1198,21 @@ class TestScanLessonsCache:
         scan_lessons([current_root])
         assert str(old_file.resolve()) not in lesson_matcher_mod._parse_cache
         assert str(current_file.resolve()) in lesson_matcher_mod._parse_cache
+
+    def test_scan_evicts_entry_shadowed_by_earlier_directory(self, tmp_path):
+        earlier_root = tmp_path / "earlier"
+        later_root = tmp_path / "later"
+        later_file = later_root / "foo.md"
+        _write_lesson(later_file, _basic_lesson(["later"]))
+
+        scan_lessons([later_root])
+        assert str(later_file.resolve()) in lesson_matcher_mod._parse_cache
+
+        _write_lesson(earlier_root / "foo.md", _basic_lesson(["earlier"]))
+        lessons = scan_lessons([earlier_root, later_root])
+
+        assert lessons[0]["keywords"] == ["earlier"]
+        assert str(later_file.resolve()) not in lesson_matcher_mod._parse_cache
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`scan_lessons()` YAML-parses every lesson file on every call. The Claude Code `match-lessons` hook is a **fresh process per tool call**, so a process-local cache there buys nothing. On Bob's corpus this is 0.46–0.62s of blocking latency on every `Read|Bash|Grep|WebFetch|WebSearch` PreToolUse (and every UserPromptSubmit).

Median session in a 40-transcript sample: 47 hook-eligible tool calls → ~24s of re-parsing an unchanged corpus. p90: ~160s.

Directory walks are cheap (warm `rglob` is tens of milliseconds). The tax is `yaml.safe_load`.

## What

Cache parsed lesson records keyed by `(resolved path, st_mtime_ns, st_size)`:

- In-memory for same-process reuse
- On disk (`$XDG_CACHE_HOME/gptme/lesson-scan/scan-v1.json`, override with `GPTME_LESSON_SCAN_CACHE`) so a new hook process hits too
- Re-parse only files whose mtime/size changed; a lesson written mid-session still matches on the next call
- Dedup, `session_categories`, BM25 body, and status filtering are unchanged — the cache sits under the existing walk/filter, it does not bypass them

`GPTME_LESSON_SCAN_CACHE=off` disables the disk layer (tests isolate via a tmp dir).

## Measured (Bob's 702-lesson corpus)

| path | wall |
|---|---|
| cold (no cache) | **0.458s** |
| warm disk (fresh process) | **0.055s** |
| warm memory | **0.049s** |

Warm disk is ~12% of the previous per-invocation cost.

## Tests

Regression coverage for: cold start, unchanged corpus, one file modified, one file added, one file deleted, mid-session write, disk surviving a memory reset (new process), `session_categories` round-trip, inactive files cached as skips, caller mutation not corrupting the cache.

Existing scan/filter/BM25 tests still pass (139 in `test_lesson_matcher.py`).

## Notes

This is the library-layer fix. Bob's `.claude/hooks/match-lessons.py` already imports `gptme_rag.lesson_matcher.scan_lessons`, so it picks this up via the gptme-contrib submodule pin after merge.