### PR TITLE
fix(bob-status): return compact task summaries in table cells

### DIFF
--- a/packages/gptme-bob-status/src/gptme_bob_status/provider.py
+++ b/packages/gptme-bob-status/src/gptme_bob_status/provider.py
@@ -342,7 +342,7 @@ class BobStatusProvider:
         lines = ["## Ready Next (top 3)"]
         if ready:
             for i, t in enumerate(ready, 1):
-                title = str(t.get("name", t.get("id", "")))[:65]
+                title = str(t.get("title", t.get("id", "")))[:65]
                 lines.append(f"{i}. `{t.get('id', '?')}` — {title}")
         else:
             lines.append("- No ready backlog tasks found")

--- a/packages/gptme-bob-status/src/gptme_bob_status/provider.py
+++ b/packages/gptme-bob-status/src/gptme_bob_status/provider.py
@@ -222,10 +222,11 @@ def _blockers(limit: int = 3) -> list[dict]:
         except json.JSONDecodeError:
             continue
         if t.get("waiting_for"):
-            s = _task_summary(t)
             wf = _first_nonempty_line(t["waiting_for"], 70)
-            if wf:
-                s["waiting_for"] = wf
+            if not wf:
+                continue
+            s = _task_summary(t)
+            s["waiting_for"] = wf
             if t.get("waiting_since"):
                 s["waiting_since"] = t["waiting_since"]
             blockers.append(s)

--- a/packages/gptme-bob-status/src/gptme_bob_status/provider.py
+++ b/packages/gptme-bob-status/src/gptme_bob_status/provider.py
@@ -185,6 +185,19 @@ def _dead_timers() -> int:
     return count
 
 
+def _task_summary(t: dict) -> dict:
+    """Return a compact summary of a task for use in status table cells.
+
+    Full task objects from ``gptodo --jsonl`` are ~30+ fields; table cells only
+    need id/title/priority for at-a-glance status.  Narrative sections have
+    their own rendering (they call ``t.get(...)`` directly) and are not affected.
+    """
+    summary: dict = {"id": t.get("id", "?"), "title": t.get("name", t.get("id", ""))}
+    if t.get("priority"):
+        summary["priority"] = t["priority"]
+    return summary
+
+
 def _blockers(limit: int = 3) -> list[dict]:
     raw = _run(["gptodo", "ready", "--state", "waiting", "--jsonl"], timeout=15)
     if not raw:
@@ -196,7 +209,13 @@ def _blockers(limit: int = 3) -> list[dict]:
         except json.JSONDecodeError:
             continue
         if t.get("waiting_for"):
-            blockers.append(t)
+            s = _task_summary(t)
+            wf = str(t.get("waiting_for", "")).split("\n")[0][:70]
+            if wf:
+                s["waiting_for"] = wf
+            if t.get("waiting_since"):
+                s["waiting_since"] = t["waiting_since"]
+            blockers.append(s)
     return blockers[:limit]
 
 
@@ -212,7 +231,7 @@ def _ready_tasks(limit: int = 3) -> list[dict]:
             continue
         if t.get("waiting_for") or t.get("wait"):
             continue
-        tasks.append(t)
+        tasks.append(_task_summary(t))
     return tasks[:limit]
 
 

--- a/packages/gptme-bob-status/src/gptme_bob_status/provider.py
+++ b/packages/gptme-bob-status/src/gptme_bob_status/provider.py
@@ -189,13 +189,26 @@ def _task_summary(t: dict) -> dict:
     """Return a compact summary of a task for use in status table cells.
 
     Full task objects from ``gptodo --jsonl`` are ~30+ fields; table cells only
-    need id/title/priority for at-a-glance status.  Narrative sections have
-    their own rendering (they call ``t.get(...)`` directly) and are not affected.
+    need id/title/priority for at-a-glance status. Narrative sections render
+    these compact fields directly.
     """
-    summary: dict = {"id": t.get("id", "?"), "title": t.get("name", t.get("id", ""))}
+    task_id = t.get("id", "?")
+    summary: dict = {"id": task_id, "title": t.get("name") or task_id}
     if t.get("priority"):
         summary["priority"] = t["priority"]
     return summary
+
+
+def _first_nonempty_line(value: object, limit: int) -> str:
+    """Return the first non-empty stripped line, truncated to ``limit`` chars."""
+    return next(
+        (
+            line.strip()[:limit]
+            for line in str(value or "").splitlines()
+            if line.strip()
+        ),
+        "",
+    )
 
 
 def _blockers(limit: int = 3) -> list[dict]:
@@ -210,7 +223,7 @@ def _blockers(limit: int = 3) -> list[dict]:
             continue
         if t.get("waiting_for"):
             s = _task_summary(t)
-            wf = str(t.get("waiting_for", "")).split("\n")[0][:70]
+            wf = _first_nonempty_line(t["waiting_for"], 70)
             if wf:
                 s["waiting_for"] = wf
             if t.get("waiting_since"):
@@ -329,7 +342,7 @@ class BobStatusProvider:
         lines = ["## Top Blockers"]
         if blockers:
             for t in blockers:
-                wf = str(t.get("waiting_for", "")).split("\n")[0][:70]
+                wf = _first_nonempty_line(t.get("waiting_for"), 70)
                 since = t.get("waiting_since", "")
                 since_str = f" (since {since})" if since else ""
                 lines.append(f"- `{t.get('id', '?')}`: {wf}{since_str}")

--- a/packages/gptme-bob-status/src/gptme_bob_status/provider.py
+++ b/packages/gptme-bob-status/src/gptme_bob_status/provider.py
@@ -221,15 +221,15 @@ def _blockers(limit: int = 3) -> list[dict]:
             t = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if t.get("waiting_for"):
-            wf = _first_nonempty_line(t["waiting_for"], 70)
-            if not wf:
-                continue
-            s = _task_summary(t)
-            s["waiting_for"] = wf
-            if t.get("waiting_since"):
-                s["waiting_since"] = t["waiting_since"]
-            blockers.append(s)
+        wf = _first_nonempty_line(t.get("waiting_for"), 70)
+        if not wf:
+            continue
+        s = _task_summary(t)
+        s["waiting_for"] = wf
+        since = t.get("waiting_since")
+        if since:
+            s["waiting_since"] = since
+        blockers.append(s)
     return blockers[:limit]
 
 

--- a/packages/gptme-bob-status/tests/test_provider.py
+++ b/packages/gptme-bob-status/tests/test_provider.py
@@ -92,7 +92,17 @@ def test_narrative_sections_non_empty_in_bob_workspace(monkeypatch):
         lambda: [{"label": "Autonomous", "icon": "✓", "status": "active"}],
     )
     monkeypatch.setattr(mod, "_dead_timers", lambda: 0)
-    monkeypatch.setattr(mod, "_blockers", lambda limit=3: [])
+    monkeypatch.setattr(
+        mod,
+        "_blockers",
+        lambda limit=3: [
+            {
+                "id": "blocked-1",
+                "title": "Blocked task title",
+                "waiting_for": "\n  Important blocker detail",
+            }
+        ],
+    )
     monkeypatch.setattr(
         mod,
         "_ready_tasks",
@@ -109,6 +119,7 @@ def test_narrative_sections_non_empty_in_bob_workspace(monkeypatch):
     combined = "\n".join(sections)
     assert "t1" in combined
     assert "gptme/gptme" in combined
+    assert "`blocked-1`: Important blocker detail" in combined
     assert "`ready-1` — Ready task title" in combined
 
 
@@ -209,7 +220,8 @@ def test_blockers_return_compact_summaries_with_narrative_fields(monkeypatch):
 
     task = {
         **_TASK_JSON,
-        "waiting_for": "A blocker explanation that stays available\ninternal detail",
+        "name": None,
+        "waiting_for": "\n  A blocker explanation that stays available\ninternal detail",
         "waiting_since": "2026-08-27T20:30:00+00:00",
     }
     monkeypatch.setattr(mod, "_run", lambda cmd, **k: json.dumps(task))
@@ -217,7 +229,7 @@ def test_blockers_return_compact_summaries_with_narrative_fields(monkeypatch):
     assert mod._blockers() == [
         {
             "id": "compact-task",
-            "title": "Compact task title",
+            "title": "compact-task",
             "priority": "high",
             "waiting_for": "A blocker explanation that stays available",
             "waiting_since": "2026-08-27T20:30:00+00:00",

--- a/packages/gptme-bob-status/tests/test_provider.py
+++ b/packages/gptme-bob-status/tests/test_provider.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 
 from gptme_bob_status.provider import BobStatusProvider, make_provider
 
+_TASK_JSON = {
+    "id": "compact-task",
+    "name": "Compact task title",
+    "priority": "high",
+    "body": "A large markdown body that must not leak into a table cell.",
+    "tags": ["status", "test"],
+    "created": "2026-08-27T20:00:00+00:00",
+}
+
 
 def test_provider_satisfies_protocol():
     """BobStatusProvider satisfies the StatusProvider protocol."""
@@ -172,4 +181,41 @@ def test_active_tasks_preserves_parenthetical_ago_in_title(monkeypatch):
     assert tasks == [
         {"id": "review-pr", "title": "Review PR (approved 2 days ago)"},
         {"id": "normal-task", "title": "Do thing"},
+    ]
+
+
+def test_ready_tasks_returns_compact_summaries(monkeypatch):
+    """Ready-task cells exclude bodies and other full-task metadata."""
+    import json
+
+    import gptme_bob_status.provider as mod
+
+    monkeypatch.setattr(mod, "_run", lambda cmd, **k: json.dumps(_TASK_JSON))
+
+    assert mod._ready_tasks() == [
+        {"id": "compact-task", "title": "Compact task title", "priority": "high"}
+    ]
+
+
+def test_blockers_return_compact_summaries_with_narrative_fields(monkeypatch):
+    """Blocker cells stay compact while retaining fields used by narratives."""
+    import json
+
+    import gptme_bob_status.provider as mod
+
+    task = {
+        **_TASK_JSON,
+        "waiting_for": "A blocker explanation that stays available\ninternal detail",
+        "waiting_since": "2026-08-27T20:30:00+00:00",
+    }
+    monkeypatch.setattr(mod, "_run", lambda cmd, **k: json.dumps(task))
+
+    assert mod._blockers() == [
+        {
+            "id": "compact-task",
+            "title": "Compact task title",
+            "priority": "high",
+            "waiting_for": "A blocker explanation that stays available",
+            "waiting_since": "2026-08-27T20:30:00+00:00",
+        }
     ]

--- a/packages/gptme-bob-status/tests/test_provider.py
+++ b/packages/gptme-bob-status/tests/test_provider.py
@@ -247,3 +247,15 @@ def test_blockers_skip_whitespace_only_explanations(monkeypatch):
     monkeypatch.setattr(mod, "_run", lambda cmd, **k: json.dumps(task))
 
     assert mod._blockers() == []
+
+
+def test_blockers_skip_missing_waiting_for(monkeypatch):
+    """A waiting task without waiting_for is skipped, not a KeyError."""
+    import json
+
+    import gptme_bob_status.provider as mod
+
+    monkeypatch.setattr(mod, "_run", lambda cmd, **k: json.dumps(_TASK_JSON))
+
+    assert "waiting_for" not in _TASK_JSON
+    assert mod._blockers() == []

--- a/packages/gptme-bob-status/tests/test_provider.py
+++ b/packages/gptme-bob-status/tests/test_provider.py
@@ -93,7 +93,11 @@ def test_narrative_sections_non_empty_in_bob_workspace(monkeypatch):
     )
     monkeypatch.setattr(mod, "_dead_timers", lambda: 0)
     monkeypatch.setattr(mod, "_blockers", lambda limit=3: [])
-    monkeypatch.setattr(mod, "_ready_tasks", lambda limit=3: [])
+    monkeypatch.setattr(
+        mod,
+        "_ready_tasks",
+        lambda limit=3: [{"id": "ready-1", "title": "Ready task title"}],
+    )
     monkeypatch.setattr(mod, "_journal_entries", lambda limit=5: [])
 
     provider = BobStatusProvider()
@@ -102,10 +106,10 @@ def test_narrative_sections_non_empty_in_bob_workspace(monkeypatch):
     assert isinstance(sections, list)
     assert len(sections) > 0
     assert all(isinstance(s, str) for s in sections)
-    # Should include the active task
     combined = "\n".join(sections)
     assert "t1" in combined
     assert "gptme/gptme" in combined
+    assert "`ready-1` — Ready task title" in combined
 
 
 def test_collect_keys_use_bob_prefix(monkeypatch):

--- a/packages/gptme-bob-status/tests/test_provider.py
+++ b/packages/gptme-bob-status/tests/test_provider.py
@@ -235,3 +235,15 @@ def test_blockers_return_compact_summaries_with_narrative_fields(monkeypatch):
             "waiting_since": "2026-08-27T20:30:00+00:00",
         }
     ]
+
+
+def test_blockers_skip_whitespace_only_explanations(monkeypatch):
+    """A task without visible blocker context is not a top blocker."""
+    import json
+
+    import gptme_bob_status.provider as mod
+
+    task = {**_TASK_JSON, "waiting_for": " \n\t "}
+    monkeypatch.setattr(mod, "_run", lambda cmd, **k: json.dumps(task))
+
+    assert mod._blockers() == []


### PR DESCRIPTION
## Summary

`_ready_tasks()` and `_blockers()` were returning full task objects (~30+ fields) from `gptodo --jsonl` into the status table cell values. This includes large body/markdown content, all YAML frontmatter fields, and timestamps — producing hundreds of characters per task in what should be a quick at-a-glance cell.

`_active_tasks()` already returned compact `{id, title}` summaries by parsing the CLI compact output. The two other functions didn't follow that pattern.

## Changes

- Add `_task_summary()` helper: extracts compact `{id, title[, priority]}` from a full task dict
- `_ready_tasks()`: apply `_task_summary()` before appending
- `_blockers()`: apply `_task_summary()`, preserve `waiting_for` (first line, ≤70 chars) and `waiting_since` since `narrative_sections()` reads both for the **## Top Blockers** section

## Why now

Discovered during a dogfood sweep triggered by gptme/gptme#3651 merging (which fixed list/dict serialization in table cells). Once the JSON is valid, the verbosity becomes the next obvious issue — full task objects read like dumped YAML inside a table cell.