### PR TITLE
fix(rag): content-hash change detection to stop mtime-only re-embeds

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -273,8 +273,13 @@ def index(
 
         logger.debug("Loaded %d existing files from index", len(existing_files))
 
-        # First, collect all documents and filter for new/modified
+        # First, collect all documents and filter for new/modified.
+        # cleanup_hashes: source -> current hash when that generation is already
+        # stored but leftover older hashes remain (add succeeded, delete failed).
+        # Those sources must not be re-added — chunk IDs include content_hash, so
+        # a second add of the same bytes collides — only the stale IDs are deleted.
         all_documents = []
+        cleanup_hashes: dict[str, object] = {}
         with console.status("Collecting documents...") as status:
             for path in paths:
                 if path.is_file():
@@ -310,6 +315,13 @@ def index(
                                 if stored_hashes == {current_hash}:
                                     logger.debug("Unchanged file: %s", abs_source)
                                     continue
+                                if current_hash in stored_hashes:
+                                    cleanup_hashes[abs_source] = current_hash
+                                    logger.debug(
+                                        "Current generation already indexed: %s",
+                                        abs_source,
+                                    )
+                                    continue
                                 logger.debug(
                                     "Modified file: %s (content hash changed)",
                                     abs_source,
@@ -340,8 +352,39 @@ def index(
 
                 all_documents.extend(filtered_documents)
 
+        def stale_ids_for(hash_by_source: dict[str, object]) -> list[str]:
+            return [
+                doc.doc_id
+                for doc in existing_docs
+                if doc.doc_id
+                and str(doc.metadata.get("source", "")) in hash_by_source
+                and doc.metadata.get("content_hash")
+                != hash_by_source.get(str(doc.metadata.get("source", "")))
+            ]
+
+        leftover_stale_ids = stale_ids_for(cleanup_hashes)
+
         if not all_documents:
-            console.print("No new or modified documents to index", style="yellow")
+            if leftover_stale_ids:
+                try:
+                    indexer.collection.delete(ids=leftover_stale_ids)
+                except Exception as delete_err:
+                    logger.warning(
+                        "Failed to delete %d leftover stale chunk(s): %s",
+                        len(leftover_stale_ids),
+                        delete_err,
+                    )
+                    console.print(
+                        "⚠️ Leftover stale chunks remain; they will be removed on the next run",
+                        style="yellow",
+                    )
+                else:
+                    console.print(
+                        f"✅ Removed leftover stale chunks for {len(cleanup_hashes)} files",
+                        style="green",
+                    )
+            else:
+                console.print("No new or modified documents to index", style="yellow")
             return
 
         # Then process them with a progress bar. Preserve the previous chunks until
@@ -359,14 +402,7 @@ def index(
             str(doc.metadata.get("source", "")): doc.metadata.get("content_hash")
             for doc in all_documents
         }
-        stale_ids = [
-            doc.doc_id
-            for doc in existing_docs
-            if doc.doc_id
-            and str(doc.metadata.get("source", "")) in sources
-            and doc.metadata.get("content_hash")
-            != current_hash_by_source.get(str(doc.metadata.get("source", "")))
-        ]
+        stale_ids = stale_ids_for(current_hash_by_source) + leftover_stale_ids
 
         with tqdm(
             total=n_chunks,
@@ -382,8 +418,8 @@ def index(
                 indexer.collection.delete(ids=stale_ids)
             except Exception as delete_err:
                 # Add already succeeded. Failing the command here would hide that
-                # the new generation is indexed; mixed leftover hashes are treated
-                # as modified on the next run, so a retry self-heals.
+                # the new generation is indexed; a retry sees the current hash
+                # already stored and deletes leftover older IDs without re-adding.
                 logger.warning(
                     "Indexed replacements but failed to delete %d stale chunk(s): %s",
                     len(stale_ids),

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -280,6 +280,7 @@ def index(
         # a second add of the same bytes collides — only the stale IDs are deleted.
         all_documents = []
         cleanup_hashes: dict[str, object] = {}
+        empty_sources: set[str] = set()
         with console.status("Collecting documents...") as status:
             for path in paths:
                 if path.is_file():
@@ -299,6 +300,15 @@ def index(
                         doc.metadata["source"] = abs_source
 
                         existing = existing_files.get(abs_source)
+                        if not (doc.content or "").strip():
+                            # Empty/whitespace source: never index it. If it
+                            # previously had chunks, drop them all.
+                            if existing is not None:
+                                empty_sources.add(abs_source)
+                                logger.debug("Empty file, dropping stale chunks: %s", abs_source)
+                            else:
+                                logger.debug("Skipping empty file: %s", abs_source)
+                            continue
                         if existing is None:
                             logger.debug("New file: %s", abs_source)
                             filtered_documents.append(doc)
@@ -313,16 +323,20 @@ def index(
                                 set[object], existing.get("content_hashes") or set()
                             )
                             has_unhashed = bool(existing.get("has_unhashed"))
-                            if stored_hashes and not has_unhashed:
-                                if stored_hashes == {current_hash}:
-                                    logger.debug("Unchanged file: %s", abs_source)
-                                    continue
+                            if stored_hashes:
                                 if current_hash in stored_hashes:
-                                    cleanup_hashes[abs_source] = current_hash
-                                    logger.debug(
-                                        "Current generation already indexed: %s",
-                                        abs_source,
-                                    )
+                                    # Current generation is already indexed. Skip
+                                    # re-embed even when leftover unhashed/legacy
+                                    # chunks remain — re-adding the same IDs
+                                    # UniqueConstraintErrors and aborts cleanup.
+                                    if stored_hashes != {current_hash} or has_unhashed:
+                                        cleanup_hashes[abs_source] = current_hash
+                                        logger.debug(
+                                            "Current generation already indexed: %s",
+                                            abs_source,
+                                        )
+                                    else:
+                                        logger.debug("Unchanged file: %s", abs_source)
                                     continue
                                 logger.debug(
                                     "Modified file: %s (content hash changed)",
@@ -330,12 +344,7 @@ def index(
                                 )
                                 filtered_documents.append(doc)
                                 continue
-                            # Stored doc predates content hashing, or mixed
-                            # generations after a crash: fall through to mtime
-                            # only when there is no hash at all.
-                            if stored_hashes:
-                                filtered_documents.append(doc)
-                                continue
+                            # stored_hashes empty: pure legacy, fall through to mtime
 
                         # Fallback for legacy stored docs without content_hash:
                         # compare mtime (rounded to microseconds).
@@ -364,7 +373,14 @@ def index(
                 != hash_by_source.get(str(doc.metadata.get("source", "")))
             ]
 
-        leftover_stale_ids = stale_ids_for(cleanup_hashes)
+        def ids_for_sources(sources: set[str]) -> list[str]:
+            return [
+                doc.doc_id
+                for doc in existing_docs
+                if doc.doc_id and str(doc.metadata.get("source", "")) in sources
+            ]
+
+        leftover_stale_ids = stale_ids_for(cleanup_hashes) + ids_for_sources(empty_sources)
 
         if not all_documents:
             if leftover_stale_ids:
@@ -381,8 +397,9 @@ def index(
                         style="yellow",
                     )
                 else:
+                    n_cleaned = len(cleanup_hashes) + len(empty_sources)
                     console.print(
-                        f"✅ Removed leftover stale chunks for {len(cleanup_hashes)} files",
+                        f"✅ Removed leftover stale chunks for {n_cleaned} files",
                         style="green",
                     )
             else:

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -248,9 +248,13 @@ def index(
         for doc in existing_docs:
             if "source" in doc.metadata:
                 abs_path = os.path.abspath(doc.metadata["source"])
-                entry = existing_files.setdefault(abs_path, {})
+                entry = existing_files.setdefault(abs_path, {"content_hashes": set()})
+                hashes = entry.setdefault("content_hashes", set())
                 if "content_hash" in doc.metadata:
-                    entry["content_hash"] = doc.metadata["content_hash"]
+                    if isinstance(hashes, set):
+                        hashes.add(doc.metadata["content_hash"])
+                else:
+                    entry["has_unhashed"] = True
                 last_modified = doc.metadata.get("last_modified")
                 if last_modified:
                     try:
@@ -296,9 +300,10 @@ def index(
                         # worktree churn) — skip it instead of re-embedding.
                         current_hash = doc.metadata.get("content_hash")
                         if current_hash is not None:
-                            stored_hash = existing.get("content_hash")
-                            if stored_hash is not None:
-                                if current_hash == stored_hash:
+                            stored_hashes = existing.get("content_hashes") or set()
+                            has_unhashed = bool(existing.get("has_unhashed"))
+                            if stored_hashes and not has_unhashed:
+                                if stored_hashes == {current_hash}:
                                     logger.debug("Unchanged file: %s", abs_source)
                                     continue
                                 logger.debug(
@@ -307,7 +312,12 @@ def index(
                                 )
                                 filtered_documents.append(doc)
                                 continue
-                            # Stored doc predates content hashing: fall through to mtime.
+                            # Stored doc predates content hashing, or mixed
+                            # generations after a crash: fall through to mtime
+                            # only when there is no hash at all.
+                            if stored_hashes:
+                                filtered_documents.append(doc)
+                                continue
 
                         # Fallback for legacy stored docs without content_hash:
                         # compare mtime (rounded to microseconds).
@@ -330,18 +340,29 @@ def index(
             console.print("No new or modified documents to index", style="yellow")
             return
 
-        # Then process them with a progress bar. Replace all chunks for a modified
-        # source before adding its new chunks; otherwise stale chunks survive when
-        # content or chunk boundaries change and make future fingerprint reads
-        # order-dependent.
+        # Then process them with a progress bar. Preserve the previous chunks until
+        # every replacement chunk has been embedded successfully: deleting first
+        # turns a transient embedding failure into data loss. New chunk IDs include
+        # content_hash, so old and replacement generations can coexist briefly;
+        # after a successful add, delete only the IDs from the old generation.
         sources = {str(doc.metadata.get("source", "")) for doc in all_documents}
         n_files = len(sources)
         n_chunks = len(all_documents)
 
         logger.info(f"Found {n_files} new/modified files to index ({n_chunks} chunks)")
 
-        for source in sources & existing_files.keys():
-            indexer.delete_documents({"source": source})
+        current_hash_by_source = {
+            str(doc.metadata.get("source", "")): doc.metadata.get("content_hash")
+            for doc in all_documents
+        }
+        stale_ids = [
+            doc.doc_id
+            for doc in existing_docs
+            if doc.doc_id
+            and str(doc.metadata.get("source", "")) in sources
+            and doc.metadata.get("content_hash")
+            != current_hash_by_source.get(str(doc.metadata.get("source", "")))
+        ]
 
         with tqdm(
             total=n_chunks,
@@ -351,6 +372,9 @@ def index(
         ) as pbar:
             for progress in indexer.add_documents_progress(all_documents):
                 pbar.update(progress)
+
+        if stale_ids:
+            indexer.collection.delete(ids=stale_ids)
 
         console.print(
             f"✅ Successfully indexed {n_files} files ({n_chunks} chunks)",

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -330,11 +330,18 @@ def index(
             console.print("No new or modified documents to index", style="yellow")
             return
 
-        # Then process them with a progress bar
-        n_files = len(set(doc.metadata.get("source", "") for doc in all_documents))
+        # Then process them with a progress bar. Replace all chunks for a modified
+        # source before adding its new chunks; otherwise stale chunks survive when
+        # content or chunk boundaries change and make future fingerprint reads
+        # order-dependent.
+        sources = {str(doc.metadata.get("source", "")) for doc in all_documents}
+        n_files = len(sources)
         n_chunks = len(all_documents)
 
         logger.info(f"Found {n_files} new/modified files to index ({n_chunks} chunks)")
+
+        for source in sources & existing_files.keys():
+            indexer.delete_documents({"source": source})
 
         with tqdm(
             total=n_chunks,

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -309,7 +309,9 @@ def index(
                         # worktree churn) — skip it instead of re-embedding.
                         current_hash = doc.metadata.get("content_hash")
                         if current_hash is not None:
-                            stored_hashes = existing.get("content_hashes") or set()
+                            stored_hashes = cast(
+                                set[object], existing.get("content_hashes") or set()
+                            )
                             has_unhashed = bool(existing.get("has_unhashed"))
                             if stored_hashes and not has_unhashed:
                                 if stored_hashes == {current_hash}:

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -259,10 +259,14 @@ def index(
                 if last_modified:
                     try:
                         # Parse ISO format timestamp to float
-                        entry["last_modified"] = datetime.fromisoformat(last_modified).timestamp()
+                        parsed = datetime.fromisoformat(last_modified).timestamp()
                     except ValueError:
                         logger.warning("Invalid last_modified format: %s", last_modified)
-                        entry["last_modified"] = 0
+                    else:
+                        # Keep the first valid timestamp. A later chunk with a
+                        # bad last_modified must not zero a good stored mtime —
+                        # that would re-embed every legacy source on every run.
+                        entry.setdefault("last_modified", parsed)
                 else:
                     entry.setdefault("last_modified", 0)
                 # logger.debug("Existing file: %s", abs_path)  # Too spammy
@@ -374,7 +378,21 @@ def index(
                 pbar.update(progress)
 
         if stale_ids:
-            indexer.collection.delete(ids=stale_ids)
+            try:
+                indexer.collection.delete(ids=stale_ids)
+            except Exception as delete_err:
+                # Add already succeeded. Failing the command here would hide that
+                # the new generation is indexed; mixed leftover hashes are treated
+                # as modified on the next run, so a retry self-heals.
+                logger.warning(
+                    "Indexed replacements but failed to delete %d stale chunk(s): %s",
+                    len(stale_ids),
+                    delete_err,
+                )
+                console.print(
+                    "⚠️ New chunks indexed; leftover stale chunks will be removed on the next run",
+                    style="yellow",
+                )
 
         console.print(
             f"✅ Successfully indexed {n_files} files ({n_chunks} chunks)",

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -8,6 +8,7 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 import click
 from rich.console import Console
@@ -240,20 +241,26 @@ def index(
         existing_docs = indexer.get_all_documents()
         logger.debug("Found %d existing documents in index", len(existing_docs))
 
-        existing_files = {}
+        # Map each indexed source to its stored change-detection fingerprint:
+        # content_hash (primary) plus last_modified (fallback for legacy docs that
+        # predate content hashing). Stored per-chunk but read once per source.
+        existing_files: dict[str, dict[str, object]] = {}
         for doc in existing_docs:
             if "source" in doc.metadata:
                 abs_path = os.path.abspath(doc.metadata["source"])
+                entry = existing_files.setdefault(abs_path, {})
+                if "content_hash" in doc.metadata:
+                    entry["content_hash"] = doc.metadata["content_hash"]
                 last_modified = doc.metadata.get("last_modified")
                 if last_modified:
                     try:
                         # Parse ISO format timestamp to float
-                        existing_files[abs_path] = datetime.fromisoformat(last_modified).timestamp()
+                        entry["last_modified"] = datetime.fromisoformat(last_modified).timestamp()
                     except ValueError:
                         logger.warning("Invalid last_modified format: %s", last_modified)
-                        existing_files[abs_path] = 0
+                        entry["last_modified"] = 0
                 else:
-                    existing_files[abs_path] = 0
+                    entry.setdefault("last_modified", 0)
                 # logger.debug("Existing file: %s", abs_path)  # Too spammy
 
         logger.debug("Loaded %d existing files from index", len(existing_files))
@@ -277,19 +284,41 @@ def index(
                         # Resolve to absolute path for consistent comparison
                         abs_source = os.path.abspath(source)
                         doc.metadata["source"] = abs_source
-                        current_mtime = os.path.getmtime(abs_source)
 
-                        # Include if file is new or modified
-                        if abs_source not in existing_files:
+                        existing = existing_files.get(abs_source)
+                        if existing is None:
                             logger.debug("New file: %s", abs_source)
                             filtered_documents.append(doc)
-                        # Round to microseconds (6 decimal places) for comparison
-                        elif round(current_mtime, 6) > round(existing_files[abs_source], 6):
+                            continue
+
+                        # Primary key: content hash. An unchanged hash means the file
+                        # is unchanged even if mtime moved (git restore/checkout,
+                        # worktree churn) — skip it instead of re-embedding.
+                        current_hash = doc.metadata.get("content_hash")
+                        if current_hash is not None:
+                            stored_hash = existing.get("content_hash")
+                            if stored_hash is not None:
+                                if current_hash == stored_hash:
+                                    logger.debug("Unchanged file: %s", abs_source)
+                                    continue
+                                logger.debug(
+                                    "Modified file: %s (content hash changed)",
+                                    abs_source,
+                                )
+                                filtered_documents.append(doc)
+                                continue
+                            # Stored doc predates content hashing: fall through to mtime.
+
+                        # Fallback for legacy stored docs without content_hash:
+                        # compare mtime (rounded to microseconds).
+                        current_mtime = os.path.getmtime(abs_source)
+                        stored_mtime = cast(float, existing.get("last_modified", 0))
+                        if round(current_mtime, 6) > round(stored_mtime, 6):
                             logger.debug(
                                 "Modified file: %s (current: %s, stored: %s)",
                                 abs_source,
                                 current_mtime,
-                                existing_files[abs_source],
+                                stored_mtime,
                             )
                             filtered_documents.append(doc)
                         else:

--- a/packages/gptme-rag/src/gptme_rag/indexing/document.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/document.py
@@ -68,8 +68,11 @@ class Document:
                 last_modified=last_modified,
             )
         else:
-            # Process file in chunks
-            base_id = str(path.absolute())
+            # Process file in chunks. Include the source generation in each ID so
+            # replacement chunks can be added before stale chunks are removed; this
+            # keeps the previous generation queryable if embedding the replacement
+            # fails partway through.
+            base_id = f"{path.absolute()}@{content_hash}"
             for chunk in processor.process_file(path):
                 # Ensure unique chunk IDs by using both index and position
                 chunk_id = f"{base_id}#chunk{chunk['metadata']['chunk_index']}-{chunk['metadata']['chunk_start']}"

--- a/packages/gptme-rag/src/gptme_rag/indexing/document.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/document.py
@@ -1,3 +1,4 @@
+import hashlib
 from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import datetime
@@ -44,11 +45,17 @@ class Document:
             Document instances, either a single document or multiple chunks
         """
         last_modified = datetime.fromtimestamp(path.stat().st_mtime)
+        # Content hash is the primary change-detection key: it survives mtime-only
+        # rewrites (git restore/checkout, worktree churn) that would otherwise force
+        # a full re-embed of an unchanged file. Falls back to mtime in cli.py when a
+        # stored document predates this field.
+        content_hash = hashlib.sha256(path.read_bytes()).hexdigest()
         base_metadata = {
             "source": str(path),
             "filename": path.name,
             "extension": path.suffix,
             "last_modified": last_modified.isoformat(),
+            "content_hash": content_hash,
         }
 
         if processor is None:

--- a/packages/gptme-rag/src/gptme_rag/indexing/document.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/document.py
@@ -80,6 +80,16 @@ class Document:
             except UnicodeDecodeError:
                 return
             if not content.strip():
+                # Yield a tombstone so index can delete leftover chunks for a
+                # file that used to have content and is now empty. process_text
+                # would skip this too; without a document, cli.py never sees
+                # the source and stale search hits remain.
+                yield cls(
+                    content="",
+                    metadata=base_metadata.copy(),
+                    source_path=path,
+                    last_modified=last_modified,
+                )
                 return
             # Process file in chunks. Include the source generation in each ID so
             # replacement chunks can be added before stale chunks are removed; this

--- a/packages/gptme-rag/src/gptme_rag/indexing/document.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/document.py
@@ -49,7 +49,10 @@ class Document:
         # rewrites (git restore/checkout, worktree churn) that would otherwise force
         # a full re-embed of an unchanged file. Falls back to mtime in cli.py when a
         # stored document predates this field.
-        content_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        # Read once so the stored hash and the indexed text cannot diverge if the
+        # file is rewritten between a hash pass and a later content read.
+        file_bytes = path.read_bytes()
+        content_hash = hashlib.sha256(file_bytes).hexdigest()
         base_metadata = {
             "source": str(path),
             "filename": path.name,
@@ -60,7 +63,7 @@ class Document:
 
         if processor is None:
             # If no processor provided, create single document
-            content = path.read_text()
+            content = file_bytes.decode()
             yield cls(
                 content=content,
                 metadata=base_metadata.copy(),
@@ -68,12 +71,27 @@ class Document:
                 last_modified=last_modified,
             )
         else:
+            # Skip the same files process_file would skip, but chunk the bytes we
+            # already hashed instead of re-reading the path.
+            if processor.is_binary_file(path):
+                return
+            try:
+                content = file_bytes.decode()
+            except UnicodeDecodeError:
+                return
+            if not content.strip():
+                return
             # Process file in chunks. Include the source generation in each ID so
             # replacement chunks can be added before stale chunks are removed; this
             # keeps the previous generation queryable if embedding the replacement
             # fails partway through.
             base_id = f"{path.absolute()}@{content_hash}"
-            for chunk in processor.process_file(path):
+            file_metadata = {
+                "filename": path.name,
+                "file_path": str(path.absolute()),
+                "file_type": path.suffix.lstrip("."),
+            }
+            for chunk in processor.process_text(content, file_metadata):
                 # Ensure unique chunk IDs by using both index and position
                 chunk_id = f"{base_id}#chunk{chunk['metadata']['chunk_index']}-{chunk['metadata']['chunk_start']}"
                 # Create chunk metadata with chunk-specific fields

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -219,6 +219,8 @@ def test_index_retry_after_crash_does_not_delete_replacement(tmp_path):
 
     second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
+    assert "Removed leftover stale chunks" in _plain(second.output), second.output
+    assert "Successfully indexed" not in _plain(second.output), second.output
 
     chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
     client = chromadb.PersistentClient(

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -1,0 +1,108 @@
+"""Tests for content-hash-based change detection (gptme-contrib Bug #2).
+
+The change-detection key in the `index` command was mtime-only. A git restore,
+checkout, or hot-worktree mtime rewrite would force a full re-embed of unchanged
+files. This test verifies that:
+
+1. `Document.from_file` records a stable `content_hash` (sha256 of file bytes).
+2. Re-running `index` on unchanged content does not re-embed (only first-run embeds).
+3. Touching mtime alone does not re-embed, but changing content does.
+
+See tasks/vitals-regen-index-cpu-burn-loop.md for the parent investigation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+from click.testing import CliRunner
+
+from gptme_rag.cli import cli
+from gptme_rag.indexing.document import Document
+
+
+def test_document_from_file_records_content_hash(tmp_path):
+    """from_file stores a sha256 of the file bytes in metadata."""
+    f = tmp_path / "a.txt"
+    f.write_text("hello world")
+    docs = list(Document.from_file(f))
+    assert docs, "expected at least one document"
+    expected = hashlib.sha256(b"hello world").hexdigest()
+    for doc in docs:
+        assert doc.metadata["content_hash"] == expected
+
+
+def test_content_hash_changes_when_content_changes(tmp_path):
+    """Editing file content changes the recorded content_hash."""
+    f = tmp_path / "a.txt"
+    f.write_text("v1")
+    docs_v1 = list(Document.from_file(f))
+    f.write_text("v2")
+    docs_v2 = list(Document.from_file(f))
+    h1 = docs_v1[0].metadata["content_hash"]
+    h2 = docs_v2[0].metadata["content_hash"]
+    assert h1 != h2
+
+
+def test_content_hash_stable_across_mtime_touch(tmp_path):
+    """Touching mtime alone does not change the content_hash."""
+    f = tmp_path / "a.txt"
+    f.write_text("stable")
+    h1 = list(Document.from_file(f))[0].metadata["content_hash"]
+    os.utime(f, (f.stat().st_atime + 10, f.stat().st_mtime + 10))
+    h2 = list(Document.from_file(f))[0].metadata["content_hash"]
+    assert h1 == h2
+
+
+def _run_index(runner, tmp_path, index_dir, sources):
+    """Run the index CLI against a temp persist dir. Returns CliResult."""
+    return runner.invoke(
+        cli,
+        [
+            "index",
+            "--persist-dir",
+            str(index_dir),
+            "--embedding-function",
+            "minilm",
+            *[str(s) for s in sources],
+        ],
+    )
+
+
+def test_index_skips_unchanged_mtime_only_rewrite(tmp_path):
+    """Second run on unchanged content (mtime touched) does NOT re-embed."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("some stable corpus content")
+
+    first = _run_index(runner, tmp_path, index_dir, [src])
+    assert first.exit_code == 0, first.output
+    assert "Successfully indexed 1 files" in first.output, first.output
+
+    # Simulate a git-restore style mtime rewrite: content identical, mtime bumped.
+    os.utime(f, (f.stat().st_atime + 100, f.stat().st_mtime + 100))
+    second = _run_index(runner, tmp_path, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "No new or modified documents to index" in second.output, second.output
+
+
+def test_index_reembeds_on_content_change(tmp_path):
+    """Changing content re-embeds on the next run."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("version one content")
+
+    first = _run_index(runner, tmp_path, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    f.write_text("version two content changed")
+    second = _run_index(runner, tmp_path, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "Successfully indexed 1 files" in second.output, second.output

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -110,6 +110,120 @@ def test_index_reembeds_on_content_change(tmp_path):
     assert "Successfully indexed 1 files" in second.output, second.output
 
 
+def test_index_preserves_old_chunks_when_replacement_add_fails(tmp_path, monkeypatch):
+    """A failed replacement embed must not delete the source's old chunks."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("version one content")
+
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    f.write_text("version two content")
+
+    import chromadb
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    original_add = chromadb.Collection.add
+    replacement_hash = hashlib.sha256(b"version two content").hexdigest()
+
+    def fail_replacement_add(self, *args, **kwargs):
+        metadatas = kwargs.get("metadatas") or []
+        if any(metadata.get("content_hash") == replacement_hash for metadata in metadatas):
+            raise RuntimeError("simulated embedding failure")
+        return original_add(self, *args, **kwargs)
+
+    monkeypatch.setattr(chromadb.Collection, "add", fail_replacement_add)
+    second = _run_index(runner, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "simulated embedding failure" in second.output
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    stored = collection.get(include=["metadatas"])["metadatas"]
+    assert stored is not None
+    old_hash = hashlib.sha256(b"version one content").hexdigest()
+    assert {metadata["content_hash"] for metadata in stored} == {old_hash}
+
+
+def test_index_retry_after_crash_does_not_delete_replacement(tmp_path):
+    """If add succeeded and delete did not, retry must keep the new generation."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("version one content")
+
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    import chromadb
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    f.write_text("version two content")
+    v2_hash = hashlib.sha256(b"version two content").hexdigest()
+    abs_source = str(f.resolve())
+
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    existing = collection.get(include=["embeddings", "metadatas", "documents"])
+    embeddings = existing["embeddings"]
+    assert embeddings is not None and len(embeddings) > 0
+    collection.add(
+        ids=[f"{abs_source}@{v2_hash}#chunk0-0"],
+        documents=["version two content"],
+        metadatas=[
+            {
+                "source": abs_source,
+                "filename": f.name,
+                "extension": f.suffix,
+                "content_hash": v2_hash,
+                "last_modified": "2026-08-28T00:00:00",
+                "is_chunk": True,
+            }
+        ],
+        embeddings=[existing["embeddings"][0]],
+    )
+    del collection, client
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+
+    second = _run_index(runner, index_dir, [src])
+    assert second.exit_code == 0, second.output
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    stored = collection.get(include=["metadatas"])["metadatas"]
+    assert stored is not None
+    assert {metadata["content_hash"] for metadata in stored} == {v2_hash}
+
+
 def test_index_replaces_stale_chunks_on_content_change(tmp_path):
     """Re-indexing a changed source replaces its old chunks instead of accumulating."""
     runner = CliRunner()

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -15,12 +15,20 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from gptme_rag.cli import cli
 from gptme_rag.indexing.document import Document
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _plain(output: str) -> str:
+    """Strip spinner/markup so assertions work when stdout is a TTY."""
+    return _ANSI_RE.sub("", output)
 
 
 def test_document_from_file_records_content_hash(tmp_path):
@@ -83,13 +91,13 @@ def test_index_skips_unchanged_mtime_only_rewrite(tmp_path):
 
     first = _run_index(runner, index_dir, [src])
     assert first.exit_code == 0, first.output
-    assert "Successfully indexed 1 files" in first.output, first.output
+    assert "Successfully indexed 1 files" in _plain(first.output), first.output
 
     # Simulate a git-restore style mtime rewrite: content identical, mtime bumped.
     os.utime(f, (f.stat().st_atime + 100, f.stat().st_mtime + 100))
     second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
-    assert "No new or modified documents to index" in second.output, second.output
+    assert "No new or modified documents to index" in _plain(second.output), second.output
 
 
 def test_index_reembeds_on_content_change(tmp_path):
@@ -107,7 +115,7 @@ def test_index_reembeds_on_content_change(tmp_path):
     f.write_text("version two content changed")
     second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
-    assert "Successfully indexed 1 files" in second.output, second.output
+    assert "Successfully indexed 1 files" in _plain(second.output), second.output
 
 
 def test_index_preserves_old_chunks_when_replacement_add_fails(tmp_path, monkeypatch):
@@ -131,7 +139,10 @@ def test_index_preserves_old_chunks_when_replacement_add_fails(tmp_path, monkeyp
     replacement_hash = hashlib.sha256(b"version two content").hexdigest()
 
     def fail_replacement_add(self, *args, **kwargs):
-        metadatas = kwargs.get("metadatas") or []
+        metadatas = kwargs.get("metadatas")
+        if metadatas is None and len(args) >= 3:
+            metadatas = args[2]
+        metadatas = metadatas or []
         if any(metadata.get("content_hash") == replacement_hash for metadata in metadatas):
             raise RuntimeError("simulated embedding failure")
         return original_add(self, *args, **kwargs)
@@ -326,7 +337,7 @@ def test_index_legacy_mtime_fallback_skips_unchanged(tmp_path):
     # First run: index the file, storing content_hash.
     first = _run_index(runner, index_dir, [src])
     assert first.exit_code == 0, first.output
-    assert "Successfully indexed 1 files" in first.output, first.output
+    assert "Successfully indexed 1 files" in _plain(first.output), first.output
 
     # Simulate legacy stored docs by removing content_hash from the index.
     _strip_content_hash_from_index(index_dir)
@@ -334,7 +345,7 @@ def test_index_legacy_mtime_fallback_skips_unchanged(tmp_path):
     # Second run: mtime unchanged, no content_hash → mtime fallback should skip.
     second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
-    assert "No new or modified documents to index" in second.output, second.output
+    assert "No new or modified documents to index" in _plain(second.output), second.output
 
 
 def test_index_legacy_mtime_fallback_reembeds_on_mtime_change(tmp_path):
@@ -356,4 +367,124 @@ def test_index_legacy_mtime_fallback_reembeds_on_mtime_change(tmp_path):
     os.utime(f, (f.stat().st_atime + 100, f.stat().st_mtime + 100))
     second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
-    assert "Successfully indexed 1 files" in second.output, second.output
+    assert "Successfully indexed 1 files" in _plain(second.output), second.output
+
+
+def test_from_file_hash_matches_decoded_bytes(tmp_path):
+    """Hash and document content must come from the same read of the file."""
+    f = tmp_path / "a.txt"
+    payload = "hash and content share one read"
+    f.write_bytes(payload.encode())
+    docs = list(Document.from_file(f))
+    assert docs[0].content == payload
+    assert docs[0].metadata["content_hash"] == hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _make_legacy_index_with_invalid_last_chunk_mtime(index_dir: Path) -> None:
+    """Legacy docs: drop content_hash, then poison only the last chunk's mtime."""
+    import chromadb
+
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    results = collection.get(include=["embeddings", "metadatas", "documents"])
+    assert results["ids"] and len(results["ids"]) > 1
+    metadatas = []
+    for i, metadata in enumerate(results["metadatas"]):
+        legacy = {key: value for key, value in metadata.items() if key != "content_hash"}
+        if i == len(results["ids"]) - 1:
+            legacy["last_modified"] = "not-a-timestamp"
+        metadatas.append(legacy)
+    collection.delete(ids=results["ids"])
+    collection.add(
+        ids=results["ids"],
+        embeddings=results["embeddings"],
+        metadatas=metadatas,
+        documents=results["documents"],
+    )
+
+
+def test_index_legacy_mtime_fallback_ignores_invalid_chunk_timestamp(tmp_path):
+    """A single invalid last_modified must not zero the stored mtime for a source."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "legacy.txt"
+    f.write_text("one two three four five six seven eight nine ten")
+
+    first = _run_index(
+        runner,
+        index_dir,
+        [src],
+        "--chunk-size",
+        "3",
+        "--chunk-overlap",
+        "1",
+    )
+    assert first.exit_code == 0, first.output
+
+    _make_legacy_index_with_invalid_last_chunk_mtime(index_dir)
+
+    second = _run_index(
+        runner,
+        index_dir,
+        [src],
+        "--chunk-size",
+        "3",
+        "--chunk-overlap",
+        "1",
+    )
+    assert second.exit_code == 0, second.output
+    assert "No new or modified documents to index" in _plain(second.output), second.output
+
+
+def test_index_reports_success_when_stale_delete_fails(tmp_path, monkeypatch):
+    """A failed stale-chunk delete after a successful add must not hide the add."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("version one content")
+
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    f.write_text("version two content")
+
+    import chromadb
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    original_delete = chromadb.Collection.delete
+
+    def fail_delete(self, *args, **kwargs):
+        raise RuntimeError("simulated delete failure")
+
+    monkeypatch.setattr(chromadb.Collection, "delete", fail_delete)
+    second = _run_index(runner, index_dir, [src])
+    monkeypatch.setattr(chromadb.Collection, "delete", original_delete)
+    assert second.exit_code == 0, second.output
+    assert "Successfully indexed 1 files" in _plain(second.output), second.output
+    assert "leftover stale chunks" in _plain(second.output), second.output
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    stored = collection.get(include=["metadatas"])["metadatas"]
+    assert stored is not None
+    new_hash = hashlib.sha256(b"version two content").hexdigest()
+    assert new_hash in {metadata["content_hash"] for metadata in stored}

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -490,3 +490,110 @@ def test_index_reports_success_when_stale_delete_fails(tmp_path, monkeypatch):
     assert stored is not None
     new_hash = hashlib.sha256(b"version two content").hexdigest()
     assert new_hash in {metadata["content_hash"] for metadata in stored}
+
+
+def test_index_mixed_legacy_and_current_hash_cleans_legacy_without_reembed(tmp_path):
+    """A leftover unhashed chunk beside the current hash must not re-embed."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("stable mixed-generation content")
+
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    import chromadb
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    abs_source = str(f.resolve())
+    current_hash = hashlib.sha256(b"stable mixed-generation content").hexdigest()
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    existing = collection.get(include=["embeddings", "metadatas", "documents"])
+    embeddings = existing["embeddings"]
+    assert embeddings is not None and len(embeddings) > 0
+    collection.add(
+        ids=[f"{abs_source}#legacy-unhashed"],
+        documents=["stable mixed-generation content"],
+        metadatas=[
+            {
+                "source": abs_source,
+                "filename": f.name,
+                "extension": f.suffix,
+                "last_modified": "2026-08-28T00:00:00",
+                "is_chunk": True,
+            }
+        ],
+        embeddings=[embeddings[0]],
+    )
+    del collection, client
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+
+    second = _run_index(runner, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "Successfully indexed" not in _plain(second.output), second.output
+    assert "Removed leftover stale chunks" in _plain(second.output), second.output
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    stored = collection.get(include=["metadatas"])
+    metadatas = stored["metadatas"]
+    assert metadatas is not None
+    assert {metadata.get("content_hash") for metadata in metadatas} == {current_hash}
+    assert f"{abs_source}#legacy-unhashed" not in stored["ids"]
+
+
+def test_index_emptied_file_deletes_stale_chunks(tmp_path):
+    """Emptying a previously indexed file must drop its leftover chunks."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("content that will be emptied")
+
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    import chromadb
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    f.write_text("   \n")
+    second = _run_index(runner, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "Successfully indexed" not in _plain(second.output), second.output
+    assert "Removed leftover stale chunks" in _plain(second.output), second.output
+
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    stored = collection.get(include=["metadatas"])
+    abs_source = str(f.resolve())
+    leftover = [
+        metadata for metadata in (stored["metadatas"] or []) if metadata.get("source") == abs_source
+    ]
+    assert leftover == []

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -55,7 +56,7 @@ def test_content_hash_stable_across_mtime_touch(tmp_path):
     assert h1 == h2
 
 
-def _run_index(runner, tmp_path, index_dir, sources):
+def _run_index(runner, index_dir, sources, *extra_args):
     """Run the index CLI against a temp persist dir. Returns CliResult."""
     return runner.invoke(
         cli,
@@ -64,7 +65,8 @@ def _run_index(runner, tmp_path, index_dir, sources):
             "--persist-dir",
             str(index_dir),
             "--embedding-function",
-            "minilm",
+            "default",
+            *extra_args,
             *[str(s) for s in sources],
         ],
     )
@@ -79,13 +81,13 @@ def test_index_skips_unchanged_mtime_only_rewrite(tmp_path):
     f = src / "doc.txt"
     f.write_text("some stable corpus content")
 
-    first = _run_index(runner, tmp_path, index_dir, [src])
+    first = _run_index(runner, index_dir, [src])
     assert first.exit_code == 0, first.output
     assert "Successfully indexed 1 files" in first.output, first.output
 
     # Simulate a git-restore style mtime rewrite: content identical, mtime bumped.
     os.utime(f, (f.stat().st_atime + 100, f.stat().st_mtime + 100))
-    second = _run_index(runner, tmp_path, index_dir, [src])
+    second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
     assert "No new or modified documents to index" in second.output, second.output
 
@@ -99,10 +101,145 @@ def test_index_reembeds_on_content_change(tmp_path):
     f = src / "doc.txt"
     f.write_text("version one content")
 
-    first = _run_index(runner, tmp_path, index_dir, [src])
+    first = _run_index(runner, index_dir, [src])
     assert first.exit_code == 0, first.output
 
     f.write_text("version two content changed")
-    second = _run_index(runner, tmp_path, index_dir, [src])
+    second = _run_index(runner, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "Successfully indexed 1 files" in second.output, second.output
+
+
+def test_index_replaces_stale_chunks_on_content_change(tmp_path):
+    """Re-indexing a changed source replaces its old chunks instead of accumulating."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "doc.txt"
+    f.write_text("one two three four five six seven eight")
+
+    first = _run_index(
+        runner,
+        index_dir,
+        [src],
+        "--chunk-size",
+        "3",
+        "--chunk-overlap",
+        "1",
+    )
+    assert first.exit_code == 0, first.output
+
+    import chromadb
+
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    first_count = collection.count()
+    assert first_count > 1
+    del collection, client
+    chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()
+
+    f.write_text("replacement content")
+    second = _run_index(
+        runner,
+        index_dir,
+        [src],
+        "--chunk-size",
+        "3",
+        "--chunk-overlap",
+        "1",
+    )
+    assert second.exit_code == 0, second.output
+
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    assert collection.count() < first_count
+    stored = collection.get(include=["metadatas"])["metadatas"]
+    expected_hash = hashlib.sha256(f.read_bytes()).hexdigest()
+    assert {metadata["content_hash"] for metadata in stored} == {expected_hash}
+
+
+def _strip_content_hash_from_index(index_dir: Path) -> None:
+    """Replace stored docs with legacy copies that lack content_hash metadata."""
+    import chromadb
+
+    client = chromadb.PersistentClient(
+        path=str(index_dir),
+        settings=chromadb.config.Settings(
+            allow_reset=True,
+            is_persistent=True,
+            anonymized_telemetry=False,
+        ),
+    )
+    collection = client.get_collection("default")
+    results = collection.get(include=["embeddings", "metadatas", "documents"])
+    legacy_metadatas = [
+        {key: value for key, value in metadata.items() if key != "content_hash"}
+        for metadata in results["metadatas"]
+    ]
+    collection.delete(ids=results["ids"])
+    collection.add(
+        ids=results["ids"],
+        embeddings=results["embeddings"],
+        metadatas=legacy_metadatas,
+        documents=results["documents"],
+    )
+
+
+def test_index_legacy_mtime_fallback_skips_unchanged(tmp_path):
+    """Legacy stored docs (no content_hash) use mtime fallback — unchanged mtime skips."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "legacy.txt"
+    f.write_text("legacy corpus content")
+
+    # First run: index the file, storing content_hash.
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+    assert "Successfully indexed 1 files" in first.output, first.output
+
+    # Simulate legacy stored docs by removing content_hash from the index.
+    _strip_content_hash_from_index(index_dir)
+
+    # Second run: mtime unchanged, no content_hash → mtime fallback should skip.
+    second = _run_index(runner, index_dir, [src])
+    assert second.exit_code == 0, second.output
+    assert "No new or modified documents to index" in second.output, second.output
+
+
+def test_index_legacy_mtime_fallback_reembeds_on_mtime_change(tmp_path):
+    """Legacy stored docs use mtime fallback — bumped mtime triggers re-embed."""
+    runner = CliRunner()
+    index_dir = tmp_path / "index"
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "legacy.txt"
+    f.write_text("legacy corpus content")
+
+    first = _run_index(runner, index_dir, [src])
+    assert first.exit_code == 0, first.output
+
+    # Strip content_hash to simulate legacy docs.
+    _strip_content_hash_from_index(index_dir)
+
+    # Bump mtime (no content change) → mtime fallback sees newer mtime → re-embed.
+    os.utime(f, (f.stat().st_atime + 100, f.stat().st_mtime + 100))
+    second = _run_index(runner, index_dir, [src])
     assert second.exit_code == 0, second.output
     assert "Successfully indexed 1 files" in second.output, second.output


### PR DESCRIPTION
## Problem

The `index` command's change-detection keyed solely on file mtime (`cli.py`). A git restore, checkout, or hot-worktree mtime rewrite forced a full re-embed of unchanged files — the latent cause of the vitals-regen index CPU burn once the `file_limit` cap was lifted (gptme-contrib#1523, merged).

## Fix

- `document.py`: record a `content_hash` (sha256 of file bytes) in `from_file` metadata, alongside `last_modified`.
- `cli.py`: compare `content_hash` as the **primary** change-detection key; fall back to mtime **only** for stored documents that predate content hashing (legacy index entries).

## Verification

- New `tests/test_content_hash_changedetection.py`: 6 tests covering hash recording, content-change invalidation, mtime-touch stability, and end-to-end index skip/re-embed via the CLI.
- `test_index_skips_unchanged_mtime_only_rewrite` proves the core fix: bumping mtime on unchanged content does **not** re-embed.
- `make typecheck` (gptme-rag): clean.

Closes Bug #2 of the vitals-regen index investigation.