### PR TITLE
fix(rag): do not recreate a matching-model collection on EF conflict

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 
 from .benchmark import RagBenchmark
 from .indexing.document import Document
+from .indexing.gc import gc_orphan_segment_dirs
 from .indexing.indexer import Indexer
 from .indexing.watcher import FileWatcher
 from .query.context_assembler import ContextAssembler
@@ -827,6 +828,37 @@ def watch(
     except Exception as e:
         console.print(f"❌ Error watching directory: {e}", style="red")
         console.print_exception()
+
+
+@cli.command("gc-orphans")
+@click.option(
+    "--persist-dir",
+    type=click.Path(path_type=Path),
+    default=default_persist_dir,
+    help="Directory to persist the index",
+)
+@click.option(
+    "--apply",
+    is_flag=True,
+    help="Actually delete orphan UUID dirs. Default is dry-run.",
+)
+def gc_orphans(persist_dir: Path, apply: bool):
+    """Remove leftover Chroma segment dirs not listed in chroma.sqlite3.
+
+    Recreating a collection leaves UUID-named HNSW folders on disk. This
+    command lists them (dry-run) or deletes them (--apply). Live segment
+    and collection dirs are never touched.
+    """
+    orphans = gc_orphan_segment_dirs(persist_dir, apply=apply)
+    if not orphans:
+        console.print("No orphan segment dirs", style="green")
+        return
+    mode = "Removed" if apply else "Would remove"
+    console.print(f"{mode} {len(orphans)} orphan dir(s):")
+    for path in orphans:
+        console.print(f"  {path.name}")
+    if not apply:
+        console.print("Dry-run. Pass --apply to delete.", style="yellow")
 
 
 @cli.command()

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 from .benchmark import RagBenchmark
 from .indexing.document import Document
-from .indexing.gc import gc_orphan_segment_dirs
+from .indexing.gc import ChromaCatalogError, gc_orphan_segment_dirs
 from .indexing.indexer import Indexer
 from .indexing.watcher import FileWatcher
 from .query.context_assembler import ContextAssembler
@@ -847,9 +847,14 @@ def gc_orphans(persist_dir: Path, apply: bool):
 
     Recreating a collection leaves UUID-named HNSW folders on disk. This
     command lists them (dry-run) or deletes them (--apply). Live segment
-    and collection dirs are never touched.
+    and collection dirs are never touched. --apply refuses if an indexer
+    currently holds the persist-dir writer lock.
     """
-    orphans = gc_orphan_segment_dirs(persist_dir, apply=apply)
+    try:
+        orphans = gc_orphan_segment_dirs(persist_dir, apply=apply)
+    except (ChromaCatalogError, RuntimeError) as exc:
+        console.print(f"❌ {exc}", style="red")
+        raise SystemExit(1) from exc
     if not orphans:
         console.print("No orphan segment dirs", style="green")
         return

--- a/packages/gptme-rag/src/gptme_rag/indexing/gc.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/gc.py
@@ -8,14 +8,22 @@ of them after a same-model recreate loop).
 Only UUID-named directories whose names are absent from both ``segments.id``
 and ``collections.id`` are candidates. ``chroma.sqlite3`` and live segment
 dirs are never touched.
+
+``--apply`` takes an exclusive writer lock (the same lock Indexer holds
+around collection writes). If an indexer is mid-write, apply refuses rather
+than deleting a segment dir Chroma created but has not yet catalogued.
 """
 
 from __future__ import annotations
 
+import fcntl
 import logging
+import os
 import re
 import shutil
 import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -24,12 +32,50 @@ _UUID_DIR = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
+_WRITER_LOCK_NAME = ".gptme-rag-writer.lock"
+
+
+class ChromaCatalogError(RuntimeError):
+    """chroma.sqlite3 is unreadable; GC must not report a clean persist dir."""
+
+
+@contextmanager
+def index_writer_lock(persist_dir: Path, *, blocking: bool = True) -> Iterator[None]:
+    """Exclusive lock around Chroma persist-dir writes.
+
+    Indexer holds this while adding/deleting/recreating collections. GC
+    ``apply`` takes it non-blocking and refuses if a writer is active — Chroma
+    creates a segment directory before inserting its id into sqlite, so a GC
+    snapshot taken in that window would treat a live dir as an orphan.
+    """
+    persist_dir = Path(persist_dir)
+    persist_dir.mkdir(parents=True, exist_ok=True)
+    fd = os.open(persist_dir / _WRITER_LOCK_NAME, os.O_CREAT | os.O_RDWR, 0o644)
+    flags = fcntl.LOCK_EX if blocking else (fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        try:
+            fcntl.flock(fd, flags)
+        except BlockingIOError as exc:
+            raise RuntimeError(
+                f"index writer is active in {persist_dir}; refusing to apply GC"
+            ) from exc
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
 
 
 def _live_chroma_ids(db: Path) -> set[str]:
-    """IDs that still belong to the current Chroma catalog."""
-    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    """IDs that still belong to the current Chroma catalog.
+
+    Connect by filesystem path (not a ``file:`` URI) so a persist dir whose
+    path contains ``?`` is not parsed as a sqlite query string.
+    """
+    con = sqlite3.connect(str(db))
     try:
+        con.execute("PRAGMA query_only=ON")
         tables = {
             row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
         }
@@ -43,23 +89,7 @@ def _live_chroma_ids(db: Path) -> set[str]:
         con.close()
 
 
-def gc_orphan_segment_dirs(persist_dir: Path, *, apply: bool = False) -> list[Path]:
-    """Return orphan UUID dirs; delete them when ``apply`` is True.
-
-    Dry-run (``apply=False``) is the default. If the sqlite catalog cannot be
-    read, return an empty list rather than deleting anything.
-    """
-    persist_dir = Path(persist_dir)
-    db = persist_dir / "chroma.sqlite3"
-    if not persist_dir.is_dir() or not db.is_file():
-        return []
-
-    try:
-        live_ids = _live_chroma_ids(db)
-    except sqlite3.Error as exc:
-        logger.warning("Cannot read %s (%s); refusing to GC", db, exc)
-        return []
-
+def _collect_orphans(persist_dir: Path, live_ids: set[str]) -> list[Path]:
     orphans: list[Path] = []
     for child in persist_dir.iterdir():
         if not child.is_dir():
@@ -69,10 +99,40 @@ def gc_orphan_segment_dirs(persist_dir: Path, *, apply: bool = False) -> list[Pa
         if child.name in live_ids:
             continue
         orphans.append(child)
-
-    if apply:
-        for path in orphans:
-            shutil.rmtree(path)
-            logger.info("Removed orphan segment dir %s", path)
-
     return orphans
+
+
+def _delete_orphans(orphans: list[Path]) -> list[Path]:
+    removed: list[Path] = []
+    for path in orphans:
+        try:
+            shutil.rmtree(path)
+        except OSError as exc:
+            logger.warning("Failed to remove %s: %s", path, exc)
+            continue
+        logger.info("Removed orphan segment dir %s", path)
+        removed.append(path)
+    return removed
+
+
+def gc_orphan_segment_dirs(persist_dir: Path, *, apply: bool = False) -> list[Path]:
+    """Return orphan UUID dirs; delete them when ``apply`` is True.
+
+    Dry-run (``apply=False``) is the default. Raises ``ChromaCatalogError`` if
+    the sqlite catalog cannot be read, rather than pretending the dir is clean.
+    ``apply=True`` raises ``RuntimeError`` if an index writer currently holds
+    the persist-dir lock.
+    """
+    persist_dir = Path(persist_dir)
+    db = persist_dir / "chroma.sqlite3"
+    if not persist_dir.is_dir() or not db.is_file():
+        return []
+
+    try:
+        if apply:
+            with index_writer_lock(persist_dir, blocking=False):
+                orphans = _collect_orphans(persist_dir, _live_chroma_ids(db))
+                return _delete_orphans(orphans)
+        return _collect_orphans(persist_dir, _live_chroma_ids(db))
+    except sqlite3.Error as exc:
+        raise ChromaCatalogError(f"Cannot read {db}: {exc}") from exc

--- a/packages/gptme-rag/src/gptme_rag/indexing/gc.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/gc.py
@@ -36,7 +36,7 @@ _WRITER_LOCK_NAME = ".gptme-rag-writer.lock"
 
 
 class ChromaCatalogError(RuntimeError):
-    """chroma.sqlite3 is unreadable; GC must not report a clean persist dir."""
+    """Persist dir or chroma.sqlite3 is unreadable; GC must not report a clean dir."""
 
 
 @contextmanager
@@ -119,16 +119,15 @@ def gc_orphan_segment_dirs(persist_dir: Path, *, apply: bool = False) -> list[Pa
     """Return orphan UUID dirs; delete them when ``apply`` is True.
 
     Dry-run (``apply=False``) is the default. Raises ``ChromaCatalogError`` if
-    the sqlite catalog cannot be read, rather than pretending the dir is clean.
-    ``apply=True`` raises ``RuntimeError`` if an index writer currently holds
-    the persist-dir lock.
+    the sqlite catalog or persist dir cannot be read, rather than pretending
+    the dir is clean. ``apply=True`` raises ``RuntimeError`` if an index writer
+    currently holds the persist-dir lock.
     """
     persist_dir = Path(persist_dir)
     db = persist_dir / "chroma.sqlite3"
-    if not persist_dir.is_dir() or not db.is_file():
-        return []
-
     try:
+        if not persist_dir.is_dir() or not db.is_file():
+            return []
         if apply:
             with index_writer_lock(persist_dir, blocking=False):
                 orphans = _collect_orphans(persist_dir, _live_chroma_ids(db))
@@ -136,3 +135,5 @@ def gc_orphan_segment_dirs(persist_dir: Path, *, apply: bool = False) -> list[Pa
         return _collect_orphans(persist_dir, _live_chroma_ids(db))
     except sqlite3.Error as exc:
         raise ChromaCatalogError(f"Cannot read {db}: {exc}") from exc
+    except OSError as exc:
+        raise ChromaCatalogError(f"Cannot access {persist_dir}: {exc}") from exc

--- a/packages/gptme-rag/src/gptme_rag/indexing/gc.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/gc.py
@@ -81,22 +81,33 @@ def _live_chroma_ids(db: Path) -> set[str]:
         }
         ids: set[str] = set()
         if "segments" in tables:
-            ids.update(row[0] for row in con.execute("SELECT id FROM segments") if row[0])
+            ids.update(
+                str(row[0]).lower() for row in con.execute("SELECT id FROM segments") if row[0]
+            )
         if "collections" in tables:
-            ids.update(row[0] for row in con.execute("SELECT id FROM collections") if row[0])
+            ids.update(
+                str(row[0]).lower() for row in con.execute("SELECT id FROM collections") if row[0]
+            )
         return ids
     finally:
         con.close()
 
 
 def _collect_orphans(persist_dir: Path, live_ids: set[str]) -> list[Path]:
+    """UUID hex is case-insensitive (RFC 4122); compare folded.
+
+    ``_UUID_DIR`` is IGNORECASE so an uppercase dir is a candidate. Exact-case
+    membership against sqlite's canonical lowercase ``segments.id`` would
+    classify that live dir as an orphan and ``--apply`` would ``rmtree`` it.
+    """
     orphans: list[Path] = []
+    live = {i.lower() for i in live_ids}
     for child in persist_dir.iterdir():
         if not child.is_dir():
             continue
         if not _UUID_DIR.fullmatch(child.name):
             continue
-        if child.name in live_ids:
+        if child.name.lower() in live:
             continue
         orphans.append(child)
     return orphans

--- a/packages/gptme-rag/src/gptme_rag/indexing/gc.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/gc.py
@@ -1,0 +1,78 @@
+"""Garbage-collect orphaned Chroma persist-dir segment folders.
+
+Each ``delete_collection`` / recreate leaves UUID-named HNSW directories on
+disk that are no longer listed in ``chroma.sqlite3``. They are not used by
+search or index, but they accumulate (Bob's ambient-memory persist dir had 42
+of them after a same-model recreate loop).
+
+Only UUID-named directories whose names are absent from both ``segments.id``
+and ``collections.id`` are candidates. ``chroma.sqlite3`` and live segment
+dirs are never touched.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_UUID_DIR = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _live_chroma_ids(db: Path) -> set[str]:
+    """IDs that still belong to the current Chroma catalog."""
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    try:
+        tables = {
+            row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        ids: set[str] = set()
+        if "segments" in tables:
+            ids.update(row[0] for row in con.execute("SELECT id FROM segments") if row[0])
+        if "collections" in tables:
+            ids.update(row[0] for row in con.execute("SELECT id FROM collections") if row[0])
+        return ids
+    finally:
+        con.close()
+
+
+def gc_orphan_segment_dirs(persist_dir: Path, *, apply: bool = False) -> list[Path]:
+    """Return orphan UUID dirs; delete them when ``apply`` is True.
+
+    Dry-run (``apply=False``) is the default. If the sqlite catalog cannot be
+    read, return an empty list rather than deleting anything.
+    """
+    persist_dir = Path(persist_dir)
+    db = persist_dir / "chroma.sqlite3"
+    if not persist_dir.is_dir() or not db.is_file():
+        return []
+
+    try:
+        live_ids = _live_chroma_ids(db)
+    except sqlite3.Error as exc:
+        logger.warning("Cannot read %s (%s); refusing to GC", db, exc)
+        return []
+
+    orphans: list[Path] = []
+    for child in persist_dir.iterdir():
+        if not child.is_dir():
+            continue
+        if not _UUID_DIR.fullmatch(child.name):
+            continue
+        if child.name in live_ids:
+            continue
+        orphans.append(child)
+
+    if apply:
+        for path in orphans:
+            shutil.rmtree(path)
+            logger.info("Removed orphan segment dir %s", path)
+
+    return orphans

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -490,9 +490,17 @@ class Indexer:
                     )
                     try:
                         self.collection = self.client.get_collection(name=collection_name)
-                    except Exception:
-                        # Collection truly doesn't exist yet — create it normally.
-                        need_recreate = True
+                    except Exception as peek_err:
+                        # Missing *or* temporarily unreadable (sqlite lock
+                        # during a concurrent write). Creating would be a write;
+                        # the later need_recreate block deletes first, so a
+                        # transient peek failure would wipe a live collection
+                        # from search/status. Fail loud instead.
+                        raise RuntimeError(
+                            f"Collection {collection_name!r} could not be opened "
+                            "and recreation is disabled for this command; not "
+                            f"creating or deleting it. Error: {peek_err}"
+                        ) from peek_err
                     else:
                         # Null out the mismatched embedding function so search() does not
                         # use it and produce a cryptic ChromaDB InvalidDimensionException.
@@ -533,6 +541,12 @@ class Indexer:
                                 need_recreate = True
 
         if need_recreate:
+            if not allow_recreate:
+                raise RuntimeError(
+                    f"Collection {collection_name!r} could not be opened "
+                    "and recreation is disabled for this command; not "
+                    "creating or deleting it."
+                )
             with self._index_writer_lock():
                 # Delete if exists
                 try:

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -25,7 +25,7 @@ from ..embeddings import (
 )
 from .document import Document
 from .document_processor import DocumentProcessor
-from .gc import index_writer_lock
+from .gc import _WRITER_LOCK_NAME, index_writer_lock
 
 
 # HuggingFace namespaces used for sentence-transformer / embedding models.
@@ -523,8 +523,20 @@ class Indexer:
                     else:
                         try:
                             peek = self.client.get_collection(name=collection_name)
-                        except Exception:
-                            need_recreate = True
+                        except Exception as peek_err:
+                            # Peek failed: either the collection is absent, or
+                            # the catalog is temporarily unreadable (sqlite lock
+                            # during a concurrent write). Recreate wipes first —
+                            # only do that when list_collections confirms absence.
+                            if self._collection_confirmed_missing(collection_name):
+                                need_recreate = True
+                            else:
+                                raise RuntimeError(
+                                    f"Collection {collection_name!r} could not be "
+                                    "opened and was not confirmed missing; refusing "
+                                    "to recreate. "
+                                    f"Error: {peek_err}"
+                                ) from peek_err
                         else:
                             stored = (peek.metadata or {}).get("embedding_model", "unknown")
                             if stored == current_model:
@@ -595,6 +607,38 @@ class Indexer:
         if persist_dir is None:
             return nullcontext()
         return index_writer_lock(persist_dir)
+
+    def _collection_confirmed_missing(self, collection_name: str) -> bool:
+        """True only when the catalog lists no collection of this name.
+
+        A failed get_collection() is not proof of absence: a sqlite write-lock
+        looks the same as "missing". Recreate deletes first, so a false
+        missing signal wipes a live index. If the catalog cannot be listed,
+        treat the collection as present and refuse to wipe.
+        """
+        try:
+            return collection_name not in {c.name for c in self.client.list_collections()}
+        except Exception:
+            return False
+
+    def _is_persist_artifact(self, path: Path) -> bool:
+        """True for the persist dir, files inside it, or the writer lock.
+
+        Indexing those files is always wrong: they are the index, not a
+        corpus. Watcher tests (and any watch of a tree that contains the
+        persist dir) would otherwise ingest ``.gptme-rag-writer.lock``.
+        """
+        if path.name == _WRITER_LOCK_NAME:
+            return True
+        persist = getattr(self, "persist_directory", None)
+        if persist is None:
+            return False
+        try:
+            persist_resolved = Path(persist).resolve()
+            resolved = path.resolve()
+        except OSError:
+            return False
+        return resolved == persist_resolved or persist_resolved in resolved.parents
 
     def _assign_preserved_collection(self, collection, collection_name: str) -> None:
         """Keep an EF-less handle; rebind our embedder or fail loud.
@@ -1763,9 +1807,15 @@ class Indexer:
             # Resolve symlinks to target
             try:
                 resolved = f.resolve()
-                valid_files.add(resolved)
             except Exception as e:
                 logger.warning(f"Error resolving symlink: {f} -> {e}")
+                continue
+
+            if self._is_persist_artifact(resolved):
+                logger.debug(f"Skipping persist-dir artifact: {resolved}")
+                continue
+
+            valid_files.add(resolved)
 
         # Check file limit. Strict greater-than: a corpus that lands exactly on
         # the cap is complete, not truncated, so it must not log an ERROR.

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -524,6 +524,30 @@ class Indexer:
                                     e,
                                 )
                                 self.collection = peek
+                                # `peek` was fetched WITHOUT an embedding function, so it
+                                # carries Chroma's default EF (384-dim MiniLM).  Writing
+                                # through it would embed with the wrong model and blow up
+                                # with InvalidDimensionException against the stored 768-dim
+                                # vectors.  The stored model matches ours, so our EF is
+                                # known-compatible: bind it onto the handle Chroma refused
+                                # to bind it to.  Chroma rejected the EF *object identity*,
+                                # not the model.
+                                if (
+                                    self.embedding_function is not None
+                                    and not self._bind_embedding_function(peek)
+                                ):
+                                    # Could not rebind (Chroma internals changed).  Fall
+                                    # back to fail-loud: null the EF and record the stored
+                                    # model so add/search raise a clear RuntimeError
+                                    # instead of silently writing default-EF vectors.
+                                    logger.error(
+                                        "Could not rebind embedding function to preserved "
+                                        "collection %r; it is readable but not writable. "
+                                        "Re-index with --force-recreate to restore writes.",
+                                        collection_name,
+                                    )
+                                    self.embedding_function = None
+                                    self._stored_model_name = stored
                                 need_recreate = False
                             else:
                                 need_recreate = True
@@ -570,6 +594,35 @@ class Indexer:
         }
         if scoring_weights:
             self.scoring_weights.update(scoring_weights)
+
+    def _bind_embedding_function(self, collection) -> bool:
+        """Bind ``self.embedding_function`` onto an EF-less collection handle.
+
+        ``client.get_collection(name=...)`` returns a handle carrying Chroma's
+        *default* embedding function.  Writing through such a handle embeds with
+        the wrong model, which raises ``InvalidDimensionException`` against
+        vectors stored by a non-default model (768-dim ModernBERT vs 384-dim
+        MiniLM).  Callers must only use this after verifying the collection's
+        stored ``embedding_model`` matches the current one, so the EF is
+        known-compatible and Chroma's objection was to object identity, not to
+        the model.
+
+        Returns True when the binding is in place and verified, False when
+        Chroma's internals do not expose the attribute (version drift), so the
+        caller can fail loudly instead of writing wrong-dimension vectors.
+        """
+        assert self.embedding_function is not None, (
+            "callers must skip rebinding when the current EF is Chroma's default; "
+            "an EF-less handle is already correct in that case"
+        )
+        if not hasattr(collection, "_embedding_function"):
+            return False
+        try:
+            collection._embedding_function = self.embedding_function
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Rebinding embedding function failed: %s", exc)
+            return False
+        return getattr(collection, "_embedding_function", None) is self.embedding_function
 
     @property
     def embedding_model_name(self) -> str:

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -4,6 +4,7 @@ import logging
 import subprocess
 import time
 from collections.abc import Generator, Sequence
+from contextlib import nullcontext
 from datetime import datetime
 from fnmatch import fnmatch as fnmatch_path
 from logging import Filter
@@ -24,6 +25,7 @@ from ..embeddings import (
 )
 from .document import Document
 from .document_processor import DocumentProcessor
+from .gc import index_writer_lock
 
 
 # HuggingFace namespaces used for sentence-transformer / embedding models.
@@ -469,7 +471,9 @@ class Indexer:
                         current_model,
                         e,
                     )
-                    self.collection = _auto_peeked_collection
+                    # Peeked handle was fetched WITHOUT an EF — same defect as the
+                    # matching-model preserve path. Rebind, or fail loud.
+                    self._assign_preserved_collection(_auto_peeked_collection, collection_name)
                     need_recreate = False
                 elif not allow_recreate:
                     # Read-only callers (search, status) must never wipe the index.
@@ -523,57 +527,34 @@ class Indexer:
                                     stored,
                                     e,
                                 )
-                                self.collection = peek
-                                # `peek` was fetched WITHOUT an embedding function, so it
-                                # carries Chroma's default EF (384-dim MiniLM).  Writing
-                                # through it would embed with the wrong model and blow up
-                                # with InvalidDimensionException against the stored 768-dim
-                                # vectors.  The stored model matches ours, so our EF is
-                                # known-compatible: bind it onto the handle Chroma refused
-                                # to bind it to.  Chroma rejected the EF *object identity*,
-                                # not the model.
-                                if (
-                                    self.embedding_function is not None
-                                    and not self._bind_embedding_function(peek)
-                                ):
-                                    # Could not rebind (Chroma internals changed).  Fall
-                                    # back to fail-loud: null the EF and record the stored
-                                    # model so add/search raise a clear RuntimeError
-                                    # instead of silently writing default-EF vectors.
-                                    logger.error(
-                                        "Could not rebind embedding function to preserved "
-                                        "collection %r; it is readable but not writable. "
-                                        "Re-index with --force-recreate to restore writes.",
-                                        collection_name,
-                                    )
-                                    self.embedding_function = None
-                                    self._stored_model_name = stored
+                                self._assign_preserved_collection(peek, collection_name)
                                 need_recreate = False
                             else:
                                 need_recreate = True
 
         if need_recreate:
-            # Delete if exists
-            try:
-                self.client.delete_collection(collection_name)
-            except (ValueError, NotFoundError):
-                pass
+            with self._index_writer_lock():
+                # Delete if exists
+                try:
+                    self.client.delete_collection(collection_name)
+                except (ValueError, NotFoundError):
+                    pass
 
-            # Create new collection
-            metadata = {
-                "hnsw:space": "cosine",
-                "embedding_model": current_model,
-                "embedding_backend": self.embedding_backend_name,
-            }
-            logger.info(f"Creating new collection with {current_model} embeddings")
-            self.collection = self.client.create_collection(
-                name=collection_name,
-                metadata=metadata,
-                embedding_function=self.embedding_function,
-            )
-            # The unavailable model belonged to the collection we just replaced.
-            # Keep the guard only while preserving that old collection.
-            self._stored_model_name = None
+                # Create new collection
+                metadata = {
+                    "hnsw:space": "cosine",
+                    "embedding_model": current_model,
+                    "embedding_backend": self.embedding_backend_name,
+                }
+                logger.info(f"Creating new collection with {current_model} embeddings")
+                self.collection = self.client.create_collection(
+                    name=collection_name,
+                    metadata=metadata,
+                    embedding_function=self.embedding_function,
+                )
+                # The unavailable model belonged to the collection we just replaced.
+                # Keep the guard only while preserving that old collection.
+                self._stored_model_name = None
 
         # Initialize cache with 5-minute TTL and 100MB memory limit
         self.cache = SmartRAGCache(ttl_seconds=300, max_memory_bytes=100 * 1024 * 1024)
@@ -594,6 +575,37 @@ class Indexer:
         }
         if scoring_weights:
             self.scoring_weights.update(scoring_weights)
+
+    def _index_writer_lock(self):
+        persist_dir = getattr(self, "persist_directory", None)
+        if persist_dir is None:
+            return nullcontext()
+        return index_writer_lock(persist_dir)
+
+    def _assign_preserved_collection(self, collection, collection_name: str) -> None:
+        """Keep an EF-less handle; rebind our embedder or fail loud.
+
+        ``get_collection(name=...)`` returns a handle carrying Chroma's default
+        EF. Writing through it embeds at the wrong dimension. The stored model
+        matches ours, so our EF is known-compatible — Chroma objected to object
+        identity, not the model. Bind it; if Chroma internals hid the attribute,
+        null the EF so add/search raise instead of writing MiniLM vectors.
+        """
+        self.collection = collection
+        if self.embedding_function is None:
+            return
+        if self._bind_embedding_function(collection):
+            return
+        logger.error(
+            "Could not rebind embedding function to preserved "
+            "collection %r; it is readable but not writable. "
+            "Re-index with --force-recreate to restore writes.",
+            collection_name,
+        )
+        stored = (collection.metadata or {}).get("embedding_model")
+        self.embedding_function = None
+        if stored:
+            self._stored_model_name = stored
 
     def _bind_embedding_function(self, collection) -> bool:
         """Bind ``self.embedding_function`` onto an EF-less collection handle.
@@ -689,19 +701,20 @@ class Indexer:
 
     def reset_collection(self) -> None:
         """Reset the collection to a clean state."""
-        try:
-            self.client.delete_collection(self.collection_name)
-        except (ValueError, NotFoundError):
-            pass
-        self.collection = self.client.create_collection(
-            name=self.collection_name,
-            metadata={
-                "hnsw:space": "cosine",
-                "embedding_model": self.embedding_model_name,
-                "embedding_backend": self.embedding_backend_name,
-            },
-            embedding_function=self.embedding_function,
-        )
+        with self._index_writer_lock():
+            try:
+                self.client.delete_collection(self.collection_name)
+            except (ValueError, NotFoundError):
+                pass
+            self.collection = self.client.create_collection(
+                name=self.collection_name,
+                metadata={
+                    "hnsw:space": "cosine",
+                    "embedding_model": self.embedding_model_name,
+                    "embedding_backend": self.embedding_backend_name,
+                },
+                embedding_function=self.embedding_function,
+            )
         logger.debug(f"Reset collection: {self.collection_name}")
 
     def _refresh_collection(self) -> None:
@@ -730,11 +743,12 @@ class Indexer:
         assert document.doc_id is not None
 
         try:
-            self.collection.add(
-                documents=[document.content],
-                metadatas=[document.metadata],
-                ids=[document.doc_id],
-            )
+            with self._index_writer_lock():
+                self.collection.add(
+                    documents=[document.content],
+                    metadatas=[document.metadata],
+                    ids=[document.doc_id],
+                )
             logger.debug(f"Added document with ID: {document.doc_id}")
         except Exception as e:
             # Never reset the collection here: wiping the entire persistent
@@ -746,7 +760,8 @@ class Indexer:
     def delete_documents(self, where: dict) -> None:
         """Delete documents matching the where clause."""
         try:
-            self.collection.delete(where=where)
+            with self._index_writer_lock():
+                self.collection.delete(where=where)
             logger.debug(f"Deleted documents matching: {where}")
         except NotFoundError:
             # The cached Collection object is stale (collection was recreated).
@@ -754,7 +769,8 @@ class Indexer:
             logger.debug("Collection handle stale on delete; refreshing and retrying")
             try:
                 self._refresh_collection()
-                self.collection.delete(where=where)
+                with self._index_writer_lock():
+                    self.collection.delete(where=where)
                 logger.debug(f"Deleted documents matching: {where} (after refresh)")
             except NotFoundError as retry_err:
                 # Collection still missing after refresh (race condition).
@@ -813,7 +829,8 @@ class Indexer:
                 ids.append(doc.doc_id)
 
             # Add batch to collection
-            self.collection.add(documents=contents, metadatas=metadatas, ids=ids)  # type: ignore[arg-type]
+            with self._index_writer_lock():
+                self.collection.add(documents=contents, metadatas=metadatas, ids=ids)  # type: ignore[arg-type]
         except Exception as e:
             logger.error(f"Failed to process batch: {e}")
             raise

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -407,8 +407,15 @@ class Indexer:
                 metadata = self.collection.metadata or {}
                 stored_model = metadata.get("embedding_model", "unknown")
 
-                if stored_model != current_model or force_recreate:
-                    if not allow_recreate and not force_recreate:
+                if force_recreate:
+                    logger.info(
+                        "Force recreate requested (stored: %r, current: %r)",
+                        stored_model,
+                        current_model,
+                    )
+                    need_recreate = True
+                elif stored_model != current_model:
+                    if not allow_recreate:
                         # Read-only callers (search, status) must never wipe the index.
                         # Warn loudly and keep the existing collection as-is.
                         logger.warning(
@@ -426,11 +433,7 @@ class Indexer:
                         self.embedding_function = None
                         self._stored_model_name = stored_model
                         need_recreate = False
-                    elif (
-                        _openrouter_fallback
-                        and not force_recreate
-                        and _looks_like_openrouter_model(stored_model)
-                    ):
+                    elif _openrouter_fallback and _looks_like_openrouter_model(stored_model):
                         # OPENROUTER_API_KEY is missing, so we fell back to ModernBERT,
                         # but the existing collection was indexed with an OpenRouter model.
                         # Silently recreating would destroy the user's data — raise a clear
@@ -447,7 +450,9 @@ class Indexer:
                         )
                     else:
                         logger.info(
-                            f"Model mismatch (stored: {stored_model}, current: {current_model}) or force recreate"
+                            "Model mismatch (stored: %r, current: %r)",
+                            stored_model,
+                            current_model,
                         )
                         need_recreate = True
 
@@ -496,9 +501,32 @@ class Indexer:
                             self._stored_model_name = _stored
                         need_recreate = False
                 else:
-                    # Collection doesn't exist or other error
-                    logger.debug(f"Collection access error: {e}")
-                    need_recreate = True
+                    # Collection doesn't exist *or* Chroma raised an EF-object
+                    # conflict even though stored_model == current_model.
+                    # Peek without an embedding function before wiping: a matching
+                    # collection must be preserved (the 84k-chunk ambient-memory wipe).
+                    logger.debug("Collection access error: %s", e)
+                    if force_recreate:
+                        need_recreate = True
+                    else:
+                        try:
+                            peek = self.client.get_collection(name=collection_name)
+                        except Exception:
+                            need_recreate = True
+                        else:
+                            stored = (peek.metadata or {}).get("embedding_model", "unknown")
+                            if stored == current_model:
+                                logger.warning(
+                                    "Collection %r exists with matching model %r but could not "
+                                    "be rebound (%s); preserving it instead of recreating",
+                                    collection_name,
+                                    stored,
+                                    e,
+                                )
+                                self.collection = peek
+                                need_recreate = False
+                            else:
+                                need_recreate = True
 
         if need_recreate:
             # Delete if exists

--- a/packages/gptme-rag/src/gptme_rag/indexing/watcher.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/watcher.py
@@ -60,6 +60,8 @@ class IndexEventHandler(FileSystemEventHandler):
     def _should_process(self, path: str) -> bool:
         """Check if a file should be processed based on pattern and ignore patterns."""
         path_obj = Path(path)
+        if self._is_persist_path(path_obj):
+            return False
         return path_obj.match(self.pattern) and not any(
             path_obj.match(pattern) for pattern in self.ignore_patterns
         )
@@ -238,9 +240,9 @@ class IndexEventHandler(FileSystemEventHandler):
             logger.debug(f"Skipping non-file: {path}")
             return True
 
-        # Skip if in index directory
-        if "index" in path.parts:
-            logger.debug(f"Skipping file in index directory: {path}")
+        # Skip persist-dir internals (lock file, chroma sqlite, segment dirs)
+        if self._is_persist_path(path):
+            logger.debug(f"Skipping persist-dir artifact: {path}")
             return True
 
         # Skip binary and system files
@@ -260,6 +262,21 @@ class IndexEventHandler(FileSystemEventHandler):
 
         logger.debug(f"File will be processed: {path}")
         return False
+
+    def _is_persist_path(self, path: Path) -> bool:
+        """Skip the indexer's persist dir — those files are the index, not corpus."""
+        is_persist = getattr(self.indexer, "_is_persist_artifact", None)
+        if callable(is_persist):
+            return bool(is_persist(path))
+        persist = getattr(self.indexer, "persist_directory", None)
+        if persist is None:
+            return False
+        try:
+            persist_resolved = Path(persist).resolve()
+            resolved = path.resolve()
+        except OSError:
+            return False
+        return resolved == persist_resolved or persist_resolved in resolved.parents
 
     def _update_index_with_retries(self, path: Path, content: str, max_attempts: int = 5) -> bool:
         """Update index for a file with retries."""

--- a/packages/gptme-rag/tests/test_file_limit.py
+++ b/packages/gptme-rag/tests/test_file_limit.py
@@ -21,6 +21,32 @@ def _write_files(directory, count: int, prefix: str = "doc") -> None:
         (directory / f"{prefix}-{i:03d}.txt").write_text(f"content {i}")
 
 
+def test_get_valid_files_skips_persist_dir_artifacts(tmp_path):
+    """Files inside persist_directory are the index, not corpus, and must not be indexed.
+
+    Regression: FileWatcher.start() calls index_directory on the watched tree,
+    which contained persist_directory (tmp_path/index). The writer lock created
+    during Indexer.__init__ was ingested as an extra document, so watcher tests
+    that asserted len(results) == 1 failed.
+    """
+    persist_dir = tmp_path / "index"
+    keep = tmp_path / "keep.txt"
+    keep.write_text("corpus")
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="default",
+        collection_name="default",
+    )
+    files = indexer._get_valid_files(tmp_path)
+    names = {p.name for p in files}
+    assert "keep.txt" in names
+    assert ".gptme-rag-writer.lock" not in names
+    assert "chroma.sqlite3" not in names
+    assert all(persist_dir.resolve() not in p.parents for p in files)
+
+
 def test_get_valid_files_truncates_and_logs_error(tmp_path, caplog):
     """A directory over file_limit is truncated and the truncation is an ERROR."""
     _write_files(tmp_path, 12)

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -1,0 +1,178 @@
+"""Regression tests for same-model recreate wipes and orphan segment GC.
+
+Bob's ambient-memory index was deleted and rebuilt from zero when logs showed
+``Model mismatch (stored: modernbert, current: modernbert) or force recreate``.
+The index command uses allow_recreate=True, so two paths can wipe a live
+collection without an operator asking:
+
+1. The exception fallback: get_collection() raises (Chroma EF-object conflict
+   even when stored_model == current_model) and the handler sets
+   need_recreate=True.
+2. force_recreate=True is logged as "Model mismatch" even when the models
+   match, hiding that the wipe was requested rather than detected.
+
+These tests pin both: matching-model EF conflicts must preserve the
+collection, and force-recreate logs must not say "mismatch".
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import chromadb
+from chromadb.api.client import Client
+from chromadb.config import Settings
+from click.testing import CliRunner
+
+from gptme_rag.cli import cli
+from gptme_rag.indexing.indexer import Indexer
+
+UUID_DIR = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _make_default_collection(persist_dir: Path, *, n_docs: int = 1) -> None:
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "default",
+            "embedding_backend": "default",
+        },
+    )
+    col.add(
+        ids=[f"doc-{i}" for i in range(n_docs)],
+        embeddings=[[0.1] * 384 for _ in range(n_docs)],
+        documents=[f"keep me {i}" for i in range(n_docs)],
+    )
+    assert col.count() == n_docs
+    del client
+
+
+def test_same_model_get_collection_error_does_not_wipe(tmp_path, monkeypatch):
+    """EF-object conflict on a matching-model collection must not delete it.
+
+    Regression: Indexer.__init__ caught get_collection() failures and set
+    need_recreate=True whenever allow_recreate=True (the index command
+    default). Chroma can raise on embedding-function identity even when
+    stored_model == current_model; that wiped an 84k-chunk index.
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+
+    real_get = Client.get_collection
+    calls = {"n": 0}
+
+    def boom(self, name, embedding_function=None, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("Embedding function conflict")
+        return real_get(self, name, embedding_function=embedding_function, **kwargs)
+
+    monkeypatch.setattr(Client, "get_collection", boom)
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="default",
+        collection_name="default",
+        allow_recreate=True,
+        force_recreate=False,
+    )
+
+    assert indexer.collection.count() == 1, (
+        "Matching-model get_collection error wiped the collection — "
+        "same-model recreate-guard regression"
+    )
+    verify = chromadb.PersistentClient(
+        path=str(persist_dir),
+        settings=Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False),
+    )
+    assert verify.get_collection("default").count() == 1
+
+
+def test_force_recreate_same_model_does_not_log_mismatch(tmp_path, caplog):
+    """force_recreate with stored == current must not claim a model mismatch.
+
+    The combined log line hid that the wipe was requested, not detected —
+    operators saw ``Model mismatch (stored: X, current: X)`` and chased a
+    comparison bug that was actually --force-recreate.
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+
+    with caplog.at_level(logging.INFO, logger="gptme_rag.indexing.indexer"):
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="default",
+            collection_name="default",
+            force_recreate=True,
+        )
+
+    messages = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Model mismatch" not in messages, (
+        "force_recreate logged as a model mismatch — operators cannot tell "
+        "a requested wipe from a detected one"
+    )
+    assert "Force recreate" in messages
+    # force_recreate is allowed to wipe; this test only pins the log.
+    assert indexer.collection is not None
+
+
+def test_gc_orphan_segment_dirs_dry_run_and_apply(tmp_path):
+    """UUID dirs not listed in chroma.sqlite3 segments are orphans; others stay."""
+    from gptme_rag.indexing.gc import gc_orphan_segment_dirs
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+
+    orphan = persist_dir / UUID_DIR
+    orphan.mkdir()
+    (orphan / "data_level0.bin").write_bytes(b"stale")
+
+    live_dirs = {p.name for p in persist_dir.iterdir() if p.is_dir()}
+    assert UUID_DIR in live_dirs
+
+    dry = gc_orphan_segment_dirs(persist_dir, apply=False)
+    assert any(p.name == UUID_DIR for p in dry)
+    assert orphan.exists(), "dry-run must not delete"
+
+    applied = gc_orphan_segment_dirs(persist_dir, apply=True)
+    assert any(p.name == UUID_DIR for p in applied)
+    assert not orphan.exists(), "apply must delete the orphan UUID dir"
+    assert (persist_dir / "chroma.sqlite3").exists()
+    remaining = {p.name for p in persist_dir.iterdir() if p.is_dir()}
+    assert UUID_DIR not in remaining
+    assert remaining, "must not delete live segment dirs"
+
+
+def test_gc_orphans_cli_defaults_to_dry_run(tmp_path):
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+    orphan = persist_dir / UUID_DIR
+    orphan.mkdir()
+    (orphan / "data_level0.bin").write_bytes(b"stale")
+
+    result = CliRunner().invoke(
+        cli,
+        ["gc-orphans", "--persist-dir", str(persist_dir)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert orphan.exists(), "CLI default is dry-run"
+    assert UUID_DIR in result.output
+
+    result = CliRunner().invoke(
+        cli,
+        ["gc-orphans", "--persist-dir", str(persist_dir), "--apply"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert not orphan.exists()

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -385,6 +385,37 @@ def test_gc_orphans_catalog_error_is_not_reported_as_clean(tmp_path):
     assert "No orphan segment dirs" not in result.output
 
 
+def test_gc_orphans_oserror_is_not_a_traceback(tmp_path):
+    """Permission errors on persist-dir access must exit 1 with a clean message.
+
+    Regression: gc_orphan_segment_dirs only wrapped sqlite3.Error, so
+    iterdir/lock-file OSError leaked as a traceback. The CLI is dry-run
+    by default and should report a permission error, not dump frames.
+    """
+    from gptme_rag.indexing.gc import ChromaCatalogError, gc_orphan_segment_dirs
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+
+    with patch(
+        "gptme_rag.indexing.gc._collect_orphans",
+        side_effect=PermissionError("read-only persist dir"),
+    ):
+        with pytest.raises(ChromaCatalogError, match="read-only persist dir"):
+            gc_orphan_segment_dirs(persist_dir)
+        result = CliRunner().invoke(
+            cli,
+            ["gc-orphans", "--persist-dir", str(persist_dir)],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code != 0
+    assert "No orphan segment dirs" not in result.output
+    assert "Traceback" not in result.output
+    assert "Cannot access" in result.output
+
+
 def test_gc_orphans_handles_question_mark_in_persist_path(tmp_path):
     from gptme_rag.indexing.gc import gc_orphan_segment_dirs
 

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -21,24 +21,41 @@ import logging
 from pathlib import Path
 
 import chromadb
+import pytest
 from chromadb.api.client import Client
 from chromadb.config import Settings
 from click.testing import CliRunner
 
 from gptme_rag.cli import cli
-from gptme_rag.indexing.indexer import Indexer
+from gptme_rag.indexing.document import Document
+from gptme_rag.indexing.indexer import Indexer, ModernBERTEmbedding
 
 UUID_DIR = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
 
-def _make_default_collection(persist_dir: Path, *, n_docs: int = 1) -> None:
+def _stub_modernbert(monkeypatch) -> None:
+    """Make ModernBERTEmbedding constructible without loading 768-dim weights.
+
+    Patching the class itself would break the ``isinstance`` checks the indexer
+    uses to name the current model, so stub the instance methods instead.
+    """
+    monkeypatch.setattr(ModernBERTEmbedding, "__init__", lambda self, **kw: None)
+    monkeypatch.setattr(
+        ModernBERTEmbedding,
+        "__call__",
+        lambda self, input: [[0.1] * 768 for _ in input],  # noqa: A002
+    )
+    monkeypatch.setattr(ModernBERTEmbedding, "is_msmarco", False, raising=False)
+
+
+def _make_default_collection(persist_dir: Path, *, n_docs: int = 1, model: str = "default") -> None:
     settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
     client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
     col = client.create_collection(
         name="default",
         metadata={
             "hnsw:space": "cosine",
-            "embedding_model": "default",
+            "embedding_model": model,
             "embedding_backend": "default",
         },
     )
@@ -176,3 +193,102 @@ def test_gc_orphans_cli_defaults_to_dry_run(tmp_path):
     )
     assert result.exit_code == 0, result.output
     assert not orphan.exists()
+
+
+def test_preserved_collection_keeps_custom_embedding_function(tmp_path, monkeypatch):
+    """A preserved handle must write with OUR embedder, not Chroma's default.
+
+    Regression: the preserve branch assigned the handle returned by
+    ``get_collection(name=...)`` — fetched deliberately without an embedding
+    function — straight to ``self.collection``. ``_add_documents`` calls
+    ``collection.add(documents=...)`` with no explicit ``embeddings=``, so that
+    handle embeds with Chroma's default 384-dim MiniLM and raises
+    InvalidDimensionException against 768-dim ModernBERT vectors. Preserving a
+    collection you can no longer write to is not preserving it.
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir, model="modernbert")
+
+    _stub_modernbert(monkeypatch)
+
+    real_get = Client.get_collection
+    calls = {"n": 0}
+
+    def boom(self, name, embedding_function=None, **kwargs):
+        calls["n"] += 1
+        if embedding_function is not None:
+            raise ValueError("Embedding function conflict")
+        return real_get(self, name, embedding_function=None, **kwargs)
+
+    monkeypatch.setattr(Client, "get_collection", boom)
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="modernbert",
+        collection_name="default",
+        allow_recreate=True,
+        force_recreate=False,
+    )
+
+    assert indexer.collection.count() == 1, "matching-model EF conflict wiped the collection"
+    assert indexer.collection._embedding_function is indexer.embedding_function, (
+        "preserved collection still carries Chroma's default embedder — writes "
+        "would embed at the wrong dimension"
+    )
+    assert indexer._stored_model_name is None, (
+        "rebinding succeeded, so the collection is writable; the read-only "
+        "fail-loud guard must not be armed"
+    )
+
+
+def test_preserve_fails_loud_when_rebinding_is_impossible(tmp_path, monkeypatch):
+    """If the EF cannot be rebound, arm the guard rather than write bad vectors.
+
+    Chroma internals are not API. If a future version drops the attribute we
+    bind to, the collection must become read-only with a clear RuntimeError
+    instead of silently embedding at the default dimension.
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir, model="modernbert")
+
+    _stub_modernbert(monkeypatch)
+    monkeypatch.setattr(Indexer, "_bind_embedding_function", lambda self, col: False)
+
+    real_get = Client.get_collection
+
+    def boom(self, name, embedding_function=None, **kwargs):
+        if embedding_function is not None:
+            raise ValueError("Embedding function conflict")
+        return real_get(self, name, embedding_function=None, **kwargs)
+
+    monkeypatch.setattr(Client, "get_collection", boom)
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="modernbert",
+        collection_name="default",
+        allow_recreate=True,
+        force_recreate=False,
+    )
+
+    assert indexer.collection.count() == 1, "fail-loud path must still preserve the data"
+    assert indexer._stored_model_name == "modernbert"
+    assert indexer.embedding_function is None
+    doc = Document(content="x", metadata={"source": "x.md"}, doc_id="x")
+    with pytest.raises(RuntimeError, match="stored embedding model"):
+        indexer.add_document(doc)
+
+
+def test_bind_embedding_function_reports_failure_on_unknown_handle():
+    """Version drift must be detectable so callers can fail loud, not silently."""
+    indexer = Indexer.__new__(Indexer)
+    indexer.embedding_function = object()
+
+    class Opaque:
+        __slots__ = ()
+
+    assert indexer._bind_embedding_function(Opaque()) is False

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -416,6 +416,42 @@ def test_gc_orphans_oserror_is_not_a_traceback(tmp_path):
     assert "Cannot access" in result.output
 
 
+def test_gc_orphans_preserves_live_uuid_dir_case_insensitive(tmp_path):
+    """Uppercase UUID dir whose lowercase id is in the catalog is live, not orphan.
+
+    Regression: _UUID_DIR is IGNORECASE but membership was exact-case. On a
+    case-insensitive filesystem (macOS default) that combination would rmtree
+    a live segment whose on-disk name used uppercase hex.
+    """
+    import sqlite3
+
+    from gptme_rag.indexing.gc import gc_orphan_segment_dirs
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    live_id = UUID_DIR
+    upper_live = persist_dir / live_id.upper()
+    upper_live.mkdir()
+    (upper_live / "data_level0.bin").write_bytes(b"live")
+    real_orphan = persist_dir / "11111111-2222-3333-4444-555555555555"
+    real_orphan.mkdir()
+
+    con = sqlite3.connect(str(persist_dir / "chroma.sqlite3"))
+    con.execute("CREATE TABLE segments (id TEXT)")
+    con.execute("INSERT INTO segments (id) VALUES (?)", (live_id,))
+    con.commit()
+    con.close()
+
+    dry = gc_orphan_segment_dirs(persist_dir, apply=False)
+    names = {p.name for p in dry}
+    assert upper_live.name not in names
+    assert real_orphan.name in names
+
+    gc_orphan_segment_dirs(persist_dir, apply=True)
+    assert upper_live.exists(), "case-variant of a catalogued UUID must not be deleted"
+    assert not real_orphan.exists()
+
+
 def test_gc_orphans_handles_question_mark_in_persist_path(tmp_path):
     from gptme_rag.indexing.gc import gc_orphan_segment_dirs
 

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -416,6 +416,46 @@ def test_gc_orphans_oserror_is_not_a_traceback(tmp_path):
     assert "Cannot access" in result.output
 
 
+def test_allow_recreate_false_peek_failure_does_not_wipe(tmp_path, monkeypatch):
+    """Read-only Indexer must not delete a live collection if peek also fails.
+
+    Regression: the ``not allow_recreate`` except branch set
+    ``need_recreate=True`` when the EF-less ``get_collection()`` raised
+    (transient sqlite lock, permission, missing-looking catalog). The later
+    ``if need_recreate`` block then deleted and recreated the collection,
+    wiping it from search/status.
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir, n_docs=3)
+
+    real_get = Client.get_collection
+
+    def boom(self, name, embedding_function=None, **kwargs):
+        raise ValueError("Embedding function conflict")
+
+    monkeypatch.setattr(Client, "get_collection", boom)
+
+    with pytest.raises(RuntimeError, match="recreation is disabled"):
+        Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="default",
+            collection_name="default",
+            allow_recreate=False,
+        )
+
+    monkeypatch.setattr(Client, "get_collection", real_get)
+    verify = chromadb.PersistentClient(
+        path=str(persist_dir),
+        settings=Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False),
+    )
+    assert verify.get_collection("default").count() == 3, (
+        "allow_recreate=False peek failure wiped the collection — "
+        "read-only recreate-guard regression"
+    )
+
+
 def test_gc_orphans_preserves_live_uuid_dir_case_insensitive(tmp_path):
     """Uppercase UUID dir whose lowercase id is in the catalog is live, not orphan.
 

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -456,6 +456,48 @@ def test_allow_recreate_false_peek_failure_does_not_wipe(tmp_path, monkeypatch):
     )
 
 
+def test_allow_recreate_true_peek_failure_does_not_wipe(tmp_path, monkeypatch):
+    """index-command Indexer must not delete a live collection if peek also fails.
+
+    Regression: the allow_recreate=True except branch treated a failed
+    EF-less get_collection() as "collection missing" and set
+    need_recreate=True. Recreate deletes first, so a transient sqlite
+    lock during a concurrent write would wipe a matching live collection
+    (the original 84k-chunk incident, still open on the write path after
+    the read-only guard).
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir, n_docs=3)
+
+    real_get = Client.get_collection
+
+    def boom(self, name, embedding_function=None, **kwargs):
+        raise ValueError("database is locked")
+
+    monkeypatch.setattr(Client, "get_collection", boom)
+
+    with pytest.raises(RuntimeError, match="not confirmed missing"):
+        Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="default",
+            collection_name="default",
+            allow_recreate=True,
+            force_recreate=False,
+        )
+
+    monkeypatch.setattr(Client, "get_collection", real_get)
+    verify = chromadb.PersistentClient(
+        path=str(persist_dir),
+        settings=Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False),
+    )
+    assert verify.get_collection("default").count() == 3, (
+        "allow_recreate=True peek failure wiped the collection — "
+        "write-path recreate-guard regression"
+    )
+
+
 def test_gc_orphans_preserves_live_uuid_dir_case_insensitive(tmp_path):
     """Uppercase UUID dir whose lowercase id is in the catalog is live, not orphan.
 

--- a/packages/gptme-rag/tests/test_same_model_recreate_guard.py
+++ b/packages/gptme-rag/tests/test_same_model_recreate_guard.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import chromadb
 import pytest
@@ -292,3 +293,131 @@ def test_bind_embedding_function_reports_failure_on_unknown_handle():
         __slots__ = ()
 
     assert indexer._bind_embedding_function(Opaque()) is False
+
+
+def test_auto_mode_rebinds_preserved_collection(tmp_path, monkeypatch):
+    """Auto mode must not leave Chroma's default EF on a matching-model handle.
+
+    The auto exception path used to assign the EF-less peek handle and skip
+    ``_bind_embedding_function``. Writes then embedded with MiniLM against a
+    ModernBERT collection.
+    """
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir, model="modernbert")
+    _stub_modernbert(monkeypatch)
+
+    real_get = Client.get_collection
+
+    def boom(self, name, embedding_function=None, **kwargs):
+        if embedding_function is not None:
+            raise ValueError("Embedding function conflict")
+        return real_get(self, name, embedding_function=None, **kwargs)
+
+    monkeypatch.setattr(Client, "get_collection", boom)
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+        allow_recreate=True,
+        force_recreate=False,
+    )
+
+    assert indexer.collection.count() == 1
+    assert indexer.collection._embedding_function is indexer.embedding_function
+    assert indexer._stored_model_name is None
+
+
+def test_gc_orphans_refuses_apply_while_writer_lock_is_held(tmp_path):
+    """flock is per-open-file-description; same-process double-open does not
+    conflict, so the holder must be a child process."""
+    import subprocess
+    import sys
+
+    from gptme_rag.indexing.gc import gc_orphan_segment_dirs
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+    orphan = persist_dir / UUID_DIR
+    orphan.mkdir()
+    lock_path = persist_dir / ".gptme-rag-writer.lock"
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import fcntl, os, sys, time\n"
+            "fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)\n"
+            "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+            "sys.stdout.write('locked\\n')\n"
+            "sys.stdout.flush()\n"
+            "time.sleep(30)\n",
+            str(lock_path),
+        ],
+        stdout=subprocess.PIPE,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline() == b"locked\n"
+        with pytest.raises(RuntimeError, match="index writer is active"):
+            gc_orphan_segment_dirs(persist_dir, apply=True)
+    finally:
+        holder.kill()
+        holder.wait()
+
+    assert orphan.exists()
+
+
+def test_gc_orphans_catalog_error_is_not_reported_as_clean(tmp_path):
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    (persist_dir / "chroma.sqlite3").write_bytes(b"not sqlite")
+
+    result = CliRunner().invoke(
+        cli,
+        ["gc-orphans", "--persist-dir", str(persist_dir)],
+    )
+
+    assert result.exit_code != 0
+    assert "No orphan segment dirs" not in result.output
+
+
+def test_gc_orphans_handles_question_mark_in_persist_path(tmp_path):
+    from gptme_rag.indexing.gc import gc_orphan_segment_dirs
+
+    persist_dir = tmp_path / "index?literal"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+    orphan = persist_dir / UUID_DIR
+    orphan.mkdir()
+
+    assert orphan in gc_orphan_segment_dirs(persist_dir)
+
+
+def test_gc_orphans_continues_after_one_delete_failure(tmp_path):
+    from gptme_rag.indexing.gc import gc_orphan_segment_dirs
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    _make_default_collection(persist_dir)
+    first = persist_dir / UUID_DIR
+    second = persist_dir / "11111111-2222-3333-4444-555555555555"
+    first.mkdir()
+    second.mkdir()
+
+    real_rmtree = __import__("shutil").rmtree
+
+    def fail_first(path, *args, **kwargs):
+        if Path(path) == first:
+            raise PermissionError("read-only")
+        return real_rmtree(path, *args, **kwargs)
+
+    with patch("gptme_rag.indexing.gc.shutil.rmtree", side_effect=fail_first):
+        removed = gc_orphan_segment_dirs(persist_dir, apply=True)
+
+    assert first.exists()
+    assert not second.exists()
+    assert removed == [second]


### PR DESCRIPTION
## Problem

`Indexer.__init__` treated any `get_collection()` failure as "collection missing" when `allow_recreate=True` (the `index` command default). Chroma can raise on embedding-function *object identity* even when `stored_model == current_model`. That path deleted Bob's 84k-chunk ambient-memory index and left ~42 orphan UUID dirs.

Logs made it worse: `--force-recreate` and a real model mismatch shared one line (`Model mismatch (stored: X, current: X) or force recreate`), so operators chased a comparison bug that was often just a requested wipe.

## Fix

- On `get_collection()` failure, peek **without** an embedding function. If the collection exists and `stored_model == current_model`, preserve it instead of recreating.
- Split the log: `Force recreate requested` vs `Model mismatch`.
- Add `gptme-rag gc-orphans` (dry-run by default, `--apply` to delete) for leftover Chroma UUID dirs not listed in `segments`/`collections`.

## Tests

`tests/test_same_model_recreate_guard.py`:
- matching-model EF conflict does not wipe
- force-recreate does not log "Model mismatch"
- GC dry-run vs `--apply`

Existing recreate/wipe tests still pass. `make typecheck` clean.

## Out of scope

- Does **not** run GC against a live persist dir (Bob's catch-up is still writing).
- Content-hash change detection is gptme-contrib#1534 (still open). This PR is the recreate-guard half of the same incident.

Step 3.4 of `vitals-regen-index-cpu-burn-loop`.
