### PR TITLE
fix(gptodo): retry transient Claude auth failures once

### DIFF
--- a/packages/gptodo/src/gptodo/auth.py
+++ b/packages/gptodo/src/gptodo/auth.py
@@ -10,7 +10,7 @@ DEFAULT_MAX_BYTES = 2000
 
 _AUTH_FAILURE_RE = re.compile(
     rb"\b401\b|unauthorized|invalid authentication credentials|"
-    rb"invalid bearer token|authentication_(?:error|failed)|"
+    rb"invalid bearer token|authentication[ _](?:error|failed)|"
     rb"oauth.{0,40}(?:expired|fail|error|invalid)|please run /login",
     re.IGNORECASE,
 )

--- a/packages/gptodo/src/gptodo/auth.py
+++ b/packages/gptodo/src/gptodo/auth.py
@@ -1,0 +1,47 @@
+"""Classify short-lived Claude Code authentication failures."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+DEFAULT_MAX_BYTES = 2000
+
+_AUTH_FAILURE_RE = re.compile(
+    rb"\b401\b|unauthorized|invalid authentication credentials|"
+    rb"invalid bearer token|authentication_(?:error|failed)|"
+    rb"oauth.{0,40}(?:expired|fail|error|invalid)|please run /login",
+    re.IGNORECASE,
+)
+
+
+def is_transient_auth_death(output: str | bytes, max_bytes: int = DEFAULT_MAX_BYTES) -> bool:
+    """Return whether a small output contains a Claude auth-failure signature.
+
+    The size gate is required: a successful agent can produce a large transcript
+    that discusses HTTP 401 without having failed authentication itself.
+    """
+    data = output.encode(errors="replace") if isinstance(output, str) else output
+    return 0 < len(data) <= max_bytes and bool(_AUTH_FAILURE_RE.search(data))
+
+
+def is_auth_death_file(path: Path, max_bytes: int = DEFAULT_MAX_BYTES) -> bool:
+    """Classify a captured process output file, returning False if unreadable."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return False
+    return is_transient_auth_death(data, max_bytes=max_bytes)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--classify-file", type=Path, required=True)
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    args = parser.parse_args(argv)
+    return 0 if is_auth_death_file(args.classify_file, args.max_bytes) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -252,7 +252,21 @@ def spawn_agent(
                 # retry happens inside tmux so check_session keeps one session ID.
                 python = shlex.quote(sys.executable)
                 auth_check = f"{python} -m gptodo.auth --classify-file {safe_output}"
-                shell_cmd = f'touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; if [ "$EXIT_CODE" -ne 0 ] && {auth_check}; then cp {safe_output} {safe_output}.first-auth-failure; sleep 5; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; fi; echo "EXIT_CODE=$EXIT_CODE" >> {safe_output}; kill $TAIL_PID 2>/dev/null'
+                # Concatenate the classifier so the shell never sees a
+                # `{auth_check}` token. That is a Python f-string field, not a
+                # bash brace group (`{ cmd; }`).
+                shell_cmd = (
+                    f"touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; "
+                    f"{claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; "
+                    'if [ "$EXIT_CODE" -ne 0 ] && '
+                    + auth_check
+                    + (
+                        f"; then cp {safe_output} {safe_output}.first-auth-failure; "
+                        f"sleep 5; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; fi; "
+                        f'echo "EXIT_CODE=$EXIT_CODE" >> {safe_output}; '
+                        "kill $TAIL_PID 2>/dev/null"
+                    )
+                )
             else:
                 # Non-gptme non-claude (codex) still launches `claude -p` today;
                 # keep that pre-existing command, but do not apply Claude-only retry.

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -391,8 +391,11 @@ def spawn_agent(
 
         if backend == "claude" and result.returncode != 0 and is_transient_auth_death(output):
             logger.warning("Claude authentication failed; retrying once after 5 seconds")
-            time.sleep(5)
             first_auth_failure = output
+            # Persist before the retry so a TimeoutExpired/exception on the
+            # second run cannot leave the session output file empty.
+            output_file.write_text(first_auth_failure)
+            time.sleep(5)
             result = subprocess.run(
                 cmd,
                 cwd=workspace,

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -247,11 +247,16 @@ def spawn_agent(
                 else ""
             )
             claude_cmd = f'{timeout_prefix}claude -p {model_arg} {sysprompt_arg} --dangerously-skip-permissions --tools default -- "$(cat {safe_prompt_file})"'
-            # Run the classifier in gptodo's current Python environment. The
-            # retry happens inside tmux so check_session keeps one session ID.
-            python = shlex.quote(sys.executable)
-            auth_check = f"{python} -m gptodo.auth --classify-file {safe_output}"
-            shell_cmd = f'touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; if [ "$EXIT_CODE" -ne 0 ] && {auth_check}; then cp {safe_output} {safe_output}.first-auth-failure; sleep 5; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; fi; echo "EXIT_CODE=$EXIT_CODE" >> {safe_output}; kill $TAIL_PID 2>/dev/null'
+            if backend == "claude":
+                # Run the classifier in gptodo's current Python environment. The
+                # retry happens inside tmux so check_session keeps one session ID.
+                python = shlex.quote(sys.executable)
+                auth_check = f"{python} -m gptodo.auth --classify-file {safe_output}"
+                shell_cmd = f'touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; if [ "$EXIT_CODE" -ne 0 ] && {auth_check}; then cp {safe_output} {safe_output}.first-auth-failure; sleep 5; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; fi; echo "EXIT_CODE=$EXIT_CODE" >> {safe_output}; kill $TAIL_PID 2>/dev/null'
+            else:
+                # Non-gptme non-claude (codex) still launches `claude -p` today;
+                # keep that pre-existing command, but do not apply Claude-only retry.
+                shell_cmd = f'touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; {claude_cmd} > {safe_output} 2>&1; echo "EXIT_CODE=$?" >> {safe_output}; kill $TAIL_PID 2>/dev/null'
 
         # Build environment exports for critical API keys
         # These may not be inherited by tmux detached sessions

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -13,11 +13,15 @@ import logging
 import os
 import shlex
 import subprocess
+import sys
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
+
+from gptodo.auth import is_transient_auth_death
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +246,12 @@ def spawn_agent(
                 if system_prompt_file
                 else ""
             )
-            shell_cmd = f'touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; {timeout_prefix}claude -p {model_arg} {sysprompt_arg} --dangerously-skip-permissions --tools default -- "$(cat {safe_prompt_file})" > {safe_output} 2>&1; echo "EXIT_CODE=$?" >> {safe_output}; kill $TAIL_PID 2>/dev/null'
+            claude_cmd = f'{timeout_prefix}claude -p {model_arg} {sysprompt_arg} --dangerously-skip-permissions --tools default -- "$(cat {safe_prompt_file})"'
+            # Run the classifier in gptodo's current Python environment. The
+            # retry happens inside tmux so check_session keeps one session ID.
+            python = shlex.quote(sys.executable)
+            auth_check = f"{python} -m gptodo.auth --classify-file {safe_output}"
+            shell_cmd = f'touch {safe_output}; tail -f {safe_output} & TAIL_PID=$!; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; if [ "$EXIT_CODE" -ne 0 ] && {auth_check}; then cp {safe_output} {safe_output}.first-auth-failure; sleep 5; {claude_cmd} > {safe_output} 2>&1; EXIT_CODE=$?; fi; echo "EXIT_CODE=$EXIT_CODE" >> {safe_output}; kill $TAIL_PID 2>/dev/null'
 
         # Build environment exports for critical API keys
         # These may not be inherited by tmux detached sessions
@@ -373,9 +382,29 @@ def spawn_agent(
             timeout=timeout if timeout > 0 else None,
             env=env,
         )
+        output = result.stdout + "\n" + result.stderr
 
-        # Save output
-        output_file.write_text(result.stdout + "\n" + result.stderr)
+        if backend == "claude" and result.returncode != 0 and is_transient_auth_death(output):
+            logger.warning("Claude authentication failed; retrying once after 5 seconds")
+            time.sleep(5)
+            first_auth_failure = output
+            result = subprocess.run(
+                cmd,
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                timeout=timeout if timeout > 0 else None,
+                env=env,
+            )
+            output = (
+                first_auth_failure
+                + "\n=== Retried after transient authentication failure ===\n"
+                + result.stdout
+                + "\n"
+                + result.stderr
+            )
+
+        output_file.write_text(output)
 
         session.status = "completed" if result.returncode == 0 else "failed"
         session.completed_at = datetime.now(timezone.utc).isoformat()

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -1,16 +1,19 @@
 """Tests for subagent session management."""
 
+import subprocess
 from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
 
+from gptodo.auth import is_transient_auth_death
 from gptodo.subagent import (
     AgentSession,
     _setup_coordination,
     list_sessions,
     load_session,
     save_session,
+    spawn_agent,
 )
 
 
@@ -81,6 +84,83 @@ def test_load_corrupted_session(sessions_dir):
     (sd / "corrupt.json").write_text("not valid json")
     loaded = load_session("corrupt", sessions_dir)
     assert loaded is None
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "401 Invalid authentication credentials",
+        '{"error":"authentication_failed"}',
+        '{"type":"authentication_error"}',
+        "Unauthorized: please run /login",
+    ],
+)
+def test_transient_auth_death_signatures(output):
+    assert is_transient_auth_death(output)
+
+
+def test_transient_auth_death_requires_small_output():
+    assert not is_transient_auth_death("401\n" + "x" * 3000)
+
+
+def test_transient_auth_death_uses_encoded_byte_size():
+    assert not is_transient_auth_death("401 " + "å" * 1000, max_bytes=1500)
+
+
+@patch("gptodo.subagent.time.sleep")
+@patch("gptodo.subagent.subprocess.run")
+def test_claude_foreground_retries_tiny_auth_failure_once(run, sleep, sessions_dir):
+    run.side_effect = [
+        subprocess.CompletedProcess([], 1, "", "Error: 401 Invalid authentication credentials"),
+        subprocess.CompletedProcess([], 0, "done", ""),
+    ]
+
+    session = spawn_agent("task", "prompt", backend="claude", workspace=sessions_dir)
+
+    assert session.status == "completed"
+    assert run.call_count == 2
+    sleep.assert_called_once_with(5)
+    assert "Invalid authentication credentials" in open(session.output_file).read()
+    assert "done" in open(session.output_file).read()
+
+
+@patch("gptodo.subagent.time.sleep")
+@patch("gptodo.subagent.subprocess.run")
+def test_claude_foreground_does_not_retry_large_output_mentioning_401(run, sleep, sessions_dir):
+    run.return_value = subprocess.CompletedProcess([], 1, "401\n" + "x" * 3000, "")
+
+    session = spawn_agent("task", "prompt", backend="claude", workspace=sessions_dir)
+
+    assert session.status == "failed"
+    run.assert_called_once()
+    sleep.assert_not_called()
+
+
+@patch("gptodo.subagent.time.sleep")
+@patch("gptodo.subagent.subprocess.run")
+def test_claude_foreground_retries_only_once(run, sleep, sessions_dir):
+    failure = subprocess.CompletedProcess([], 1, "", "authentication_failed")
+    run.side_effect = [failure, failure]
+
+    session = spawn_agent("task", "prompt", backend="claude", workspace=sessions_dir)
+
+    assert session.status == "failed"
+    assert run.call_count == 2
+    sleep.assert_called_once_with(5)
+
+
+@patch("gptodo.subagent.subprocess.run")
+def test_claude_background_command_retries_auth_failure(run, sessions_dir):
+    run.return_value = subprocess.CompletedProcess([], 0, "", "")
+
+    spawn_agent("task", "prompt", backend="claude", background=True, workspace=sessions_dir)
+
+    tmux_command = run.call_args.args[0][-1]
+    assert tmux_command.count("claude -p") == 2
+    assert "gptodo.auth --classify-file" in tmux_command
+    assert ".first-auth-failure" in tmux_command
+    assert "sleep 5" in tmux_command
+    assert "EXIT_CODE=$EXIT_CODE" in tmux_command
 
 
 # --- Coordination tests ---

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -1,5 +1,6 @@
 """Tests for subagent session management."""
 
+import shlex
 import subprocess
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -180,6 +181,14 @@ def test_claude_background_command_retries_auth_failure(run, sessions_dir):
     assert ".first-auth-failure" in tmux_command
     assert "sleep 5" in tmux_command
     assert "EXIT_CODE=$EXIT_CODE" in tmux_command
+    inner = shlex.split(tmux_command)[-1]
+    assert "{auth_check}" not in inner
+    syntax = subprocess.run(
+        ["bash", "-n", "-c", inner],
+        capture_output=True,
+        text=True,
+    )
+    assert syntax.returncode == 0, syntax.stderr
 
 
 @patch("gptodo.subagent.subprocess.run")

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -151,6 +151,23 @@ def test_claude_foreground_retries_only_once(run, sleep, sessions_dir):
     sleep.assert_called_once_with(5)
 
 
+@patch("gptodo.subagent.time.sleep")
+@patch("gptodo.subagent.subprocess.run")
+def test_claude_foreground_preserves_first_auth_output_if_retry_times_out(run, sleep, sessions_dir):
+    run.side_effect = [
+        subprocess.CompletedProcess([], 1, "", "Error: 401 Invalid authentication credentials"),
+        subprocess.TimeoutExpired(cmd="claude", timeout=1),
+    ]
+
+    session = spawn_agent("task", "prompt", backend="claude", workspace=sessions_dir)
+
+    assert session.status == "failed"
+    assert "Timeout" in (session.error or "")
+    assert "Invalid authentication credentials" in open(session.output_file).read()
+    assert run.call_count == 2
+    sleep.assert_called_once_with(5)
+
+
 @patch("gptodo.subagent.subprocess.run")
 def test_claude_background_command_retries_auth_failure(run, sessions_dir):
     run.return_value = subprocess.CompletedProcess([], 0, "", "")

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -93,6 +93,8 @@ def test_load_corrupted_session(sessions_dir):
         '{"error":"authentication_failed"}',
         '{"type":"authentication_error"}',
         "Unauthorized: please run /login",
+        "Authentication failed",
+        "Authentication error",
     ],
 )
 def test_transient_auth_death_signatures(output):
@@ -161,6 +163,18 @@ def test_claude_background_command_retries_auth_failure(run, sessions_dir):
     assert ".first-auth-failure" in tmux_command
     assert "sleep 5" in tmux_command
     assert "EXIT_CODE=$EXIT_CODE" in tmux_command
+
+
+@patch("gptodo.subagent.subprocess.run")
+def test_codex_background_command_does_not_retry_auth_failure(run, sessions_dir):
+    run.return_value = subprocess.CompletedProcess([], 0, "", "")
+
+    spawn_agent("task", "prompt", backend="codex", background=True, workspace=sessions_dir)
+
+    tmux_command = run.call_args.args[0][-1]
+    assert "gptodo.auth --classify-file" not in tmux_command
+    assert ".first-auth-failure" not in tmux_command
+    assert tmux_command.count("sleep 5") == 0
 
 
 # --- Coordination tests ---


### PR DESCRIPTION
## Summary

- add a 2 KiB size-gated classifier for Claude Code authentication failures
- retry foreground and background/tmux Claude spawns once after a 5-second backoff
- preserve the first auth-failure output for diagnosis and retain the original failure behavior for non-auth errors

## Verification

- `uv run --package gptodo pytest packages/gptodo/tests/test_subagent.py -q` (19 passed)
- `make typecheck-packages`
- pre-commit hooks passed on commit
- full gptodo suite: 554 passed; one unrelated existing failure in `test_skip_claimed.py::TestGetClaimedTaskIds::test_excludes_own_agent_claims` due to the ambient `GIT_COMMITTER_SESSION_ID` overriding the test's `AGENT_ID=me`

Closes gptme/gptme-contrib#1536
