### PR TITLE
fix(gptodo): emit waiting_for/waiting_since on recurrence reset

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2956,7 +2956,7 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # Strip now-stale actionable/blocker metadata when the edit lands the task
         # in a terminal state (TASKS.md best-practice #7: terminal tasks must not
         # keep next_action/waiting_for/waiting_since/wait). Recurring tasks reset to
-        # todo further below and must keep these fields, so skip when recur is set.
+        # waiting further below and must keep these fields, so skip when recur is set.
         # tracking_issue / upstream_coordination_id are intentionally preserved for
         # permanent traceability.
         # cancelled is terminal regardless of recur. A done task only escapes the
@@ -3085,15 +3085,20 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
 
                     current_wait = parse_wait(post.metadata.get("wait"))
                     next_wait = advance_wait(current_wait, recur)
+                    wait_iso = next_wait.isoformat()
                     post.metadata["state"] = "waiting"
-                    post.metadata["wait"] = next_wait.isoformat()
+                    post.metadata["wait"] = wait_iso
                     post.metadata["wait_kind"] = "machine"
-                    # Strip any pre-existing waiting_for/waiting_since: the wait: date IS the
-                    # machine gate. Leaving them would trap the task permanently — task_has_waiting_blocker
-                    # treats any waiting_for as a human blocker that requires explicit resolution,
-                    # so the task would never auto-surface after the time gate expires.
-                    post.metadata.pop("waiting_for", None)
-                    post.metadata.pop("waiting_since", None)
+                    # validate_task_frontmatter requires waiting_for + waiting_since
+                    # on state=waiting. A leftover human blocker (e.g. "John to review")
+                    # would trap the task after the gate expires, so REPLACE it with a
+                    # recurrence-gate string. "next recurrence gate (wait: <date>)" is
+                    # classified as a time_gate by the auto-releaser, so the task
+                    # re-surfaces when wait: expires.
+                    post.metadata["waiting_for"] = f"next recurrence gate (wait: {wait_iso})"
+                    post.metadata["waiting_since"] = datetime.now(timezone.utc).isoformat(
+                        timespec="seconds"
+                    )
                     if not _completed_explicitly_set_global:
                         post.metadata.pop("completed", None)
                     with open(task.path, "w") as f:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3520,12 +3520,7 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
             task
             for task in all_tasks
             if task.state in ["backlog", "todo", "active"]
-            or (
-                task.state == "waiting"
-                and task.metadata.get("wait_kind") == "machine"
-                and not task_is_waiting_for_date(task)
-                and not task.metadata.get("waiting_for")
-            )
+            or (task.state == "waiting" and not task_has_waiting_blocker(task))
         ]
 
     # Apply pool filter (default: general only; --pool all to see every pool)
@@ -3761,12 +3756,7 @@ def next_(output_json, use_cache, pool_filter, exclude_pool, limit, order):
         task
         for task in all_tasks
         if task.state in ["backlog", "todo", "active"]
-        or (
-            task.state == "waiting"
-            and task.metadata.get("wait_kind") == "machine"
-            and not task_is_waiting_for_date(task)
-            and not task.metadata.get("waiting_for")
-        )
+        or (task.state == "waiting" and not task_has_waiting_blocker(task))
     ]
 
     # Apply pool filter (default: general only; --pool all to see every pool)

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2993,6 +2993,18 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                 post.metadata.pop("waiting_for", None)
                 post.metadata.pop("waiting_since", None)
                 post.metadata.pop("wait_kind", None)
+        # Drop generated recurrence-gate waiting_for whenever the final state
+        # is not waiting, even if this edit did not touch wait. A state-only
+        # `--set state todo` used to skip the wait-sync (gated on wait_was_set)
+        # and leave waiting_for, which task_has_waiting_blocker treats as a
+        # human blocker on non-waiting states (P1 on gptme/gptme-contrib#1539
+        # / 69034e96). Keep wait: — the user did not ask to clear the date.
+        if post.metadata.get("state") != "waiting" and is_generated_recurrence_waiting_for(
+            post.metadata.get("waiting_for", "")
+        ):
+            post.metadata.pop("waiting_for", None)
+            post.metadata.pop("waiting_since", None)
+            post.metadata.pop("wait_kind", None)
         # Auto-set waiting_since only when THIS edit explicitly sets state to waiting
         # AND waiting_for is either already present or being set in the same edit.
         # Guarding on waiting_for prevents an injected waiting_since from triggering

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2972,7 +2972,10 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                 explicit_state = any(
                     op == "set" and field == "state" for op, field, _value in changes
                 )
-                if not explicit_state:
+                # Only default waiting → todo. A leftover recurrence-gate
+                # string on done/cancelled/active must not reopen or demote
+                # the task (P1 on gptme/gptme-contrib#1539 / ecb15242).
+                if not explicit_state and post.metadata.get("state") == "waiting":
                     post.metadata["state"] = "todo"
                 post.metadata.pop("waiting_for", None)
                 post.metadata.pop("waiting_since", None)

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2964,14 +2964,28 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
             )
             if recurrence_gate and wait_set is None:
                 # Clearing a generated recurrence gate means it is no longer
-                # waiting. Remove the generated blocker metadata as one unit so
-                # the task cannot be left permanently blocked without a date.
-                post.metadata["state"] = "todo"
+                # a machine time-gate. Remove the generated blocker metadata as
+                # one unit so the task cannot stay permanently blocked without
+                # a date. Only default state to todo when this edit did not
+                # set state — `--set wait none --set state done` must not
+                # overwrite the explicit state (P1 on gptme/gptme-contrib#1539).
+                explicit_state = any(
+                    op == "set" and field == "state" for op, field, _value in changes
+                )
+                if not explicit_state:
+                    post.metadata["state"] = "todo"
                 post.metadata.pop("waiting_for", None)
                 post.metadata.pop("waiting_since", None)
                 post.metadata.pop("wait_kind", None)
             elif recurrence_gate and post.metadata.get("state") == "waiting":
                 post.metadata["waiting_for"] = f"next recurrence gate (wait: {wait_set})"
+            elif recurrence_gate:
+                # Wait changed but the task is no longer waiting. Drop the
+                # generated recurrence string so it cannot trap a todo/done
+                # task as a leftover human-looking blocker.
+                post.metadata.pop("waiting_for", None)
+                post.metadata.pop("waiting_since", None)
+                post.metadata.pop("wait_kind", None)
         # Auto-set waiting_since only when THIS edit explicitly sets state to waiting
         # AND waiting_for is either already present or being set in the same edit.
         # Guarding on waiting_for prevents an injected waiting_since from triggering

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2941,10 +2941,13 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # because state still holds the pre-edit value when wait is processed
         # (P1 on gptme/gptme-contrib#1539). Combined with the existing
         # transitioning_to_waiting check just below, this covers both orderings.
+        # Last --set wait wins (same as the apply loop). next() without
+        # reversed() would rewrite waiting_for from the first wait while
+        # metadata['wait'] holds a later one, permanently trapping the task.
         wait_set = next(
             (
                 value
-                for op, field, value in changes
+                for op, field, value in reversed(changes)
                 if op == "set" and field == "wait" and value is not None
             ),
             None,

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2944,23 +2944,33 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # Last --set wait wins (same as the apply loop). next() without
         # reversed() would rewrite waiting_for from the first wait while
         # metadata['wait'] holds a later one, permanently trapping the task.
-        # Include None: `--set wait NEW --set wait none` pops wait, and a
-        # non-None filter would still rewrite waiting_for to NEW, leaving a
-        # recurrence-gate string with no wait date (P1 on #1539).
-        wait_set = next(
-            (value for op, field, value in reversed(changes) if op == "set" and field == "wait"),
-            None,
+        wait_change = next(
+            (
+                (True, value)
+                for op, field, value in reversed(changes)
+                if op == "set" and field == "wait"
+            ),
+            (False, None),
         )
-        if wait_set is not None:
+        wait_was_set, wait_set = wait_change
+        if wait_was_set:
             import re as _re
 
             _wf = post.metadata.get("waiting_for", "")
-            if (
+            recurrence_gate = (
                 post.metadata.get("wait_kind") == "machine"
-                and post.metadata.get("state") == "waiting"
                 and isinstance(_wf, str)
                 and _re.match(r"^next recurrence gate \(wait: ", _wf)
-            ):
+            )
+            if recurrence_gate and wait_set is None:
+                # Clearing a generated recurrence gate means it is no longer
+                # waiting. Remove the generated blocker metadata as one unit so
+                # the task cannot be left permanently blocked without a date.
+                post.metadata["state"] = "todo"
+                post.metadata.pop("waiting_for", None)
+                post.metadata.pop("waiting_since", None)
+                post.metadata.pop("wait_kind", None)
+            elif recurrence_gate and post.metadata.get("state") == "waiting":
                 post.metadata["waiting_for"] = f"next recurrence gate (wait: {wait_set})"
         # Auto-set waiting_since only when THIS edit explicitly sets state to waiting
         # AND waiting_for is either already present or being set in the same edit.

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -133,6 +133,7 @@ from gptodo.utils import (
     KNOWN_FRONTMATTER_FIELDS,
     lint_frontmatter_fields,
     resolve_known_frontmatter_fields,
+    is_generated_recurrence_waiting_for,
     task_has_waiting_blocker,
     task_is_waiting_for_date,
     task_matches_pool_filter,
@@ -2954,14 +2955,10 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         )
         wait_was_set, wait_set = wait_change
         if wait_was_set:
-            import re as _re
-
             _wf = post.metadata.get("waiting_for", "")
-            recurrence_gate = (
-                post.metadata.get("wait_kind") == "machine"
-                and isinstance(_wf, str)
-                and _re.match(r"^next recurrence gate \(wait: ", _wf)
-            )
+            recurrence_gate = post.metadata.get(
+                "wait_kind"
+            ) == "machine" and is_generated_recurrence_waiting_for(_wf)
             if recurrence_gate and wait_set is None:
                 # Clearing a generated recurrence gate means it is no longer
                 # a machine time-gate. Remove the generated blocker metadata as
@@ -2977,9 +2974,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                 # the task (P1 on gptme/gptme-contrib#1539 / ecb15242).
                 if not explicit_state and post.metadata.get("state") == "waiting":
                     post.metadata["state"] = "todo"
-                post.metadata.pop("waiting_for", None)
-                post.metadata.pop("waiting_since", None)
-                post.metadata.pop("wait_kind", None)
+                if post.metadata.get("state") == "waiting":
+                    # `--set wait none --set state waiting` must not pop
+                    # waiting_for/waiting_since: state=waiting requires both
+                    # (P1 on gptme/gptme-contrib#1539 / b859fbf4). Drop
+                    # wait_kind so this is no longer a machine time-gate.
+                    post.metadata.pop("wait_kind", None)
+                else:
+                    post.metadata.pop("waiting_for", None)
+                    post.metadata.pop("waiting_since", None)
+                    post.metadata.pop("wait_kind", None)
             elif recurrence_gate and post.metadata.get("state") == "waiting":
                 post.metadata["waiting_for"] = f"next recurrence gate (wait: {wait_set})"
             elif recurrence_gate:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2944,12 +2944,11 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # Last --set wait wins (same as the apply loop). next() without
         # reversed() would rewrite waiting_for from the first wait while
         # metadata['wait'] holds a later one, permanently trapping the task.
+        # Include None: `--set wait NEW --set wait none` pops wait, and a
+        # non-None filter would still rewrite waiting_for to NEW, leaving a
+        # recurrence-gate string with no wait date (P1 on #1539).
         wait_set = next(
-            (
-                value
-                for op, field, value in reversed(changes)
-                if op == "set" and field == "wait" and value is not None
-            ),
+            (value for op, field, value in reversed(changes) if op == "set" and field == "wait"),
             None,
         )
         if wait_set is not None:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2956,9 +2956,15 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         wait_was_set, wait_set = wait_change
         if wait_was_set:
             _wf = post.metadata.get("waiting_for", "")
-            recurrence_gate = post.metadata.get(
-                "wait_kind"
-            ) == "machine" and is_generated_recurrence_waiting_for(_wf)
+            generated_wf = is_generated_recurrence_waiting_for(_wf)
+            wait_kind = post.metadata.get("wait_kind")
+            # A leftover generated waiting_for without wait_kind is still a
+            # recurrence gate: `--set wait none --set state waiting` pops
+            # wait_kind (state=waiting requires waiting_for) and a later
+            # `--set wait NEW` must restore the machine gate. Otherwise the
+            # old generated string permanently traps the task after the new
+            # date expires (P1 on gptme/gptme-contrib#1539 / 7a046593).
+            recurrence_gate = generated_wf and wait_kind in ("machine", None)
             if recurrence_gate and wait_set is None:
                 # Clearing a generated recurrence gate means it is no longer
                 # a machine time-gate. Remove the generated blocker metadata as
@@ -2986,6 +2992,7 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                     post.metadata.pop("wait_kind", None)
             elif recurrence_gate and post.metadata.get("state") == "waiting":
                 post.metadata["waiting_for"] = f"next recurrence gate (wait: {wait_set})"
+                post.metadata["wait_kind"] = "machine"
             elif recurrence_gate:
                 # Wait changed but the task is no longer waiting. Drop the
                 # generated recurrence string so it cannot trap a todo/done

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2930,6 +2930,21 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                         value = normalize_state(value, warn=False)
 
                     post.metadata[field] = value
+                    # When --set wait is used on a recurrence-reset task (state=waiting,
+                    # wait_kind=machine, waiting_for="next recurrence gate (wait: ...)"),
+                    # keep waiting_for in sync with the new wait value so
+                    # task_has_waiting_blocker can still match the recurrence-gate pattern.
+                    # Without this, a manual wait adjustment permanently traps the task.
+                    if field == "wait" and value is not None:
+                        import re as _re
+
+                        _wf = post.metadata.get("waiting_for", "")
+                        if (
+                            post.metadata.get("wait_kind") == "machine"
+                            and post.metadata.get("state") == "waiting"
+                            and _re.match(r"^next recurrence gate \(wait: ", _wf)
+                        ):
+                            post.metadata["waiting_for"] = f"next recurrence gate (wait: {value})"
         # Auto-set waiting_since only when THIS edit explicitly sets state to waiting
         # AND waiting_for is either already present or being set in the same edit.
         # Guarding on waiting_for prevents an injected waiting_since from triggering
@@ -3099,6 +3114,10 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                     post.metadata["waiting_since"] = datetime.now(timezone.utc).isoformat(
                         timespec="seconds"
                     )
+                    # A stale probe from a previous waiting cycle no longer describes
+                    # the new recurrence gate. Clear it so task_has_waiting_blocker
+                    # uses the wait: date rather than the old probe exit-code.
+                    post.metadata.pop("probe", None)
                     if not _completed_explicitly_set_global:
                         post.metadata.pop("completed", None)
                     with open(task.path, "w") as f:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2930,21 +2930,36 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                         value = normalize_state(value, warn=False)
 
                     post.metadata[field] = value
-                    # When --set wait is used on a recurrence-reset task (state=waiting,
-                    # wait_kind=machine, waiting_for="next recurrence gate (wait: ...)"),
-                    # keep waiting_for in sync with the new wait value so
-                    # task_has_waiting_blocker can still match the recurrence-gate pattern.
-                    # Without this, a manual wait adjustment permanently traps the task.
-                    if field == "wait" and value is not None:
-                        import re as _re
+        # When --set wait is used on a recurrence-reset task (state=waiting,
+        # wait_kind=machine, waiting_for="next recurrence gate (wait: ...)"),
+        # keep waiting_for in sync with the new wait value so
+        # task_has_waiting_blocker can still match the recurrence-gate pattern.
+        # Without this, a manual wait adjustment permanently traps the task.
+        #
+        # Must run AFTER every --set in this invocation is applied. Doing it
+        # inside the per-field loop misses `--set wait X --set state waiting`
+        # because state still holds the pre-edit value when wait is processed
+        # (P1 on gptme/gptme-contrib#1539). Combined with the existing
+        # transitioning_to_waiting check just below, this covers both orderings.
+        wait_set = next(
+            (
+                value
+                for op, field, value in changes
+                if op == "set" and field == "wait" and value is not None
+            ),
+            None,
+        )
+        if wait_set is not None:
+            import re as _re
 
-                        _wf = post.metadata.get("waiting_for", "")
-                        if (
-                            post.metadata.get("wait_kind") == "machine"
-                            and post.metadata.get("state") == "waiting"
-                            and _re.match(r"^next recurrence gate \(wait: ", _wf)
-                        ):
-                            post.metadata["waiting_for"] = f"next recurrence gate (wait: {value})"
+            _wf = post.metadata.get("waiting_for", "")
+            if (
+                post.metadata.get("wait_kind") == "machine"
+                and post.metadata.get("state") == "waiting"
+                and isinstance(_wf, str)
+                and _re.match(r"^next recurrence gate \(wait: ", _wf)
+            ):
+                post.metadata["waiting_for"] = f"next recurrence gate (wait: {wait_set})"
         # Auto-set waiting_since only when THIS edit explicitly sets state to waiting
         # AND waiting_for is either already present or being set in the same edit.
         # Guarding on waiting_for prevents an injected waiting_since from triggering

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -640,22 +640,26 @@ class TaskInfo:
 def task_has_waiting_blocker(task: "TaskInfo") -> bool:
     """Return True when a task is explicitly waiting on an external condition."""
     state = normalize_state(task.state or "", warn=False) if task.state else ""
+    waiting_for = str(task.metadata.get("waiting_for") or "").strip()
+    recurrence_gate = task.wait is not None and waiting_for == (
+        f"next recurrence gate (wait: {task.wait.isoformat()})"
+    )
     # A machine time-gate that has already expired is not a blocker — the wait has passed.
     # Guards: task.wait is not None (probe-only tasks with no date stay blocked)
     #         and no probe field (probe+expired-date tasks still need probe resolution)
-    #         and no waiting_for field (a human-described blocker must be resolved explicitly,
-    #         even if the time gate also expired — waiting_for takes precedence).
+    #         and no human waiting_for field (the generated recurrence-gate description
+    #         documents the same wait: field and is therefore safe to release).
     if (
         task.metadata.get("wait_kind") == "machine"
         and task.wait is not None
         and not task_is_waiting_for_date(task)
         and not task.metadata.get("probe")
-        and not task.metadata.get("waiting_for")
+        and (not waiting_for or recurrence_gate)
     ):
         return False
     if state == "waiting":
         return True
-    return bool(task.metadata.get("waiting_for"))
+    return bool(waiting_for)
 
 
 def task_pool(task: "TaskInfo") -> str:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -637,6 +637,19 @@ class TaskInfo:
 # =============================================================================
 
 
+# Exact generated recurrence-gate waiting_for. Prefix-only matching would treat
+# a human suffix ("... (wait: 2025-01-01) - confirm with Bob") as a machine
+# gate and silently overwrite it on --set wait (gptme/gptme-contrib#1539).
+_GENERATED_RECURRENCE_WAITING_FOR = re.compile(r"^next recurrence gate \(wait: .+\)$")
+
+
+def is_generated_recurrence_waiting_for(waiting_for: object) -> bool:
+    """True when waiting_for is exactly a generated recurrence-gate string."""
+    if not isinstance(waiting_for, str):
+        return False
+    return bool(_GENERATED_RECURRENCE_WAITING_FOR.match(waiting_for.strip()))
+
+
 def task_has_waiting_blocker(task: "TaskInfo") -> bool:
     """Return True when a task is explicitly waiting on an external condition."""
     state = normalize_state(task.state or "", warn=False) if task.state else ""

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -637,10 +637,11 @@ class TaskInfo:
 # =============================================================================
 
 
-# Exact generated recurrence-gate waiting_for. Prefix-only matching would treat
-# a human suffix ("... (wait: 2025-01-01) - confirm with Bob") as a machine
-# gate and silently overwrite it on --set wait (gptme/gptme-contrib#1539).
-_GENERATED_RECURRENCE_WAITING_FOR = re.compile(r"^next recurrence gate \(wait: .+\)$")
+# Exact generated recurrence-gate waiting_for. `.+` would treat a human note
+# inside the parentheses ("... (wait: 2025-01-01 - confirm with Bob)") as a
+# machine gate and silently overwrite it on --set wait (gptme/gptme-contrib#1539).
+# Generated dates are ISO via datetime.isoformat() — no spaces — so \S+ is exact.
+_GENERATED_RECURRENCE_WAITING_FOR = re.compile(r"^next recurrence gate \(wait: \S+\)$")
 
 
 def is_generated_recurrence_waiting_for(waiting_for: object) -> bool:

--- a/packages/gptodo/tests/test_recur.py
+++ b/packages/gptodo/tests/test_recur.py
@@ -122,21 +122,29 @@ class TestRecurCliReset:
         assert future > date.today()
 
     def test_recurring_task_reset_emits_valid_frontmatter(self, workspace: Path):
-        """Regression test: recur reset emits state=waiting with required waiting-state fields."""
+        """Regression: recur reset emits state=waiting with validator-required fields.
+
+        The task frontmatter validator rejects state=waiting without waiting_for
+        and waiting_since. The waiting_for string must be a recurrence gate (not a
+        human blocker) so the auto-releaser still surfaces the task when wait: expires.
+        """
         write_task(workspace, "weekly-review", state="active", recur="7d")
         runner = CliRunner()
-        runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
+        result = runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
+        assert result.exit_code == 0, result.output
 
         post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
-        # state=waiting + wait= is valid frontmatter; state=todo + wait= is rejected by validator
         assert post.metadata["state"] == "waiting"
         assert "wait" in post.metadata
         assert post.metadata.get("wait_kind") == "machine"
-        # waiting_for must NOT be set: the wait: date is the machine gate.
-        # A waiting_for field would be treated as a human blocker and prevent auto-surfacing
-        # once the time gate expires (task_has_waiting_blocker requires waiting_for absent).
-        assert "waiting_for" not in post.metadata
-        assert "waiting_since" not in post.metadata
+        waiting_for = post.metadata.get("waiting_for")
+        assert isinstance(waiting_for, str)
+        assert "recurrence gate" in waiting_for
+        assert str(post.metadata["wait"]) in waiting_for
+        waiting_since = post.metadata.get("waiting_since")
+        assert isinstance(waiting_since, str)
+        # Must be a parseable ISO timestamp, not a date-only leftover.
+        assert "T" in waiting_since
 
     def test_unknown_recur_format_marks_done_normally(self, workspace: Path):
         write_task(workspace, "mystery-task", state="active", recur="every-week")

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -681,3 +681,61 @@ def test_set_wait_on_recurrence_gate_updates_waiting_for(
         f"waiting_for must reference the new wait date {new_wait!r}; got {wf!r}. "
         "A stale waiting_for permanently traps the task after the new gate expires."
     )
+
+
+def test_set_wait_and_state_waiting_together_updates_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Combined --set wait + --set state waiting must still sync waiting_for.
+
+    The per-field wait-sync used to inspect metadata['state'] while applying
+    wait, so `--set wait NEW --set state waiting` on a not-yet-waiting
+    recurrence-gate task left waiting_for pointing at the old date. After the
+    new wait expires, task_has_waiting_blocker treats that stale string as a
+    human blocker and the task never auto-surfaces (gptme/gptme-contrib#1539).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: todo\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: 'next recurrence gate (wait: {old_wait})'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"recur: 7d\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            new_wait,
+            "--set",
+            "state",
+            "waiting",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == "waiting"
+    assert str(post.metadata["wait"]).startswith(
+        new_wait
+    ), f"wait: must be updated to {new_wait}, got {post.metadata['wait']}"
+    wf = post.metadata.get("waiting_for", "")
+    assert new_wait in wf, (
+        f"waiting_for must reference the new wait date {new_wait!r}; got {wf!r}. "
+        "A stale waiting_for permanently traps the task after the new gate expires."
+    )

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -855,3 +855,108 @@ def test_trailing_set_wait_none_releases_recurrence_gate(
     assert "waiting_for" not in post.metadata
     assert "waiting_since" not in post.metadata
     assert "wait_kind" not in post.metadata
+
+
+def test_set_wait_none_preserves_explicit_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--set wait none --set state done` must not overwrite the explicit state.
+
+    The wait-none recurrence-gate release used to force state=todo after all
+    --set ops, so an explicit `--set state done` (or cancelled) was lost
+    (gptme/gptme-contrib#1539 P1 on e71b18de).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    old_wf = f"next recurrence gate (wait: {old_wait})"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{old_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            "none",
+            "--set",
+            "state",
+            "done",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == "done", (
+        f"explicit --set state done must survive wait-none release, "
+        f"got {post.metadata.get('state')!r}"
+    )
+    assert "wait" not in post.metadata
+    assert "waiting_for" not in post.metadata
+    assert "waiting_since" not in post.metadata
+    assert "wait_kind" not in post.metadata
+
+
+def test_set_wait_on_nonwaiting_recurrence_gate_drops_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--set wait NEW --set state todo` must drop the generated waiting_for.
+
+    If wait-sync only rewrites waiting_for when state stays waiting, a leftover
+    recurrence-gate string on a todo task is treated as a human blocker and
+    traps the task (same family as gptme/gptme-contrib#1539).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: 'next recurrence gate (wait: {old_wait})'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            new_wait,
+            "--set",
+            "state",
+            "todo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == "todo"
+    assert str(post.metadata["wait"]).startswith(new_wait)
+    assert "waiting_for" not in post.metadata
+    assert "waiting_since" not in post.metadata
+    assert "wait_kind" not in post.metadata

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -260,11 +260,12 @@ def test_edit_done_with_recur_resets_to_waiting(
 def test_recur_reset_strips_preexisting_waiting_for(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression: recurring reset must strip pre-existing waiting_for/waiting_since.
+    """Regression: recurring reset must replace a leftover human waiting_for.
 
-    A task that was previously in a human-waiting state (waiting_for: 'John to review')
-    with a recur field must have those fields removed on done→reset. Otherwise the
-    waiting_for guard in task_has_waiting_blocker keeps the task permanently blocked.
+    A prior human-wait (waiting_for: 'John to review') must not survive done→reset,
+    or it stays a permanent blocker after the time gate expires. Replace it with a
+    recurrence-gate string (and a fresh waiting_since) so the validator is happy
+    and the auto-releaser still treats the task as a time gate.
     """
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
@@ -293,10 +294,13 @@ def test_recur_reset_strips_preexisting_waiting_for(
     post = fm.load(tasks_dir / "human-wait-recur.md")
     assert post.metadata["state"] == "waiting", "recurring task must reset to waiting"
     assert post.metadata.get("wait_kind") == "machine"
-    assert (
-        "waiting_for" not in post.metadata
-    ), "recur reset must strip waiting_for so the task can auto-surface when the time gate expires"
-    assert "waiting_since" not in post.metadata, "recur reset must strip waiting_since"
+    waiting_for = post.metadata.get("waiting_for", "")
+    assert "John" not in waiting_for, "human leftover waiting_for must not survive reset"
+    assert "recurrence gate" in waiting_for
+    assert str(post.metadata["wait"]) in waiting_for
+    waiting_since = str(post.metadata.get("waiting_since", ""))
+    assert waiting_since, "state=waiting requires waiting_since"
+    assert not waiting_since.startswith("2026-08-01"), "waiting_since must be refreshed"
 
 
 def test_edit_done_with_subday_recur_stores_datetime(

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -911,6 +911,53 @@ def test_set_wait_none_preserves_explicit_state(
     assert "wait_kind" not in post.metadata
 
 
+@pytest.mark.parametrize("start_state", ["done", "cancelled", "active"])
+def test_set_wait_none_does_not_reopen_nonwaiting_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_state: str
+) -> None:
+    """`--set wait none` must not force todo on a non-waiting task.
+
+    The wait-none release used to set state=todo whenever no explicit
+    `--set state` was in the same edit, even if the task was already
+    done/cancelled/active and merely carried leftover recurrence-gate
+    metadata (gptme/gptme-contrib#1539 P1 on ecb15242).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    old_wf = f"next recurrence gate (wait: {old_wait})"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: {start_state}\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{old_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["edit", "recur-gate-task", "--set", "wait", "none"],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == start_state, (
+        f"--set wait none must not reopen/demote {start_state} to todo, "
+        f"got {post.metadata.get('state')!r}"
+    )
+    assert "wait" not in post.metadata
+    assert "waiting_for" not in post.metadata
+    assert "waiting_since" not in post.metadata
+    assert "wait_kind" not in post.metadata
+
+
 def test_set_wait_on_nonwaiting_recurrence_gate_drops_waiting_for(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from gptodo.cli import cli
 from gptodo.utils import (
     advance_wait,
+    is_generated_recurrence_waiting_for,
     is_task_ready,
     is_valid_recur_value,
     load_tasks,
@@ -1007,3 +1008,112 @@ def test_set_wait_on_nonwaiting_recurrence_gate_drops_waiting_for(
     assert "waiting_for" not in post.metadata
     assert "waiting_since" not in post.metadata
     assert "wait_kind" not in post.metadata
+
+
+def test_generated_recurrence_waiting_for_is_exact_string() -> None:
+    assert is_generated_recurrence_waiting_for("next recurrence gate (wait: 2025-01-01)")
+    assert is_generated_recurrence_waiting_for(
+        "next recurrence gate (wait: 2025-01-01T00:00:00+00:00)"
+    )
+    assert not is_generated_recurrence_waiting_for(
+        "next recurrence gate (wait: 2025-01-01) - confirm with Bob"
+    )
+    assert not is_generated_recurrence_waiting_for("John to review the PR")
+    assert not is_generated_recurrence_waiting_for("")
+    assert not is_generated_recurrence_waiting_for(None)
+
+
+def test_set_wait_none_with_explicit_waiting_keeps_valid_frontmatter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--set wait none --set state waiting` must not drop waiting_for.
+
+    Popping waiting_for/waiting_since while leaving state=waiting produces
+    invalid frontmatter (validator requires both) and was the P1 on
+    gptme/gptme-contrib#1539 / b859fbf4.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    old_wf = f"next recurrence gate (wait: {old_wait})"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{old_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            "none",
+            "--set",
+            "state",
+            "waiting",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == "waiting"
+    assert "wait" not in post.metadata
+    assert "wait_kind" not in post.metadata
+    assert post.metadata.get("waiting_for"), (
+        "state=waiting requires waiting_for; wait-none must not pop it when "
+        "the edit explicitly stays waiting"
+    )
+    assert post.metadata.get("waiting_since"), (
+        "state=waiting requires waiting_since; wait-none must not pop it when "
+        "the edit explicitly stays waiting"
+    )
+
+
+def test_set_wait_does_not_rewrite_suffixed_recurrence_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A human suffix on a recurrence-gate string must not be overwritten.
+
+    Prefix-only matching treated 'next recurrence gate (wait: DATE) - note'
+    as a generated gate and replaced it on --set wait, destroying the note
+    (gptme/gptme-contrib#1539).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    human_wf = f"next recurrence gate (wait: {old_wait}) - confirm with Bob"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{human_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "recur-gate-task", "--set", "wait", new_wait])
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert str(post.metadata["wait"]).startswith(new_wait)
+    assert (
+        post.metadata.get("waiting_for") == human_wf
+    ), f"human-suffixed waiting_for must be preserved; got {post.metadata.get('waiting_for')!r}"

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -1233,3 +1233,69 @@ def test_set_wait_does_not_rewrite_inner_paren_recurrence_waiting_for(
         "inner-paren human waiting_for must be preserved; "
         f"got {post.metadata.get('waiting_for')!r}"
     )
+
+
+def test_set_wait_after_wait_none_staying_waiting_restores_recurrence_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--set wait none --set state waiting` then `--set wait NEW` must stay releasable.
+
+    The first edit pops wait_kind (state=waiting still requires waiting_for) and
+    leaves the generated recurrence string. A later `--set wait NEW` used to skip
+    wait-sync because wait_kind was gone, so waiting_for stayed on the old date
+    and the task never auto-surfaced after the new date expired
+    (P1 on gptme/gptme-contrib#1539 / 7a046593).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    old_wf = f"next recurrence gate (wait: {old_wait})"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{old_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"recur: 7d\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    first = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            "none",
+            "--set",
+            "state",
+            "waiting",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    second = runner.invoke(cli, ["edit", "recur-gate-task", "--set", "wait", new_wait])
+    assert second.exit_code == 0, second.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == "waiting"
+    assert str(post.metadata["wait"]).startswith(new_wait)
+    assert post.metadata.get("wait_kind") == "machine", (
+        "later --set wait must restore wait_kind=machine so the new date remains "
+        f"a releasable recurrence gate; got {post.metadata.get('wait_kind')!r}"
+    )
+    wf = post.metadata.get("waiting_for", "")
+    assert new_wait in str(wf), (
+        f"waiting_for must reference the new wait date {new_wait!r}; got {wf!r}. "
+        "A leftover generated string for the old date permanently traps the task."
+    )
+    assert old_wait not in str(
+        wf
+    ), f"waiting_for must not keep the old wait date {old_wait!r}; got {wf!r}."

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -1089,6 +1089,11 @@ def test_generated_recurrence_waiting_for_is_exact_string() -> None:
     assert not is_generated_recurrence_waiting_for(
         "next recurrence gate (wait: 2025-01-01) - confirm with Bob"
     )
+    # Note *inside* the parentheses is also human — `.+` used to match it
+    # (P1 on gptme/gptme-contrib#1539 / e52af179).
+    assert not is_generated_recurrence_waiting_for(
+        "next recurrence gate (wait: 2025-01-01 - confirm with Bob)"
+    )
     assert not is_generated_recurrence_waiting_for("John to review the PR")
     assert not is_generated_recurrence_waiting_for("")
     assert not is_generated_recurrence_waiting_for(None)
@@ -1188,3 +1193,43 @@ def test_set_wait_does_not_rewrite_suffixed_recurrence_waiting_for(
     assert (
         post.metadata.get("waiting_for") == human_wf
     ), f"human-suffixed waiting_for must be preserved; got {post.metadata.get('waiting_for')!r}"
+
+
+def test_set_wait_does_not_rewrite_inner_paren_recurrence_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A human note *inside* the wait parentheses must not be overwritten.
+
+    `.+` in is_generated_recurrence_waiting_for matched
+    'next recurrence gate (wait: DATE - note)' as generated and --set wait
+    replaced it, destroying the note (P1 on gptme/gptme-contrib#1539 / e52af179).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    human_wf = f"next recurrence gate (wait: {old_wait} - confirm with Bob)"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{human_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "recur-gate-task", "--set", "wait", new_wait])
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert str(post.metadata["wait"]).startswith(new_wait)
+    assert post.metadata.get("waiting_for") == human_wf, (
+        "inner-paren human waiting_for must be preserved; "
+        f"got {post.metadata.get('waiting_for')!r}"
+    )

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -600,3 +600,84 @@ def test_machine_expired_wait_with_human_waiting_for_stays_blocked(tmp_path: Pat
         "(waiting_for takes precedence over an expired time gate)"
     )
     assert not is_task_ready(task, {}), "machine task with human waiting_for must not be ready"
+
+
+def test_recur_reset_clears_stale_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recurring reset must clear a stale probe field.
+
+    A recurring task may previously have carried a machine probe (e.g. a CI check).
+    On the done→waiting reset that probe is no longer relevant and must be removed.
+    If kept, task_has_waiting_blocker evaluates the probe and the task never
+    auto-surfaces after the new recurrence gate expires.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    today = date.today().isoformat()
+    (tasks_dir / "probe-recur.md").write_text(
+        f"---\n"
+        f"state: active\n"
+        f"created: 2026-01-01\n"
+        f"wait: {today}\n"
+        f"recur: 7d\n"
+        f"probe: 'gh run view 123 --repo owner/repo --json conclusion -q .conclusion'\n"
+        f"wait_kind: machine\n"
+        f"---\n"
+        f"# probe-recur\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "probe-recur", "--set", "state", "done"])
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "probe-recur.md")
+    assert post.metadata["state"] == "waiting", "recurring task must reset to waiting"
+    assert "probe" not in post.metadata, (
+        "stale probe must be cleared on recurrence reset; "
+        "a leftover probe prevents task_has_waiting_blocker from releasing the task"
+    )
+
+
+def test_set_wait_on_recurrence_gate_updates_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--set wait on a recurrence-gate waiting task must keep waiting_for in sync.
+
+    After a recurring reset the task carries waiting_for="next recurrence gate (wait: <old>)".
+    If the user postpones via --set wait <new>, waiting_for must be updated to the new date.
+    Without this, task_has_waiting_blocker fails to match the recurrence-gate pattern on
+    the new wait value and permanently traps the task even after the new gate expires.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: 'next recurrence gate (wait: {old_wait})'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"recur: 7d\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "recur-gate-task", "--set", "wait", new_wait])
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert str(post.metadata["wait"]).startswith(
+        new_wait
+    ), f"wait: must be updated to {new_wait}, got {post.metadata['wait']}"
+    wf = post.metadata.get("waiting_for", "")
+    assert new_wait in wf, (
+        f"waiting_for must reference the new wait date {new_wait!r}; got {wf!r}. "
+        "A stale waiting_for permanently traps the task after the new gate expires."
+    )

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -800,3 +800,60 @@ def test_last_set_wait_wins_in_waiting_for_sync(
     assert (
         first_wait not in wf
     ), f"waiting_for must not keep the first --set wait {first_wait!r}; got {wf!r}."
+
+
+def test_trailing_set_wait_none_does_not_rewrite_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Last --set wait none must win: do not rewrite waiting_for to a cleared date.
+
+    `--set wait NEW --set wait none` pops wait. A last-wins filter that skipped
+    None still rewrote waiting_for to NEW, so the task kept a recurrence-gate
+    string with no wait date. task_has_waiting_blocker then treats state=waiting
+    as permanently blocked (gptme/gptme-contrib#1539).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    new_wait = "2030-06-15"
+    old_wf = f"next recurrence gate (wait: {old_wait})"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: '{old_wf}'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"recur: 7d\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            new_wait,
+            "--set",
+            "wait",
+            "none",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert (
+        "wait" not in post.metadata
+    ), f"wait: must be cleared by trailing --set wait none, got {post.metadata.get('wait')!r}"
+    wf = post.metadata.get("waiting_for", "")
+    assert (
+        new_wait not in wf
+    ), f"waiting_for must not be rewritten to the cleared wait {new_wait!r}; got {wf!r}."
+    assert wf == old_wf, f"waiting_for must stay the pre-edit recurrence string; got {wf!r}."

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -739,3 +739,64 @@ def test_set_wait_and_state_waiting_together_updates_waiting_for(
         f"waiting_for must reference the new wait date {new_wait!r}; got {wf!r}. "
         "A stale waiting_for permanently traps the task after the new gate expires."
     )
+
+
+def test_last_set_wait_wins_in_waiting_for_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multiple --set wait in one edit must sync waiting_for to the LAST value.
+
+    The apply loop overwrites wait in order, so the last --set wait is the
+    effective date. The post-loop sync used to take the first match from
+    `changes`, leaving waiting_for pointing at an earlier date while wait
+    holds the later one. After that later date expires,
+    task_has_waiting_blocker treats the stale string as a human blocker
+    (gptme/gptme-contrib#1539).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2025-01-01"
+    first_wait = "2030-06-15"
+    last_wait = "2030-07-01"
+    (tasks_dir / "recur-gate-task.md").write_text(
+        f"---\n"
+        f"state: waiting\n"
+        f"wait_kind: machine\n"
+        f"wait: {old_wait}\n"
+        f"waiting_for: 'next recurrence gate (wait: {old_wait})'\n"
+        f"waiting_since: 2026-08-01T00:00:00+00:00\n"
+        f"created: 2026-01-01\n"
+        f"recur: 7d\n"
+        f"---\n"
+        f"# recur-gate-task\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "edit",
+            "recur-gate-task",
+            "--set",
+            "wait",
+            first_wait,
+            "--set",
+            "wait",
+            last_wait,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert str(post.metadata["wait"]).startswith(
+        last_wait
+    ), f"wait: must be the last --set wait {last_wait}, got {post.metadata['wait']}"
+    wf = post.metadata.get("waiting_for", "")
+    assert (
+        last_wait in wf
+    ), f"waiting_for must reference the last wait date {last_wait!r}; got {wf!r}."
+    assert (
+        first_wait not in wf
+    ), f"waiting_for must not keep the first --set wait {first_wait!r}; got {wf!r}."

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -1,5 +1,6 @@
 """Tests for wait: and recur: scheduling fields."""
 
+import json
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
@@ -301,6 +302,55 @@ def test_recur_reset_strips_preexisting_waiting_for(
     waiting_since = str(post.metadata.get("waiting_since", ""))
     assert waiting_since, "state=waiting requires waiting_since"
     assert not waiting_since.startswith("2026-08-01"), "waiting_since must be refreshed"
+
+
+def test_expired_recurrence_gate_surfaces_in_ready_and_next(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A generated recurrence description must not become a permanent blocker."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    expired = "2020-01-01T00:00:00+00:00"
+    write_task(
+        tasks_dir,
+        "weekly-review",
+        state="waiting",
+        created="2026-01-01",
+        recur="7d",
+        wait=expired,
+        wait_kind="machine",
+        waiting_for=f"'next recurrence gate (wait: {expired})'",
+        waiting_since="2026-01-01T00:00:00+00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    ready = runner.invoke(cli, ["ready", "--json"])
+    assert ready.exit_code == 0, ready.output
+    assert {task["id"] for task in json.loads(ready.output)["ready_tasks"]} == {"weekly-review"}
+
+    next_result = runner.invoke(cli, ["next", "--json"])
+    assert next_result.exit_code == 0, next_result.output
+    assert json.loads(next_result.output)["next_task"]["id"] == "weekly-review"
+
+
+def test_stale_recurrence_description_stays_blocked(tmp_path: Path) -> None:
+    """Only the generated description for the current wait: is releasable."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "weekly-review",
+        state="waiting",
+        wait="2020-01-01",
+        wait_kind="machine",
+        waiting_for="'next recurrence gate (wait: 2019-01-01)'",
+        waiting_since="2026-01-01T00:00:00+00:00",
+    )
+
+    task = load_tasks(tasks_dir)[0]
+    assert task_has_waiting_blocker(task)
 
 
 def test_edit_done_with_subday_recur_stores_datetime(

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -1010,6 +1010,77 @@ def test_set_wait_on_nonwaiting_recurrence_gate_drops_waiting_for(
     assert "wait_kind" not in post.metadata
 
 
+def test_set_state_todo_on_recurrence_gate_drops_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--set state todo` must drop generated recurrence waiting_for.
+
+    Wait-sync used to run only when wait was set, so a state-only change
+    left waiting_for on the todo task. task_has_waiting_blocker then
+    treated it as a human blocker (P1 on gptme/gptme-contrib#1539 / 69034e96).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    old_wait = "2030-06-15"
+    old_wf = f"next recurrence gate (wait: {old_wait})"
+    write_task(
+        tasks_dir,
+        "recur-gate-task",
+        state="waiting",
+        wait_kind="machine",
+        wait=old_wait,
+        waiting_for=f"'{old_wf}'",
+        waiting_since="2026-08-01T00:00:00+00:00",
+        created="2026-01-01",
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "recur-gate-task", "--set", "state", "todo"])
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "recur-gate-task.md")
+    assert post.metadata["state"] == "todo"
+    assert str(post.metadata["wait"]).startswith(old_wait)
+    assert "waiting_for" not in post.metadata
+    assert "waiting_since" not in post.metadata
+    assert "wait_kind" not in post.metadata
+
+    task = load_tasks(tasks_dir)[0]
+    assert not task_has_waiting_blocker(
+        task
+    ), "leftover generated waiting_for on todo must not be a human blocker"
+
+
+def test_set_state_todo_preserves_human_waiting_for(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """State-only todo must not strip a human waiting_for suffix."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "human-gate-task",
+        state="waiting",
+        wait_kind="machine",
+        wait="2030-06-15",
+        waiting_for="'next recurrence gate (wait: 2030-06-15) - confirm with Bob'",
+        waiting_since="2026-08-01T00:00:00+00:00",
+        created="2026-01-01",
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "human-gate-task", "--set", "state", "todo"])
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "human-gate-task.md")
+    assert post.metadata["state"] == "todo"
+    assert "confirm with Bob" in str(post.metadata.get("waiting_for", ""))
+
+
 def test_generated_recurrence_waiting_for_is_exact_string() -> None:
     assert is_generated_recurrence_waiting_for("next recurrence gate (wait: 2025-01-01)")
     assert is_generated_recurrence_waiting_for(

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -802,15 +802,14 @@ def test_last_set_wait_wins_in_waiting_for_sync(
     ), f"waiting_for must not keep the first --set wait {first_wait!r}; got {wf!r}."
 
 
-def test_trailing_set_wait_none_does_not_rewrite_waiting_for(
+def test_trailing_set_wait_none_releases_recurrence_gate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Last --set wait none must win: do not rewrite waiting_for to a cleared date.
+    """Last --set wait none must clear the generated recurrence blocker.
 
-    `--set wait NEW --set wait none` pops wait. A last-wins filter that skipped
-    None still rewrote waiting_for to NEW, so the task kept a recurrence-gate
-    string with no wait date. task_has_waiting_blocker then treats state=waiting
-    as permanently blocked (gptme/gptme-contrib#1539).
+    `--set wait NEW --set wait none` pops wait. Leaving the generated
+    waiting_for behind would make a state=waiting task permanently blocked
+    without a date (gptme/gptme-contrib#1539).
     """
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
@@ -852,8 +851,7 @@ def test_trailing_set_wait_none_does_not_rewrite_waiting_for(
     assert (
         "wait" not in post.metadata
     ), f"wait: must be cleared by trailing --set wait none, got {post.metadata.get('wait')!r}"
-    wf = post.metadata.get("waiting_for", "")
-    assert (
-        new_wait not in wf
-    ), f"waiting_for must not be rewritten to the cleared wait {new_wait!r}; got {wf!r}."
-    assert wf == old_wf, f"waiting_for must stay the pre-edit recurrence string; got {wf!r}."
+    assert post.metadata["state"] == "todo"
+    assert "waiting_for" not in post.metadata
+    assert "waiting_since" not in post.metadata
+    assert "wait_kind" not in post.metadata


### PR DESCRIPTION
## Summary

#1443 landed `state: waiting` + `wait:` + `wait_kind: machine` on recurrence reset, then (in the same squash) stripped `waiting_for`/`waiting_since` so a leftover human blocker would not trap the next cycle.

The task frontmatter validator now requires both fields on `state=waiting`. Completing a `recur:` task through the documented path therefore fails pre-commit, and sessions abandon the close — that is the leaked-recurrence-gate root cause.

This writes a **time-gate** `waiting_for` instead of stripping:

```yaml
waiting_for: next recurrence gate (wait: 2026-09-04)
waiting_since: '<now>'
```

That string is classified as a time gate by the auto-releaser, so the task still re-surfaces when `wait:` expires. A leftover human blocker (`John to review the PR`) is replaced, not preserved.

## Test plan

- [x] `uv run pytest tests/test_recur.py tests/test_wait_recur.py` — 47 passed
- [x] `make typecheck` in `packages/gptodo` — clean
- [x] Emitted file passes `validate_task_frontmatter.py`; the stripped form fails with `state=waiting requires waiting_for/waiting_since`