### PR TITLE
feat(bobutils): add GFM table-cell escape helper

### DIFF
--- a/packages/bobutils/src/bobutils/markdown.py
+++ b/packages/bobutils/src/bobutils/markdown.py
@@ -1,0 +1,44 @@
+"""Markdown helpers shared by generators that write GFM tables.
+
+An unescaped ``|`` in a table cell splits the row into phantom columns.
+GFM resolves ``\\|`` *before* inline parsing, so wrapping the pipe in a
+code span is not a shelter — `` `--json|--context` `` still becomes two
+cells. HN titles and LLM-authored idea descriptions hit this constantly.
+
+The producer (``escape_table_cell``) and the consumer
+(``split_table_row_cells``) share one regex so they cannot drift. The
+brain-repo incident this exists for: unescaped Active-Idea rows jammed
+``bob-retire-graduated-ideas.service`` (2026-08-28, rows 1163/1164).
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["escape_table_cell", "split_table_row_cells"]
+
+# A `|` that is not already backslash-escaped. Idempotent replace of this
+# pattern is what keeps re-running a generator from producing `\\\\|`.
+_UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
+
+
+def escape_table_cell(text: object) -> str:
+    """Escape literal ``|`` so a cell cannot introduce a phantom table column.
+
+    Idempotent: an already-escaped ``\\|`` is left alone. Non-strings are
+    coerced with ``str()`` so callers can pass scores/ids without a cast.
+    """
+    return _UNESCAPED_PIPE_RE.sub(r"\\|", str(text))
+
+
+def split_table_row_cells(line: str) -> list[str]:
+    """Return stripped content cells for a single GFM table row.
+
+    Splits on unescaped pipes only. Leading/trailing delimiter pipes are
+    dropped so ``| a | b |`` → ``['a', 'b']``. This is the consumer-side
+    counterpart of :func:`escape_table_cell` — ``str.split('|')`` is the
+    wrong oracle because it does not understand escaping.
+    """
+    parts = _UNESCAPED_PIPE_RE.split(line)
+    content_cells = parts[1:-1] if line.endswith("|") else parts[1:]
+    return [cell.strip() for cell in content_cells]

--- a/packages/bobutils/src/bobutils/markdown.py
+++ b/packages/bobutils/src/bobutils/markdown.py
@@ -6,20 +6,38 @@ code span is not a shelter — `` `--json|--context` `` still becomes two
 cells. HN titles and LLM-authored idea descriptions hit this constantly.
 
 The producer (``escape_table_cell``) and the consumer
-(``split_table_row_cells``) share one regex so they cannot drift. The
-brain-repo incident this exists for: unescaped Active-Idea rows jammed
+(``split_table_row_cells``) share one scanner so they cannot drift. A
+negative-lookbehind regex is the wrong scanner: ``(?<!\\\\)|`` treats an
+even backslash run as an escape, but GFM renders ``\\\\|`` as a literal
+backslash plus a column delimiter. The brain-repo incident this exists
+for: unescaped Active-Idea rows jammed
 ``bob-retire-graduated-ideas.service`` (2026-08-28, rows 1163/1164).
 """
 
 from __future__ import annotations
 
-import re
-
 __all__ = ["escape_table_cell", "split_table_row_cells"]
 
-# A `|` that is not already backslash-escaped. Idempotent replace of this
-# pattern is what keeps re-running a generator from producing `\\\\|`.
-_UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
+
+def _unescaped_pipe_indices(text: str) -> list[int]:
+    """Return indices of ``|`` that GFM treats as delimiters.
+
+    A backslash escapes the next character, so a pipe is unescaped iff
+    the run of backslashes immediately before it has even length
+    (including zero). Walking pairs is what keeps ``\\\\|`` (even) a
+    delimiter and ``\\|`` (odd) a literal pipe.
+    """
+    indices: list[int] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if text[i] == "|":
+            indices.append(i)
+        i += 1
+    return indices
 
 
 def escape_table_cell(text: object) -> str:
@@ -28,7 +46,18 @@ def escape_table_cell(text: object) -> str:
     Idempotent: an already-escaped ``\\|`` is left alone. Non-strings are
     coerced with ``str()`` so callers can pass scores/ids without a cast.
     """
-    return _UNESCAPED_PIPE_RE.sub(r"\\|", str(text))
+    s = str(text)
+    idxs = _unescaped_pipe_indices(s)
+    if not idxs:
+        return s
+    parts: list[str] = []
+    last = 0
+    for i in idxs:
+        parts.append(s[last:i])
+        parts.append("\\|")
+        last = i + 1
+    parts.append(s[last:])
+    return "".join(parts)
 
 
 def split_table_row_cells(line: str) -> list[str]:
@@ -42,7 +71,13 @@ def split_table_row_cells(line: str) -> list[str]:
     escaping. This is the consumer-side counterpart of
     :func:`escape_table_cell`.
     """
-    parts = _UNESCAPED_PIPE_RE.split(line)
+    idxs = _unescaped_pipe_indices(line)
+    parts: list[str] = []
+    last = 0
+    for i in idxs:
+        parts.append(line[last:i])
+        last = i + 1
+    parts.append(line[last:])
     # Unescaped delimiter pipes produce empty split parts. Drop those only —
     # not "the first part" / "the last part" by position. A row with no
     # leading pipe, or a last cell that ends with ``\\|``, must keep that cell.

--- a/packages/bobutils/src/bobutils/markdown.py
+++ b/packages/bobutils/src/bobutils/markdown.py
@@ -34,11 +34,20 @@ def escape_table_cell(text: object) -> str:
 def split_table_row_cells(line: str) -> list[str]:
     """Return stripped content cells for a single GFM table row.
 
-    Splits on unescaped pipes only. Leading/trailing delimiter pipes are
-    dropped so ``| a | b |`` → ``['a', 'b']``. This is the consumer-side
-    counterpart of :func:`escape_table_cell` — ``str.split('|')`` is the
-    wrong oracle because it does not understand escaping.
+    Splits on unescaped pipes only. Empty leading/trailing split parts are
+    the delimiter pipes, so ``| a | b |`` → ``['a', 'b']``. A raw
+    ``str.endswith('|')`` slice is the wrong test: a cell that *ends* with
+    an escaped ``\\|`` also ends with ``|``, and slicing it off drops the
+    cell. Do not use ``str.split('|')`` either — it does not understand
+    escaping. This is the consumer-side counterpart of
+    :func:`escape_table_cell`.
     """
     parts = _UNESCAPED_PIPE_RE.split(line)
-    content_cells = parts[1:-1] if line.endswith("|") else parts[1:]
-    return [cell.strip() for cell in content_cells]
+    # Unescaped delimiter pipes produce empty split parts. Drop those only —
+    # not "the first part" / "the last part" by position. A row with no
+    # leading pipe, or a last cell that ends with ``\\|``, must keep that cell.
+    if parts and parts[0] == "":
+        parts = parts[1:]
+    if parts and parts[-1] == "":
+        parts = parts[:-1]
+    return [cell.strip() for cell in parts]

--- a/packages/bobutils/tests/test_markdown.py
+++ b/packages/bobutils/tests/test_markdown.py
@@ -61,6 +61,18 @@ def test_split_treats_escaped_pipe_as_one_cell() -> None:
     ]
 
 
+def test_even_backslash_run_does_not_shelter_a_pipe() -> None:
+    # GFM: \\ is a literal backslash; the following | is still a delimiter.
+    # (?<!\\)| misses this because it only inspects the preceding character.
+    raw = "a" + "\\\\" + "|" + "b"
+    assert list(raw) == ["a", "\\", "\\", "|", "b"]
+    escaped = escape_table_cell(raw)
+    assert list(escaped) == ["a", "\\", "\\", "\\", "|", "b"]
+    assert escape_table_cell(escaped) == escaped
+    assert split_table_row_cells("| " + escaped + " |") == [escaped]
+    assert split_table_row_cells("| " + raw + " |") == ["a\\\\", "b"]
+
+
 def test_escaped_row_parses_as_one_cell_for_the_real_consumer() -> None:
     """End-to-end: producer and consumer agree on a title that contains ``|``.
 

--- a/packages/bobutils/tests/test_markdown.py
+++ b/packages/bobutils/tests/test_markdown.py
@@ -36,6 +36,22 @@ def test_split_drops_delimiter_pipes() -> None:
     assert split_table_row_cells("| a | b |") == ["a", "b"]
 
 
+def test_split_keeps_cells_without_leading_delimiter() -> None:
+    # GFM allows rows that omit the leading/trailing pipe. Position-based
+    # slicing (parts[1:] / parts[1:-1]) silently dropped the first cell.
+    assert split_table_row_cells("a | b") == ["a", "b"]
+    assert split_table_row_cells("a | b |") == ["a", "b"]
+    assert split_table_row_cells("| a | b") == ["a", "b"]
+
+
+def test_split_keeps_last_cell_ending_in_escaped_pipe() -> None:
+    # line.endswith("|") is true for both a trailing delimiter and a cell
+    # that ends with \| — only the empty split part is the delimiter.
+    assert split_table_row_cells(r"| a \|") == [r"a \|"]
+    assert split_table_row_cells(r"| a \| |") == [r"a \|"]
+    assert split_table_row_cells(r"a \|") == [r"a \|"]
+
+
 def test_split_treats_escaped_pipe_as_one_cell() -> None:
     row = r"| 1 | **Show HN: Foo \| a tool for bars** | 100 |"
     assert split_table_row_cells(row) == [

--- a/packages/bobutils/tests/test_markdown.py
+++ b/packages/bobutils/tests/test_markdown.py
@@ -1,0 +1,61 @@
+"""Tests for bobutils.markdown GFM table-cell escaping.
+
+The escaper is only correct if it agrees with the consumer that refuses to
+rewrite a malformed table. Naive ``str.split('|')`` is the wrong oracle —
+it does not understand ``\\|``.
+"""
+
+from __future__ import annotations
+
+from bobutils.markdown import escape_table_cell, split_table_row_cells
+
+
+def test_escapes_bare_pipe() -> None:
+    assert escape_table_cell("chrome|chromium") == r"chrome\|chromium"
+
+
+def test_escapes_pipe_inside_code_span() -> None:
+    # GFM resolves `\|` before inline parsing, so code spans are not a shelter.
+    assert escape_table_cell("`--json|--context`") == r"`--json\|--context`"
+
+
+def test_is_idempotent() -> None:
+    once = escape_table_cell("(AKARN|Elena V)")
+    assert escape_table_cell(once) == once
+
+
+def test_leaves_pipe_free_text_untouched() -> None:
+    assert escape_table_cell("plain title") == "plain title"
+
+
+def test_coerces_non_str() -> None:
+    assert escape_table_cell(336) == "336"
+
+
+def test_split_drops_delimiter_pipes() -> None:
+    assert split_table_row_cells("| a | b |") == ["a", "b"]
+
+
+def test_split_treats_escaped_pipe_as_one_cell() -> None:
+    row = r"| 1 | **Show HN: Foo \| a tool for bars** | 100 |"
+    assert split_table_row_cells(row) == [
+        "1",
+        r"**Show HN: Foo \| a tool for bars**",
+        "100",
+    ]
+
+
+def test_escaped_row_parses_as_one_cell_for_the_real_consumer() -> None:
+    """End-to-end: producer and consumer agree on a title that contains ``|``.
+
+    Asserting against :func:`split_table_row_cells` (rather than ``str.split``)
+    is the point — the escaper is only correct if it agrees with the consumer
+    that refuses to rewrite the table.
+    """
+    title = "Show HN: Foo | a tool for bars"
+    row = f"| 1 | **{escape_table_cell(title)}** | 100 |"
+    cells = split_table_row_cells(row)
+    assert len(cells) == 3
+    assert cells[1] == r"**Show HN: Foo \| a tool for bars**"
+    # The naive split is the failure mode this exists to prevent.
+    assert len(row.split("|")) > 5


### PR DESCRIPTION
## Summary

Two brain-repo idea-backlog generators each carry a copy of a GFM table-cell
escaper. An unescaped `|` splits a row into phantom columns, which makes
`idea_backlog_terminal_state_audit.py` refuse to rewrite the table and jams
`bob-retire-graduated-ideas.service` (2026-08-28, rows 1163/1164).

This adds `bobutils.markdown.escape_table_cell` (idempotent; skips already
backslash-escaped pipes) and `split_table_row_cells` (the consumer-side
counterpart). Producer and consumer share one regex so they cannot drift.
`str.split('|')` is the wrong oracle because it does not understand escaping;
the tests assert against the real splitter.

Brain-repo follow-up (after this merges and the submodule is bumped): point
`scripts/generate-backlog-ideas.py` and `scripts/seed-idea-backlog.py` at the
shared helper and drop the local copies.

## Test plan

- [x] `cd packages/bobutils && uv run pytest tests/test_markdown.py -q` — 8 passed
- [x] `make -C packages/bobutils typecheck` — clean
