### PR TITLE
fix(rag): raise pathspec floor to 1.0 for GitIgnoreSpecPattern

### DIFF
--- a/packages/gptme-rag/pyproject.toml
+++ b/packages/gptme-rag/pyproject.toml
@@ -35,7 +35,9 @@ dependencies = [
     # constrain it on 3.10 so the package stays installable there.
     "onnxruntime<1.24; python_version < '3.11'",
     "regex>=2024.11.6",
-    "pathspec>=0.12",
+    # 1.0 introduced pathspec.patterns.gitignore.spec.GitIgnoreSpecPattern,
+    # which indexer.py imports at module scope; 0.12 has no such module.
+    "pathspec>=1.0",
 ]
 
 [project.urls]

--- a/packages/gptme-rag/tests/test_file_limit.py
+++ b/packages/gptme-rag/tests/test_file_limit.py
@@ -8,6 +8,7 @@ across 7 paths, of which only ~4k were ever collected). See gptme-contrib#1523.
 from __future__ import annotations
 
 import logging
+import shutil
 import subprocess
 
 import pytest
@@ -89,6 +90,7 @@ def test_index_cli_threads_pattern_to_collect_documents(tmp_path, monkeypatch):
     assert observed_patterns == ["*.md"]
 
 
+@pytest.mark.skipif(shutil.which("git") is None, reason="requires the git executable")
 def test_get_valid_files_honors_pattern_in_git_repo(tmp_path):
     """Git-backed discovery filters files with the requested pattern."""
     (tmp_path / "docs").mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -1932,7 +1932,10 @@ provides-extras = ["dev", "test"]
 [[package]]
 name = "gptme-contrib-workspace"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1947,6 +1950,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pyyaml" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2333,7 +2337,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0,<2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
-    { name = "pathspec", specifier = ">=0.12" },
+    { name = "pathspec", specifier = ">=1.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },


### PR DESCRIPTION
Follow-up to gptme/gptme-contrib#1532, as requested (https://github.com/gptme/gptme-contrib/pull/1532#issuecomment-5452578985).

## Problem

Two review threads on #1532 were still unresolved when it merged. One was a real latent break.

**P0 — dependency floor allows a version where the package cannot be imported.**
The reviewer claimed `from pathspec.patterns.gitignore.spec import GitIgnoreSpecPattern` was an invalid import. That is wrong for the version we resolve (it exists in pathspec 1.1.1, which is why CI is green), but the underlying concern was correct for a different reason: `packages/gptme-rag` declares `pathspec>=0.12`, and that module tree did not exist before pathspec **1.0**. The import is at module scope, so any resolution landing on 0.12.x makes the entire `gptme_rag.indexing.indexer` module fail to import — not just the pattern feature.

Verified against the published wheels:

| pathspec | `pathspec/patterns/gitignore/spec.py` |
|---|---|
| 0.12.1 | absent |
| 1.0.0 | present, defines `GitIgnoreSpecPattern` |
| 1.1.1 | present |

Direct reproduction on the declared floor:

```
$ uv pip install "pathspec==0.12.1"
$ python -c "from pathspec.patterns.gitignore.spec import GitIgnoreSpecPattern"
ModuleNotFoundError: No module named 'pathspec.patterns.gitignore'
```

Note the class is not re-exported from `pathspec.patterns.gitignore` — only the `.spec` submodule path works, so the reviewer's suggested alternative (`GitIgnorePattern` in `pathspec.patterns.gitignore`) would not have worked either.

**P2 — the git-backed test needs `git` on PATH.**
I dismissed this on #1532 on the grounds that skipping would silently stop testing the behavior the PR fixed. That reasoning holds for CI, where git is always present, so a `skipif` guard changes nothing there — it only keeps the suite runnable for a local dev without git, where the test could not be meaningful anyway. Cheap enough to just do.

## Changes

- Raise the floor to `pathspec>=1.0` (with a comment naming the reason).
- Guard `test_get_valid_files_honors_pattern_in_git_repo` with `skipif(shutil.which("git") is None)`.
- `uv.lock` updated by the repo's own pre-commit hook. Besides the `pathspec` specifier, it also picks up a pending workspace-root change (`source = { virtual = "." }` → `editable`, plus a `pyyaml` requires-dist entry) that was already outstanding on `master` — confirmed by running `uv lock --check` in a clean worktree on pristine `master`, which reports the same pending update with no local edits present. I first tried to keep the lock diff to the single specifier line, but the pre-commit hook regenerates it, so this is the state the repo's own tooling wants. Happy to split it out if you would rather land that separately.

## Verification

- `uv run --package gptme-rag --extra test pytest packages/gptme-rag/tests/test_file_limit.py -q` — 11 passed
- `uv run ruff check` / `ruff format --check` on the changed test — clean
- full `prek` pre-commit run — passed

## Not addressed

The explicit-empty `--pattern ""` case, dismissed on #1532 and still dismissed here: Click receiving an explicitly empty glob should stay invalid user input rather than silently broadening indexing to the default pattern.
