### PR TITLE
feat(pm-bandit): restore RunItem Stage 1 shadow wiring

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -896,6 +896,13 @@ class LaneDispatcher:
             cmd.append(f"--setenv=BOB_SELECTED_MODEL={model}")
         if work_type:
             cmd.append(f"--setenv=PM_WORK_TYPE={work_type}")
+        # Transient units inherit nothing. Forward the Stage 1 shadow flag so
+        # run-item actually records observations (gptme-contrib#1506 was
+        # stripped as dead code because this was never set here).
+        cmd.append(
+            "--setenv=BOB_PM_BANDIT_SHADOW="
+            + os.environ.get("BOB_PM_BANDIT_SHADOW", "0")
+        )
         cmd.extend(["--", "bash", script_path])
 
         try:

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -94,12 +94,14 @@ from gptme_runloops.merge_lifecycle import (
     WorkItem,
     run_merge_lifecycle,
 )
+from gptme_runloops.pm_bandit import PmModelBandit
 from gptme_runloops.pm_dispatch import (
     DISPATCH_COOLDOWN_DIR_ENV,
     EFFECT_NONE,
     EFFECT_OBSERVED,
     EFFECT_UNKNOWN,
     append_full_ledger_entry,
+    classify_item_work_type,
     derive_slot_key,
     is_direct_mention,
 )
@@ -2622,6 +2624,97 @@ def _read_monitoring_rules(config: RunItemConfig) -> str:
     return ""
 
 
+def _shadow_bandit_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """True when Stage 1 shadow observations are requested.
+
+    Live slots only see this if the launcher forwards ``BOB_PM_BANDIT_SHADOW``
+    via ``systemd-run --setenv``. An orchestrator ``Environment=`` line is
+    inert for transient workers unless forwarded — that is how gptme-contrib
+    #1506/#1504 landed, accumulated zero observations, and were stripped as
+    dead code by #1519.
+    """
+    source = env if env is not None else os.environ
+    return source.get("BOB_PM_BANDIT_SHADOW", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _load_shadow_bandit(config: RunItemConfig) -> PmModelBandit | None:
+    """Load PmModelBandit for observation-only recording. Never changes routing."""
+    if not _shadow_bandit_enabled():
+        return None
+    try:
+        pm_state_dir = Path(config.state_dir) / "pm-dispatch"
+        bandit = PmModelBandit(state_dir=str(pm_state_dir))
+        _log("BOB_PM_BANDIT_SHADOW=1: bandit loaded (recording observations only)")
+        return bandit
+    except Exception as exc:
+        _log(f"WARN: failed to load bandit: {exc}")
+        return None
+
+
+def _log_shadow_bandit_choice(
+    bandit: PmModelBandit,
+    *,
+    item_types: Sequence[str],
+    repo: str,
+    model: str,
+) -> None:
+    """Log what the bandit would pick. Does not override the dispatched model."""
+    try:
+        work_type = classify_item_work_type(list(item_types), repo=repo)
+        available = [
+            m for m in (model, os.environ.get("BOB_PM_FAST_LANE_MODEL", "")) if m
+        ]
+        if not available:
+            return
+        bandit_model = bandit.resolve_model(work_type, available)
+        _log(
+            f"BOB_PM_BANDIT_SHADOW: work_type={work_type} "
+            f"actual_model={model or '-'} bandit_model={bandit_model}"
+        )
+    except Exception as exc:
+        _log(f"WARN: bandit shadow logging failed: {exc}")
+
+
+def _record_shadow_bandit_outcome(
+    bandit: PmModelBandit,
+    *,
+    item_types: Sequence[str],
+    repo: str,
+    model: str,
+    item_effect: str,
+) -> None:
+    """Record a Stage 1 outcome for the model that actually ran.
+
+    Skip ``EFFECT_UNKNOWN``: a biased zero is worse than no signal for work
+    types (e.g. master_ci_failure) where observability is structurally absent.
+    """
+    try:
+        work_type = classify_item_work_type(list(item_types), repo=repo)
+        if item_effect == EFFECT_UNKNOWN:
+            _log(
+                "BOB_PM_BANDIT_SHADOW: outcome skipped (unknown effect): "
+                f"work_type={work_type}, model={model}"
+            )
+            return
+        if not model:
+            _log(
+                "BOB_PM_BANDIT_SHADOW: outcome skipped (no model): "
+                f"work_type={work_type}, effect={item_effect}"
+            )
+            return
+        reward = 1.0 if item_effect == EFFECT_OBSERVED else 0.0
+        bandit.record_outcome(work_type, model, reward)
+        _log(
+            f"BOB_PM_BANDIT_SHADOW: recorded outcome {work_type} -> {model} = {reward}"
+        )
+    except Exception as exc:
+        _log(f"WARN: bandit outcome recording failed: {exc}")
+
+
 def _ambient_env(config: RunItemConfig, backend: str, model: str) -> dict[str, str]:
     """p-m.sh:417-422 — harness tag for ambient-memory injections."""
     if not config.ambient_harness_env:
@@ -2729,6 +2822,10 @@ def run_work_file(
             pass
 
         ambient = _ambient_env(config, backend, model)
+        # Stage 1 (shadow mode): load the bandit but do not use it for routing.
+        # Gated by BOB_PM_BANDIT_SHADOW; live only when the slot launcher
+        # forwards that env into the transient unit.
+        bandit = _load_shadow_bandit(config)
         if hooks.sysprompt_builder is not None:
             _log("Building system prompt...")
             env = os.environ.copy()
@@ -2810,6 +2907,14 @@ def run_work_file(
             )
             _log(f"Prompt: {len(plan.prompt)} chars")
 
+            if bandit is not None:
+                _log_shadow_bandit_choice(
+                    bandit,
+                    item_types=item.types,
+                    repo=item.repo,
+                    model=model,
+                )
+
             if rate_limited:
                 _log(f"Rate-limited: skipping item {index} and remaining items")
                 break
@@ -2853,9 +2958,16 @@ def run_work_file(
                     infra_failure = item_outcome.infra_failure
                 if item_outcome.exit_code != 0 and overall_exit == 0:
                     overall_exit = item_outcome.exit_code
-                item_effects.append(
-                    run_post_session(plan, item, item_outcome, config, hooks)
-                )
+                item_effect = run_post_session(plan, item, item_outcome, config, hooks)
+                item_effects.append(item_effect)
+                if bandit is not None:
+                    _record_shadow_bandit_outcome(
+                        bandit,
+                        item_types=item.types,
+                        repo=item.repo,
+                        model=model,
+                        item_effect=item_effect,
+                    )
             finally:
                 # bash EXIT-trap parity: the claim is abandoned on every exit
                 # path, including SIGTERM (the CLI converts it to SystemExit

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -35,6 +35,8 @@ from gptme_runloops.merge_lifecycle import (
     SelfMergeCheckResult,
     run_merge_lifecycle,
 )
+from gptme_runloops.pm_bandit import PmModelBandit
+from gptme_runloops.pm_dispatch import EFFECT_NONE, EFFECT_OBSERVED, EFFECT_UNKNOWN
 from gptme_runloops.run_item import (
     PR_OBSERVE_TYPES,
     PR_STATE_TYPES,
@@ -45,6 +47,9 @@ from gptme_runloops.run_item import (
     RunItemHooks,
     _handle_cc_rate_limit,
     _inspect_cc_failure,
+    _load_shadow_bandit,
+    _record_shadow_bandit_outcome,
+    _shadow_bandit_enabled,
     build_execution_plan,
     clear_slot_event_markers,
     derive_lock_paths,
@@ -616,6 +621,105 @@ def test_run_work_file_happy_path(tmp_path) -> None:
     assert lock_file.read_text() == ""
     history = config.lock_history.read_text()
     assert "ACQUIRED" in history and "RELEASED" in history
+
+
+def test_shadow_bandit_enabled_reads_env() -> None:
+    assert _shadow_bandit_enabled({}) is False
+    assert _shadow_bandit_enabled({"BOB_PM_BANDIT_SHADOW": "0"}) is False
+    assert _shadow_bandit_enabled({"BOB_PM_BANDIT_SHADOW": "1"}) is True
+    assert _shadow_bandit_enabled({"BOB_PM_BANDIT_SHADOW": "true"}) is True
+
+
+def test_load_shadow_bandit_none_when_flag_off(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("BOB_PM_BANDIT_SHADOW", raising=False)
+    assert _load_shadow_bandit(make_config(tmp_path)) is None
+
+
+def test_load_shadow_bandit_when_flag_on(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("BOB_PM_BANDIT_SHADOW", "1")
+    bandit = _load_shadow_bandit(make_config(tmp_path))
+    assert isinstance(bandit, PmModelBandit)
+    assert bandit.state_dir == tmp_path / "state-dir" / "pm-dispatch"
+
+
+def test_record_shadow_bandit_outcome_skips_unknown_effect(tmp_path) -> None:
+    bandit = PmModelBandit(state_dir=str(tmp_path / "pm-dispatch"))
+    _record_shadow_bandit_outcome(
+        bandit,
+        item_types=["pr_update"],
+        repo="gptme/gptme-contrib",
+        model="claude-sonnet-4-6",
+        item_effect=EFFECT_UNKNOWN,
+    )
+    assert bandit.summary() == {}
+
+
+def test_record_shadow_bandit_outcome_records_observed(tmp_path) -> None:
+    bandit = PmModelBandit(state_dir=str(tmp_path / "pm-dispatch"))
+    _record_shadow_bandit_outcome(
+        bandit,
+        item_types=["pr_update"],
+        repo="gptme/gptme-contrib",
+        model="claude-sonnet-4-6",
+        item_effect=EFFECT_OBSERVED,
+    )
+    summary = bandit.summary()
+    assert "pr-review" in summary
+    assert summary["pr-review"]["claude-sonnet-4-6"]["selections"] == 1
+
+
+def test_record_shadow_bandit_outcome_zero_for_none(tmp_path) -> None:
+    bandit = PmModelBandit(state_dir=str(tmp_path / "pm-dispatch"))
+    _record_shadow_bandit_outcome(
+        bandit,
+        item_types=["ci_failure"],
+        repo="gptme/gptme",
+        model="claude-sonnet-4-6",
+        item_effect=EFFECT_NONE,
+    )
+    summary = bandit.summary()
+    arm = summary["ci-fix"]["claude-sonnet-4-6"]
+    assert arm["selections"] == 1
+    assert arm["mean"] < 0.5
+
+
+def test_run_work_file_records_shadow_bandit_outcome(tmp_path, monkeypatch) -> None:
+    """Flag on → live path writes bandit-state.json. Prevents a repeat of
+    #1519 stripping this as dead code because the env was never set."""
+    monkeypatch.setenv("BOB_PM_BANDIT_SHADOW", "1")
+    monkeypatch.setattr(
+        "gptme_runloops.run_item.run_post_session",
+        lambda *args, **kwargs: EFFECT_OBSERVED,
+    )
+    (tmp_path / "monitoring-rules.md").write_text("RULES CONTENT")
+    item = make_item()
+    work_file = _write_work_file(tmp_path, item)
+    config = make_config(tmp_path)
+    run_cmd = FakeRunCmd()
+    run_cmd.on("rev-parse", stdout="abc123\n")
+    run_cmd.on(
+        "gh", stdout='{"state": "OPEN", "headRefOid": "AA", "mergeCommit": null}'
+    )
+    hooks = make_hooks(
+        run_cmd=run_cmd,
+        merge_lifecycle_io=FakeLifecycleIO(status="in-progress"),
+        claim_tool=["fake-coordination"],
+    )
+    rc = run_work_file(
+        work_file,
+        config,
+        hooks,
+        backend="claude-code",
+        model="claude-sonnet-4-6",
+        lane="slow",
+        dispatch_id="unit-1",
+        slot_key="gptme/gptme-contrib#1234",
+    )
+    assert rc == 0
+    state_file = tmp_path / "state-dir" / "pm-dispatch" / "bandit-state.json"
+    assert state_file.is_file(), "shadow bandit must persist an observation"
+    reloaded = PmModelBandit(state_dir=str(tmp_path / "state-dir" / "pm-dispatch"))
+    assert reloaded.summary()
 
 
 def test_run_work_file_claim_denied_skips_and_exits_zero(tmp_path) -> None:


### PR DESCRIPTION
## Why

Stage 1 shadow wiring landed in #1506 / #1504 and was then stripped by #1519 as "dead code" because `BOB_PM_BANDIT_SHADOW` was never set on live slots. Transient `systemd-run` units inherit nothing from the parent service, so an orchestrator `Environment=` line (even if it had been present) would have been inert.

The helpers existed; the production path never invoked them. That is the shipped-but-not-live class, env-gated-and-never-forwarded shape.

## What

Restore observation-only `PmModelBandit` wiring in `run_work_file`:

- Load the bandit when `BOB_PM_BANDIT_SHADOW=1`
- Log the work type and what the bandit *would* pick
- Record the outcome for the model that actually ran (`EFFECT_OBSERVED` → 1.0, `EFFECT_NONE` → 0.0, skip `EFFECT_UNKNOWN`)
- **No routing change.** Stage 2 still waits on `MIN_BANDIT_OBSERVATIONS`.

Also forward `BOB_PM_BANDIT_SHADOW` from the Python `LaneDispatcher` systemd-run path, matching the bash `run_slot_unit` companion in ErikBjare/bob.

Helpers are module-level and tested so a later "unused" sweep cannot delete them without failing tests.

## Tests

- `_shadow_bandit_enabled` / `_load_shadow_bandit` / `_record_shadow_bandit_outcome` unit tests
- `run_work_file` integration: flag on + observed effect → `bandit-state.json` persisted

`pytest packages/gptme-runloops/tests/test_run_item.py packages/gptme-runloops/tests/test_pm_bandit.py packages/gptme-runloops/tests/test_pm_dispatch.py` — 384 passed.

## Companion (Bob)

The live slot path is bash `run_slot_unit`. That `--setenv` and the orchestrator `Environment=BOB_PM_BANDIT_SHADOW=1` ship in the brain repo this session. This PR is the executor half.

## Not in this PR

- Stage 2 actual routing (`BOB_PM_BANDIT_ARMS=ci_failure,greptile_needs_fix`)
- Cheap-model fast-lane re-enable (deliberately off until the bandit has a reconciled reward path)

Ref: #1075, #1504, #1506, #1519, ErikBjare/bob#860