### PR TITLE
feat(rag): add KnowledgeEntrySource over gptme JSONL store

### DIFF
--- a/packages/gptme-rag/README.md
+++ b/packages/gptme-rag/README.md
@@ -18,6 +18,7 @@ This is the **vector search** complement to [`gptme-wisdom`](https://github.com/
 - 🔌 MCP server for agent integration (`gptme-rag mcp`)
 - 🛠️ CLI interface (`gptme-rag index`, `gptme-rag search`)
 - 📊 Injection logging and index-health/rot reporting (`gptme_rag.observability`)
+- 🧠 Knowledge-entry source over gptme's JSONL store (`KnowledgeEntrySource`, `memory_type="knowledge_entry"`)
 
 ## Quick Start
 

--- a/packages/gptme-rag/src/gptme_rag/knowledge_source.py
+++ b/packages/gptme-rag/src/gptme_rag/knowledge_source.py
@@ -1,0 +1,185 @@
+"""Knowledge-entry source for gptme-rag.
+
+Reads the JSONL store written by ``gptme-util knowledge save``
+(``~/.local/share/gptme/knowledge/entries.jsonl``, respects ``XDG_DATA_HOME``)
+and yields :class:`~gptme_rag.indexing.document.Document` objects tagged
+``memory_type="knowledge_entry"``.
+
+This module is a *rebuildable index* over that file. It does not write the
+store, score queries, or replace the JSONL as source of truth. Schema and
+skip-invalid-line policy match ``gptme.knowledge`` (gptme/gptme#3622).
+
+Chroma metadata values must be scalars (str/int/float/bool). Tags and
+keywords are therefore stored as comma-separated strings; the original lists
+are also folded into ``content`` so lexical search still sees them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .indexing.document import Document
+
+logger = logging.getLogger(__name__)
+
+
+def default_knowledge_entries_path() -> Path:
+    """Return the JSONL path used by gptme's knowledge store.
+
+    Matches ``gptme.dirs.get_data_dir() / "knowledge" / "entries.jsonl"`` for
+    the common cases (``XDG_DATA_HOME`` override, then ``~/.local/share/gptme``)
+    without importing gptme.
+    """
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "gptme" / "knowledge" / "entries.jsonl"
+    return Path.home() / ".local" / "share" / "gptme" / "knowledge" / "entries.jsonl"
+
+
+def _is_valid_entry(parsed: object) -> bool:
+    """Return whether parsed JSON has the fields required by the store."""
+    if not isinstance(parsed, dict):
+        return False
+    try:
+        uuid.UUID(str(parsed.get("id", "")))
+    except (AttributeError, TypeError, ValueError):
+        return False
+    if not all(
+        isinstance(parsed.get(key), expected_type)
+        for key, expected_type in (
+            ("problem", str),
+            ("resolution", str),
+            ("tags", list),
+            ("created_at", str),
+        )
+    ):
+        return False
+    problem = parsed["problem"].strip()
+    resolution = parsed["resolution"].strip()
+    if not problem or not resolution:
+        return False
+    tags = parsed["tags"]
+    return all(isinstance(tag, str) for tag in tags)
+
+
+def _join_strings(values: Iterable[object]) -> str:
+    return ",".join(str(v).strip() for v in values if str(v).strip())
+
+
+def _entry_content(entry: dict[str, Any]) -> str:
+    tags = [str(t).strip() for t in entry.get("tags", []) if str(t).strip()]
+    keywords = [str(k).strip() for k in entry.get("keywords", []) if str(k).strip()]
+    parts = [
+        f"Problem: {entry['problem'].strip()}",
+        "",
+        f"Resolution: {entry['resolution'].strip()}",
+    ]
+    if tags:
+        parts.extend(["", f"Tags: {', '.join(tags)}"])
+    if keywords:
+        parts.extend(["", f"Keywords: {', '.join(keywords)}"])
+    return "\n".join(parts)
+
+
+def _entry_last_modified(created_at: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _document_from_entry(entry: dict[str, Any], source_path: Path) -> Document:
+    entry_id = str(entry["id"])
+    tags = [str(t).strip() for t in entry.get("tags", []) if str(t).strip()]
+    keywords = [str(k).strip() for k in entry.get("keywords", []) if str(k).strip()]
+    created_at = str(entry["created_at"])
+    metadata: dict[str, Any] = {
+        "type": "knowledge_entry",
+        "memory_type": "knowledge_entry",
+        "source": str(source_path),
+        "title": entry["problem"].strip(),
+        "problem": entry["problem"].strip(),
+        "resolution": entry["resolution"].strip(),
+        "tags": _join_strings(tags),
+        "keywords": _join_strings(keywords),
+        "created_at": created_at,
+        "id": entry_id,
+    }
+    return Document(
+        content=_entry_content(entry),
+        metadata=metadata,
+        source_path=source_path,
+        doc_id=f"knowledge_entry:{entry_id}",
+        last_modified=_entry_last_modified(created_at),
+    )
+
+
+def collect_knowledge_entry_documents(
+    entries_path: Path | None = None,
+) -> list[Document]:
+    """Collect knowledge-entry documents from a JSONL store.
+
+    Args:
+        entries_path: Path to ``entries.jsonl``. When omitted, uses
+            :func:`default_knowledge_entries_path`.
+
+    Returns:
+        One :class:`Document` per valid entry. Missing files, malformed
+        lines, and schema-invalid objects are skipped.
+    """
+    path = Path(entries_path) if entries_path is not None else default_knowledge_entries_path()
+    if not path.exists() or not path.is_file():
+        return []
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        logger.warning("knowledge_source: cannot read %s", path)
+        return []
+
+    docs: list[Document] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not _is_valid_entry(parsed):
+            continue
+        docs.append(_document_from_entry(parsed, path))
+    return docs
+
+
+@dataclass
+class KnowledgeEntrySource:
+    """Source descriptor for the gptme knowledge JSONL store.
+
+    Usage::
+
+        source = KnowledgeEntrySource(entries_path=path)
+        docs = source.collect()
+        registry.add("knowledge entries", source.collect)
+    """
+
+    entries_path: Path | None = None
+
+    def collect(self) -> list[Document]:
+        """Collect documents from :attr:`entries_path` or the default store."""
+        return collect_knowledge_entry_documents(self.entries_path)
+
+
+__all__ = [
+    "KnowledgeEntrySource",
+    "collect_knowledge_entry_documents",
+    "default_knowledge_entries_path",
+]

--- a/packages/gptme-rag/src/gptme_rag/knowledge_source.py
+++ b/packages/gptme-rag/src/gptme_rag/knowledge_source.py
@@ -67,7 +67,16 @@ def _is_valid_entry(parsed: object) -> bool:
     if not problem or not resolution:
         return False
     tags = parsed["tags"]
-    return all(isinstance(tag, str) for tag in tags)
+    if not all(isinstance(tag, str) for tag in tags):
+        return False
+    # Optional field; a bare string iterates as characters and corrupts metadata.
+    if "keywords" in parsed:
+        keywords = parsed["keywords"]
+        if not isinstance(keywords, list) or not all(
+            isinstance(keyword, str) for keyword in keywords
+        ):
+            return False
+    return True
 
 
 def _join_strings(values: Iterable[object]) -> str:

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -39,6 +39,11 @@ from pathlib import Path
 from typing import Any
 
 from .indexing.document import Document
+from .knowledge_source import (
+    KnowledgeEntrySource,
+    collect_knowledge_entry_documents,
+    default_knowledge_entries_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -358,4 +363,7 @@ __all__ = [
     "SourceRegistry",
     "de_accumulate_transcript",
     "collect_voice_call_documents",
+    "KnowledgeEntrySource",
+    "collect_knowledge_entry_documents",
+    "default_knowledge_entries_path",
 ]

--- a/packages/gptme-rag/tests/test_knowledge_source.py
+++ b/packages/gptme-rag/tests/test_knowledge_source.py
@@ -1,0 +1,154 @@
+"""Tests for gptme-rag KnowledgeEntrySource (gptme/gptme#3596).
+
+The JSONL store shipped in gptme/gptme#3622 is the source of truth.
+This source is a rebuildable index over that file — it must not invent
+a second store, and metadata values must stay Chroma-safe (scalars only).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gptme_rag.indexing.document import Document
+from gptme_rag.knowledge_source import (
+    KnowledgeEntrySource,
+    collect_knowledge_entry_documents,
+    default_knowledge_entries_path,
+)
+from gptme_rag.sources import SourceRegistry
+
+
+def _write_entries(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(e) + "\n" for e in entries), encoding="utf-8")
+
+
+def _valid_entry(**overrides: object) -> dict:
+    entry = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "problem": "zlib failure",
+        "resolution": "rebuild the archive",
+        "tags": ["git", "pytest"],
+        "keywords": ["zlib", "failure", "rebuild", "archive"],
+        "created_at": "2026-08-28T12:00:00+00:00",
+        "memory_type": "knowledge_entry",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_missing_file_returns_empty(tmp_path: Path):
+    docs = collect_knowledge_entry_documents(tmp_path / "missing.jsonl")
+    assert docs == []
+
+
+def test_collects_valid_jsonl_as_knowledge_entry_documents(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    _write_entries(path, [_valid_entry()])
+
+    docs = collect_knowledge_entry_documents(path)
+
+    assert len(docs) == 1
+    doc = docs[0]
+    assert isinstance(doc, Document)
+    assert doc.doc_id == "knowledge_entry:11111111-1111-1111-1111-111111111111"
+    assert "zlib failure" in doc.content
+    assert "rebuild the archive" in doc.content
+    assert doc.metadata["memory_type"] == "knowledge_entry"
+    assert doc.metadata["type"] == "knowledge_entry"
+    assert doc.metadata["problem"] == "zlib failure"
+    assert doc.metadata["resolution"] == "rebuild the archive"
+    assert doc.metadata["created_at"] == "2026-08-28T12:00:00+00:00"
+    assert doc.source_path == path
+
+
+def test_metadata_values_are_chroma_scalars(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    _write_entries(path, [_valid_entry()])
+
+    doc = collect_knowledge_entry_documents(path)[0]
+    for key, value in doc.metadata.items():
+        assert isinstance(
+            value, str | int | float | bool
+        ), f"{key}={value!r} is not a chroma scalar"
+
+    assert doc.metadata["tags"] == "git,pytest"
+    assert "zlib" in doc.metadata["keywords"]
+
+
+def test_skips_malformed_and_invalid_lines(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    good = _valid_entry()
+    path.write_text(
+        "\n".join(
+            [
+                "{not json",
+                json.dumps(
+                    {
+                        "id": "not-a-uuid",
+                        "problem": "x",
+                        "resolution": "y",
+                        "tags": [],
+                        "created_at": "t",
+                    }
+                ),
+                json.dumps(_valid_entry(problem="")),
+                json.dumps(
+                    _valid_entry(id="22222222-2222-2222-2222-222222222222", problem="keep me")
+                ),
+                json.dumps(["not", "an", "object"]),
+                json.dumps(good),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    docs = collect_knowledge_entry_documents(path)
+    ids = {doc.doc_id for doc in docs}
+    assert ids == {
+        "knowledge_entry:22222222-2222-2222-2222-222222222222",
+        "knowledge_entry:11111111-1111-1111-1111-111111111111",
+    }
+
+
+def test_default_path_uses_xdg_data_home(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert default_knowledge_entries_path() == tmp_path / "gptme" / "knowledge" / "entries.jsonl"
+
+
+def test_default_path_without_xdg(monkeypatch):
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    path = default_knowledge_entries_path()
+    assert path == Path.home() / ".local" / "share" / "gptme" / "knowledge" / "entries.jsonl"
+
+
+def test_knowledge_entry_source_collects_from_explicit_path(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    _write_entries(path, [_valid_entry()])
+
+    source = KnowledgeEntrySource(entries_path=path)
+    docs = source.collect()
+    assert len(docs) == 1
+    assert docs[0].metadata["memory_type"] == "knowledge_entry"
+
+
+def test_source_is_registerable(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    _write_entries(path, [_valid_entry()])
+
+    registry = SourceRegistry()
+    registry.add("knowledge entries", KnowledgeEntrySource(entries_path=path).collect)
+    docs = registry.collect()
+    assert len(docs) == 1
+    assert docs[0].metadata["memory_type"] == "knowledge_entry"
+
+
+def test_tags_in_content_for_lexical_search(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    _write_entries(path, [_valid_entry(tags=["flock", "jsonl"])])
+
+    doc = collect_knowledge_entry_documents(path)[0]
+    assert "flock" in doc.content
+    assert "jsonl" in doc.content

--- a/packages/gptme-rag/tests/test_knowledge_source.py
+++ b/packages/gptme-rag/tests/test_knowledge_source.py
@@ -152,3 +152,32 @@ def test_tags_in_content_for_lexical_search(tmp_path: Path):
     doc = collect_knowledge_entry_documents(path)[0]
     assert "flock" in doc.content
     assert "jsonl" in doc.content
+
+
+def test_skips_keywords_that_are_not_a_string_list(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    keep = _valid_entry(id="33333333-3333-3333-3333-333333333333", problem="keep me")
+    _write_entries(
+        path,
+        [
+            _valid_entry(keywords="failure"),
+            _valid_entry(keywords=["ok", 1]),
+            keep,
+        ],
+    )
+
+    docs = collect_knowledge_entry_documents(path)
+    assert [doc.doc_id for doc in docs] == ["knowledge_entry:33333333-3333-3333-3333-333333333333"]
+    assert "f, a, i, l, u, r, e" not in docs[0].content
+    assert docs[0].metadata["keywords"] != "f,a,i,l,u,r,e"
+
+
+def test_missing_keywords_is_valid(tmp_path: Path):
+    path = tmp_path / "entries.jsonl"
+    entry = _valid_entry()
+    del entry["keywords"]
+    _write_entries(path, [entry])
+
+    docs = collect_knowledge_entry_documents(path)
+    assert len(docs) == 1
+    assert docs[0].metadata["keywords"] == ""


### PR DESCRIPTION
## Summary

gptme-rag now has a `KnowledgeEntrySource` that reads the JSONL store shipped in gptme/gptme#3622 (`~/.local/share/gptme/knowledge/entries.jsonl`, `XDG_DATA_HOME` aware) and yields `Document` objects with `memory_type="knowledge_entry"`.

JSONL remains the source of truth. This is a rebuildable index, not a second store.

Partial progress on gptme/gptme#3596 (the remaining slices are session-start injection and schema generalization; not this PR).

## What it does

- `KnowledgeEntrySource` / `collect_knowledge_entry_documents()` collect one Document per valid JSONL entry
- Default path matches gptme's store: `$XDG_DATA_HOME/gptme/knowledge/entries.jsonl` or `~/.local/share/gptme/knowledge/entries.jsonl`
- Skip-invalid-line policy matches `gptme.knowledge` (malformed JSON, bad UUID, empty problem/resolution)
- Metadata is Chroma-safe: tags and keywords are comma-separated scalars, also folded into `content` for lexical search
- Registerable on `SourceRegistry`

## Out of scope

- Session-start injection
- Replacing gptme's local keyword search
- Generalizing the problem/resolution schema
- CLI `--source knowledge` flag (gptme already calls `gptme-rag index` after save)

## Test plan

- [x] `pytest packages/gptme-rag/tests/test_knowledge_source.py` (9 passed)
- [x] `pytest packages/gptme-rag/tests/test_sources.py packages/gptme-rag/tests/test_knowledge_source.py -m "not slow"` (53 passed)
- [x] `mypy src/` in gptme-rag (clean)
