### PR TITLE
feat(lsp): rename workspace edit preview coverage + workspace index + diagnostics header fixes

### DIFF
--- a/plugins/gptme-lsp/src/gptme_lsp/lsp_client.py
+++ b/plugins/gptme-lsp/src/gptme_lsp/lsp_client.py
@@ -341,6 +341,9 @@ class LSPServer:
         params = {
             "processId": None,
             "rootUri": self.workspace.as_uri(),
+            "workspaceFolders": [
+                {"uri": self.workspace.as_uri(), "name": self.workspace.name}
+            ],
             "capabilities": {
                 "textDocument": {
                     "publishDiagnostics": {"relatedInformation": True},

--- a/plugins/gptme-lsp/src/gptme_lsp/lsp_client.py
+++ b/plugins/gptme-lsp/src/gptme_lsp/lsp_client.py
@@ -345,9 +345,10 @@ class LSPServer:
                 {"uri": self.workspace.as_uri(), "name": self.workspace.name}
             ],
             "capabilities": {
+                "workspace": {"workspaceFolders": True},
                 "textDocument": {
                     "publishDiagnostics": {"relatedInformation": True},
-                }
+                },
             },
         }
         result = self._send_request("initialize", params)

--- a/plugins/gptme-lsp/src/gptme_lsp/tools/lsp_tool.py
+++ b/plugins/gptme-lsp/src/gptme_lsp/tools/lsp_tool.py
@@ -174,7 +174,7 @@ def _get_lsp_diagnostics(file: Path, workspace: Path | None = None) -> str | Non
     if info_count:
         summary.append(f"{info_count} info")
 
-        header = f"Found {', '.join(summary)}:\n\n" if summary else ""
+    header = f"Found {', '.join(summary)}:\n\n" if summary else ""
     return header + "\n".join(lines)
 
 

--- a/plugins/gptme-lsp/tests/test_lsp_tool.py
+++ b/plugins/gptme-lsp/tests/test_lsp_tool.py
@@ -213,3 +213,79 @@ def test_lsp_command_returns_generator():
     messages = list(result)
     assert len(messages) == 1
     assert "LSP Status" in messages[0].content
+
+
+def test_initialize_includes_workspace_folders():
+    """Regression: initialize must send workspaceFolders for full-workspace indexing.
+
+    Without workspaceFolders, pyright runs in open-files-only mode and rename/
+    references silently under-report cross-file edits (only the target file is
+    indexed instead of the whole project).
+    """
+    from gptme_lsp.lsp_client import LSPServer
+
+    server = LSPServer(
+        name="test",
+        command=["true"],
+        workspace=Path("/tmp/workspace-folders-test"),
+    )
+    sent = {}
+
+    def fake_send_request(method, params):
+        sent[method] = params
+        # Return a truthy result so _initialize proceeds
+        return {"capabilities": {}}
+
+    with patch.object(server, "_send_request", side_effect=fake_send_request):
+        server._initialize()
+
+    init_params = sent.get("initialize", {})
+    assert "workspaceFolders" in init_params
+    folders = init_params["workspaceFolders"]
+    assert isinstance(folders, list) and len(folders) == 1
+    assert folders[0]["uri"] == Path("/tmp/workspace-folders-test").as_uri()
+    assert folders[0]["name"] == "workspace-folders-test"
+
+
+def test_diagnostics_formats_without_info(tmp_path):
+    """Regression: diagnostics must not crash when no info-level diagnostics exist.
+
+    The `header` variable was previously nested inside `if info_count:`, so when a
+    file had only errors/warnings (info_count == 0) it was never assigned and the
+    formatter raised UnboundLocalError.
+    """
+    from gptme_lsp.lsp_client import Diagnostic
+    from gptme_lsp.tools import lsp_tool
+
+    test_file = tmp_path / "module.py"
+    test_file.write_text("def foo():\n    pass\n")
+
+    diagnostics = [
+        Diagnostic(
+            file=test_file,
+            line=1,
+            column=1,
+            severity="error",
+            message="expected expression",
+        ),
+        Diagnostic(
+            file=test_file,
+            line=2,
+            column=5,
+            severity="warning",
+            message="unused variable",
+        ),
+    ]
+    fake_server = MagicMock()
+    fake_server.get_diagnostics.return_value = diagnostics
+
+    with (
+        patch.object(lsp_tool, "_get_or_start_server", return_value=fake_server),
+        patch.object(lsp_tool, "_get_workspace", return_value=tmp_path),
+    ):
+        result = lsp_tool._get_lsp_diagnostics(test_file, tmp_path)
+
+    assert result is not None
+    assert "Found 1 error(s), 1 warning(s)" in result
+    assert "Line 1: expected expression" in result
+    assert "Line 2: unused variable" in result

--- a/plugins/gptme-lsp/tests/test_lsp_tool.py
+++ b/plugins/gptme-lsp/tests/test_lsp_tool.py
@@ -245,6 +245,10 @@ def test_initialize_includes_workspace_folders():
     assert isinstance(folders, list) and len(folders) == 1
     assert folders[0]["uri"] == Path("/tmp/workspace-folders-test").as_uri()
     assert folders[0]["name"] == "workspace-folders-test"
+    # LSP spec: clients must advertise workspace.workspaceFolders for servers
+    # to enable workspace-folder-aware indexing (not just send the folder list).
+    caps = init_params.get("capabilities", {})
+    assert caps.get("workspace", {}).get("workspaceFolders") is True
 
 
 def test_diagnostics_formats_without_info(tmp_path):

--- a/plugins/gptme-lsp/tests/test_lsp_tool.py
+++ b/plugins/gptme-lsp/tests/test_lsp_tool.py
@@ -17,6 +17,7 @@ if _plugin_src not in sys.path:
 
 # Now imports can happen at module level (path setup required first)
 from gptme_lsp.hooks import register  # noqa: E402
+from gptme_lsp.lsp_client import TextEdit, WorkspaceEdit  # noqa: E402
 from gptme_lsp.tools import tool  # noqa: E402
 from gptme_lsp.tools.lsp_tool import _get_workspace, execute  # noqa: E402
 
@@ -86,6 +87,39 @@ def test_execute_unknown_action():
 
     assert result is not None
     assert "Unknown action" in result.content
+
+
+def test_execute_rename_previews_workspace_edit(tmp_path):
+    """Test rename action formats LSP workspace edit previews."""
+    test_file = tmp_path / "module.py"
+    test_file.write_text("def old_name():\n    return old_name()\n")
+    edit = TextEdit(
+        file=test_file,
+        start_line=1,
+        start_column=5,
+        end_line=1,
+        end_column=13,
+        new_text="new_name",
+    )
+
+    with patch("gptme_lsp.tools.lsp_tool._get_workspace", return_value=tmp_path):
+        with patch(
+            "gptme_lsp.tools.lsp_tool._get_lsp_rename",
+            return_value=WorkspaceEdit([edit]),
+        ) as mock_rename:
+            result = execute(
+                code="",
+                args=["rename", f"{test_file}:1:5", "new_name"],
+                kwargs={},
+                confirm=lambda x: True,
+            )
+
+    assert result is not None
+    assert "Rename to 'new_name'" in result.content
+    assert "1 edit(s) in 1 file(s)" in result.content
+    assert "**module.py**" in result.content
+    assert "Line 1:5-1:13" in result.content
+    mock_rename.assert_called_once_with(test_file, 1, 5, "new_name", tmp_path)
 
 
 def test_execute_diagnostics_missing_file(tmp_path):


### PR DESCRIPTION
## Summary

The gptme-lsp rename benchmark work: test coverage for the rename/edit-preview flow plus two small fixes.

### Changes
- **test(lsp): cover rename workspace edit preview** (`f8c551d`) — adds 110 lines of test coverage for the LSP rename workspace-edit preview path.
- **fix(lsp): index full workspace + fix diagnostics header** (`76cd914`) — index the full workspace instead of a partial scope, and fix the diagnostics header output.

### Files
- `plugins/gptme-lsp/src/gptme_lsp/lsp_client.py` (+3)
- `plugins/gptme-lsp/src/gptme_lsp/tools/lsp_tool.py` (+1/-1)
- `plugins/gptme-lsp/tests/test_lsp_tool.py` (+110)

## Notes
Parent work: gptme-lsp rename tool (done). Idea backlog: #1083. Rebased cleanly onto current `master` (3 files, +114/-1, 2 commits ahead, 0 behind).
