### PR TITLE
test(gptme-activity-summary): regression tests for deepseek preamble parse + prompt narrative contract

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -688,6 +688,7 @@ Guidelines:
 - external_signals: News, model releases, ecosystem developments, research findings, podcast mentions
 - Reference PRs and issues using full owner/repo#NNN format (e.g. gptme/gptme#1265) so they can be hyperlinked
 - DO NOT include a "metrics" field — metrics are tracked separately from real data
+- The FIRST non-empty assistant message must be the final JSON object with a top-level "narrative" field. Do not emit any thinking preamble or reasoning text before the JSON — output the JSON object as the very first assistant message.
 
 Journal Entries ({len(entries)} total):
 ---

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -1,0 +1,114 @@
+"""Tests for the gptme fallback backend (gptme_backend.py).
+
+Covers the deepseek reasoning-model preamble gap: a JSON-shaped thinking
+preamble (e.g. ``{"thinking": "..."}``) emitted before the real answer must
+never be returned in place of the actual summary. The parser must scan all
+JSON-parseable assistant candidates and prefer the one containing a recognised
+summary key, with the final answer winning over an earlier preamble.
+"""
+
+from gptme_activity_summary.gptme_backend import (
+    _DEFAULT_MODEL,
+    _extract_assistant_text,
+    call_gptme,
+    is_enabled,
+)
+
+
+def _msg(content) -> str:
+    """Build a single gptme NDJSON assistant message line."""
+    import json
+
+    return json.dumps({"type": "message", "role": "assistant", "content": content})
+
+
+def test_returns_empty_on_no_assistant_messages():
+    """No assistant messages => empty string (best-effort, never raises)."""
+    assert _extract_assistant_text("") == ""
+    assert _extract_assistant_text('{"type":"message","role":"user","content":"hi"}') == ""
+
+
+def test_extracts_plain_json_answer():
+    """A single clean JSON answer is returned as-is."""
+    ndjson = _msg('{"narrative": "done", "accomplishments": ["x"]}')
+    out = _extract_assistant_text(ndjson)
+    assert "narrative" in out
+
+
+def test_deepseek_preamble_then_json_answer():
+    """Regression: deepseek emits a JSON-shaped thinking preamble, then the real
+    JSON answer. The parser must return the real answer, not the preamble."""
+    ndjson = "\n".join(
+        [
+            _msg('{"thinking": "Let me analyze the journal carefully"}'),
+            _msg('{"narrative": "REAL summary", "accomplishments": ["a"]}'),
+        ]
+    )
+    out = _extract_assistant_text(ndjson)
+    # The preamble has no recognized summary key; the answer does.
+    assert "REAL summary" in out
+    assert "thinking" not in out
+
+
+def test_deepseek_preamble_echoes_narrative_key_still_prefers_final_answer():
+    """Regression: even when the preamble itself contains a recognised key
+    (a thinking preamble echoing ``narrative``), the final real answer wins
+    because the parser scans in reverse (last-wins)."""
+    ndjson = "\n".join(
+        [
+            _msg('{"thinking": "hmm", "narrative": "draft preamble"}'),
+            _msg('{"narrative": "REAL final summary", "accomplishments": ["a"]}'),
+        ]
+    )
+    out = _extract_assistant_text(ndjson)
+    assert "REAL final summary" in out
+    assert "draft preamble" not in out
+
+
+def test_deepseek_preamble_in_text_then_codeblock_answer():
+    """The preamble may be wrapped in prose; the real answer may be a markdown
+    code block. The fallback should still hand back the answer text so the
+    caller's extract_json_from_response can parse the code block."""
+    ndjson = "\n".join(
+        [
+            _msg("Let me think about this:\n{\"thinking\": \"hmm\"}"),
+            _msg("```json\n{\"narrative\": \"final\"}\n```"),
+        ]
+    )
+    out = _extract_assistant_text(ndjson)
+    # Preamble is not JSON-parseable as a candidate; the code block is returned
+    # as the last message, from which the caller extracts the JSON.
+    assert '"narrative": "final"' in out
+
+
+def test_list_content_text_messages():
+    """Content as a list of text parts is collected too (current gptme format)."""
+    ndjson = "\n".join(
+        [
+            _msg([{"type": "text", "text": '{"thinking": "plan"}'}]),
+            _msg([{"type": "text", "text": '{"narrative": "list format answer"}'}]),
+        ]
+    )
+    out = _extract_assistant_text(ndjson)
+    assert "list format answer" in out
+
+
+def test_is_enabled_off_by_default():
+    """The fallback is off by default (no env set) to avoid data exfiltration."""
+    import os
+
+    os.environ.pop("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", None)
+    assert is_enabled() is False
+
+
+def test_default_model_is_deepseek_flash():
+    """The default fallback model is the cheap privacy-gated deepseek opt-in."""
+    assert "deepseek" in _DEFAULT_MODEL and "flash" in _DEFAULT_MODEL
+
+
+def test_call_gptme_returns_empty_when_disabled():
+    """call_gptme is best-effort and returns '' when the fallback is disabled."""
+    import os
+
+    os.environ.pop("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", None)
+    assert call_gptme("ignored prompt") == ""

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -71,8 +71,8 @@ def test_deepseek_preamble_in_text_then_codeblock_answer():
     caller's extract_json_from_response can parse the code block."""
     ndjson = "\n".join(
         [
-            _msg("Let me think about this:\n{\"thinking\": \"hmm\"}"),
-            _msg("```json\n{\"narrative\": \"final\"}\n```"),
+            _msg('Let me think about this:\n{"thinking": "hmm"}'),
+            _msg('```json\n{"narrative": "final"}\n```'),
         ]
     )
     out = _extract_assistant_text(ndjson)

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -93,11 +93,9 @@ def test_list_content_text_messages():
     assert "list format answer" in out
 
 
-def test_is_enabled_off_by_default():
+def test_is_enabled_off_by_default(monkeypatch):
     """The fallback is off by default (no env set) to avoid data exfiltration."""
-    import os
-
-    os.environ.pop("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", None)
+    monkeypatch.delenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", raising=False)
     assert is_enabled() is False
 
 
@@ -106,9 +104,7 @@ def test_default_model_is_deepseek_flash():
     assert "deepseek" in _DEFAULT_MODEL and "flash" in _DEFAULT_MODEL
 
 
-def test_call_gptme_returns_empty_when_disabled():
+def test_call_gptme_returns_empty_when_disabled(monkeypatch):
     """call_gptme is best-effort and returns '' when the fallback is disabled."""
-    import os
-
-    os.environ.pop("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", None)
+    monkeypatch.delenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", raising=False)
     assert call_gptme("ignored prompt") == ""


### PR DESCRIPTION
## Problem

The 2026-08-28 daily-summary failure was a subscription-fragility double-fault: the deepseek-v4-flash reasoning model emits a JSON-shaped thinking preamble (`{"thinking": "..."}`) before the real answer. The gptme fallback parser (`_extract_assistant_text`, shipped in #1489) now correctly scans all JSON-parseable candidates and prefers the recognised summary key (last-wins), which closes the original parse gap on master.

Two deliverables from the tracked issue were still missing.

## What this PR does

1. **Regression test suite** (`tests/test_gptme_backend.py`, 9 tests) — locks in the deepseek preamble behaviour: preamble-then-answer, preamble that echoes the `narrative` key (last-wins), preamble wrapped in prose + code-block answer, list-content messages, and best-effort disabled-path defaults.
2. **Prompt-level narrative contract** — the daily prompt now explicitly requires the *first non-empty assistant message* to be the final JSON object with a top-level `narrative` field, and forbids emitting any thinking preamble before the JSON.

## Verification

- `pytest packages/gptme-activity-summary/tests/` → **237 passed** (9 new + 77 cc_backend + rest)
- `mypy` on gptme_backend.py + cc_backend.py → clean
- Pre-commit (`prek`) passed

## Notes

The parser widening itself is already on master (commits 8c368bb8, bb2fc5ee, 6c604c3a). This PR is the missing test + prompt-contract half of the gptme-fallback-parse-deepseek-preamble task.