### PR TITLE
fix(gptme-activity-summary): strip think tags + raw_decode JSON in gptme fallback

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -507,15 +507,31 @@ def extract_json_from_response(response: str) -> dict[str, Any]:
     except json.JSONDecodeError:
         pass
 
-    # Try to find JSON object in the response
-    json_match = re.search(r"\{[\s\S]*\}", response)
-    if json_match:
+    # Try to find JSON object in the response using raw_decode to avoid
+    # the greedy-regex trap where <think>content with {braces}</think>
+    # followed by {"narrative": "..."} causes the regex to match too broadly.
+    # raw_decode finds all valid top-level JSON objects; prefer the last one
+    # with a recognised summary key (handles preamble-then-answer patterns).
+    decoder = json.JSONDecoder()
+    pos = 0
+    json_objects: list[dict[str, Any]] = []
+    while pos < len(response):
+        start = response.find("{", pos)
+        if start == -1:
+            break
         try:
-            result = json.loads(json_match.group(0))
-            if isinstance(result, dict):
-                return result
+            obj, end = decoder.raw_decode(response, start)
+            if isinstance(obj, dict):
+                json_objects.append(obj)
+            pos = end
         except json.JSONDecodeError:
-            pass
+            pos = start + 1
+    if json_objects:
+        _narrative_keys = ("narrative", "month_narrative")
+        for obj in reversed(json_objects):
+            if any(obj.get(k) for k in _narrative_keys):
+                return obj
+        return json_objects[-1]
 
     # Return empty dict if no JSON found
     return {}

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -122,6 +122,21 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
 
 
 _THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>", re.DOTALL)
+# gptme's no-tool-call auto-reply. Shared prefix of both variants in
+# gptme.tools.complete ("No tool call detected" / "... in last message").
+_GPTME_TRAILER_MARKER = "No tool call detected"
+
+
+def _is_gptme_trailer(text: str) -> bool:
+    """True if this assistant message is gptme's no-tool-call auto-reply.
+
+    After a successful JSON answer gptme injects a later non-JSON assistant
+    message ("No tool call detected ... use the `complete` tool"). That
+    trailer is not a better summary; preferring it over a JSON object that
+    already carries ``narrative``/``month_narrative`` re-breaks the
+    daily-summary fallback.
+    """
+    return _GPTME_TRAILER_MARKER in text
 
 
 def _strip_think_tags(text: str) -> str:
@@ -183,9 +198,28 @@ def _extract_assistant_text(stdout: str) -> str:
         # JSON-shaped thinking preamble that may also contain a summary key.
         # Reasoning models (e.g. deepseek) emit a preamble first, then the
         # real answer; scanning forward would return the preamble instead.
+        json_set = set(json_candidates)
         for candidate in reversed(json_candidates):
             parsed = json.loads(candidate)
             if isinstance(parsed, dict) and any(parsed.get(k) for k in _SUMMARY_KEYS):
+                # A later non-JSON message that is *not* gptme's auto-reply
+                # trailer is the real answer (JSON draft, then prose). The
+                # trailer-only case must keep the JSON.
+                json_index = max(i for i, c in enumerate(contents) if c == candidate)
+                later_prose = [
+                    c
+                    for c in contents[json_index + 1 :]
+                    if c not in json_set and not _is_gptme_trailer(c)
+                ]
+                if later_prose:
+                    logger.debug(
+                        "gptme fallback: JSON with summary key followed by "
+                        "later non-trailer prose; preferring prose "
+                        "(%d chars): %.100r",
+                        len(later_prose[-1]),
+                        later_prose[-1],
+                    )
+                    return later_prose[-1]
                 logger.debug(
                     "gptme fallback: returning JSON with summary key (%d chars): %.100r",
                     len(candidate),

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -139,6 +139,18 @@ def _is_gptme_trailer(text: str) -> bool:
     return _GPTME_TRAILER_MARKER in text
 
 
+def _last_non_trailer(messages: list[str]) -> str:
+    """Last message that is not gptme's no-tool-call auto-reply.
+
+    Falls back to ``messages[-1]`` if every message is a trailer (or the
+    list is empty, which the caller already guards).
+    """
+    for message in reversed(messages):
+        if not _is_gptme_trailer(message):
+            return message
+    return messages[-1] if messages else ""
+
+
 def _strip_think_tags(text: str) -> str:
     """Strip <think>...</think> reasoning blocks from model output.
 
@@ -233,13 +245,14 @@ def _extract_assistant_text(stdout: str) -> str:
         # code blocks, etc.).
         non_json = [c for c in contents if c not in set(json_candidates)]
         if non_json:
+            chosen = _last_non_trailer(non_json)
             logger.warning(
                 "gptme fallback: no JSON candidate has summary key; "
                 "falling back to last non-JSON content (%d chars): %.100r",
-                len(non_json[-1]),
-                non_json[-1],
+                len(chosen),
+                chosen,
             )
-            return non_json[-1]
+            return chosen
         logger.warning(
             "gptme fallback: no JSON candidate has summary key; "
             "returning last JSON candidate (%d chars): %.100r",
@@ -247,10 +260,11 @@ def _extract_assistant_text(stdout: str) -> str:
             json_candidates[-1],
         )
         return json_candidates[-1]
+    chosen = _last_non_trailer(contents)
     logger.warning(
         "gptme fallback: no assistant message parsed as JSON (%d messages); "
         "returning last message for caller to attempt extraction: %.100r",
         len(contents),
-        contents[-1],
+        chosen,
     )
-    return contents[-1]
+    return chosen

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -125,6 +125,7 @@ _THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>", re.DOTALL)
 # gptme's no-tool-call auto-reply. Shared prefix of both variants in
 # gptme.tools.complete ("No tool call detected" / "... in last message").
 _GPTME_TRAILER_MARKER = "No tool call detected"
+_SUMMARY_KEYS = ("narrative", "month_narrative")
 
 
 def _is_gptme_trailer(text: str) -> bool:
@@ -162,6 +163,33 @@ def _strip_think_tags(text: str) -> str:
     return _THINK_TAG_RE.sub("", text).strip()
 
 
+def _has_summary_json(text: str) -> bool:
+    """True if ``text`` contains a JSON object with a recognised summary key.
+
+    Completion-ack messages mention the word ``narrative`` without carrying a
+    JSON object. Preferring those over an earlier JSON answer is what broke
+    the 2026-08-30 live fallback (gptme log ``dancing-sad-monster``): DeepSeek
+    emitted a complete summary JSON, then "I have completed the analysis."
+    ``extract_json_from_response`` lives in ``cc_backend`` (which imports this
+    module), so this predicate stays local to avoid a circular import.
+    """
+    decoder = json.JSONDecoder()
+    pos = 0
+    while pos < len(text):
+        start = text.find("{", pos)
+        if start == -1:
+            return False
+        try:
+            obj, end = decoder.raw_decode(text, start)
+        except json.JSONDecodeError:
+            pos = start + 1
+            continue
+        if isinstance(obj, dict) and any(obj.get(k) for k in _SUMMARY_KEYS):
+            return True
+        pos = end
+    return False
+
+
 def _extract_assistant_text(stdout: str) -> str:
     """Collect assistant message contents from gptme NDJSON output."""
     contents: list[str] = []
@@ -197,7 +225,6 @@ def _extract_assistant_text(stdout: str) -> str:
     # summary key so that a JSON-shaped preamble is not returned instead of the
     # real answer; only fall back to the first JSON-parseable if none contain a
     # recognised key.
-    _SUMMARY_KEYS = ("narrative", "month_narrative")
     json_candidates: list[str] = []
     for candidate in contents:
         try:
@@ -214,24 +241,23 @@ def _extract_assistant_text(stdout: str) -> str:
         for candidate in reversed(json_candidates):
             parsed = json.loads(candidate)
             if isinstance(parsed, dict) and any(parsed.get(k) for k in _SUMMARY_KEYS):
-                # A later non-JSON message that is *not* gptme's auto-reply
-                # trailer is the real answer (JSON draft, then prose). The
-                # trailer-only case must keep the JSON.
+                # Later prose only wins if it *itself* carries a summary JSON
+                # object (e.g. a fenced JSON revision). Completion-ack prose
+                # ("I have completed the analysis") and gptme trailers do not.
                 json_index = max(i for i, c in enumerate(contents) if c == candidate)
                 later_prose = [
                     c
                     for c in contents[json_index + 1 :]
                     if c not in json_set and not _is_gptme_trailer(c)
                 ]
-                if later_prose:
-                    logger.debug(
-                        "gptme fallback: JSON with summary key followed by "
-                        "later non-trailer prose; preferring prose "
-                        "(%d chars): %.100r",
-                        len(later_prose[-1]),
-                        later_prose[-1],
-                    )
-                    return later_prose[-1]
+                for prose in reversed(later_prose):
+                    if _has_summary_json(prose):
+                        logger.debug(
+                            "gptme fallback: later prose carries summary JSON "
+                            "(%d chars); preferring it over earlier JSON draft",
+                            len(prose),
+                        )
+                        return prose
                 logger.debug(
                     "gptme fallback: returning JSON with summary key (%d chars): %.100r",
                     len(candidate),

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -14,6 +14,7 @@ failure so the caller can degrade gracefully.
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 
@@ -120,6 +121,20 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
     return _extract_assistant_text(result.stdout)
 
 
+_THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>", re.DOTALL)
+
+
+def _strip_think_tags(text: str) -> str:
+    """Strip <think>...</think> reasoning blocks from model output.
+
+    Some reasoning models (e.g. DeepSeek) embed internal reasoning in
+    <think>...</think> blocks before the actual response. These blocks may
+    themselves contain JSON-shaped text that confuses downstream JSON
+    extraction; stripping them before processing avoids greedy-regex traps.
+    """
+    return _THINK_TAG_RE.sub("", text).strip()
+
+
 def _extract_assistant_text(stdout: str) -> str:
     """Collect assistant message contents from gptme NDJSON output."""
     contents: list[str] = []
@@ -134,13 +149,18 @@ def _extract_assistant_text(stdout: str) -> str:
         if obj.get("type") == "message" and obj.get("role") == "assistant":
             content = obj.get("content")
             if isinstance(content, str) and content.strip():
-                contents.append(content)
+                # Strip <think>...</think> reasoning blocks before recording.
+                stripped = _strip_think_tags(content)
+                if stripped:
+                    contents.append(stripped)
             elif isinstance(content, list):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "text":
                         text = part.get("text", "")
                         if isinstance(text, str) and text.strip():
-                            contents.append(text)
+                            stripped = _strip_think_tags(text)
+                            if stripped:
+                                contents.append(stripped)
     if not contents:
         logger.warning("gptme fallback produced no assistant messages")
         return ""
@@ -166,11 +186,37 @@ def _extract_assistant_text(stdout: str) -> str:
         for candidate in reversed(json_candidates):
             parsed = json.loads(candidate)
             if isinstance(parsed, dict) and any(parsed.get(k) for k in _SUMMARY_KEYS):
+                logger.debug(
+                    "gptme fallback: returning JSON with summary key (%d chars): %.100r",
+                    len(candidate),
+                    candidate,
+                )
                 return candidate
+        # No JSON candidate has a summary key. Prefer non-JSON content if
+        # available — the real answer may be plain text while the JSON was
+        # a preamble (e.g. {"thinking": "..."}).  Let extract_json_from_response
+        # try to pull JSON out of the plain text (handles embedded JSON,
+        # code blocks, etc.).
+        non_json = [c for c in contents if c not in set(json_candidates)]
+        if non_json:
+            logger.warning(
+                "gptme fallback: no JSON candidate has summary key; "
+                "falling back to last non-JSON content (%d chars): %.100r",
+                len(non_json[-1]),
+                non_json[-1],
+            )
+            return non_json[-1]
+        logger.warning(
+            "gptme fallback: no JSON candidate has summary key; "
+            "returning last JSON candidate (%d chars): %.100r",
+            len(json_candidates[-1]),
+            json_candidates[-1],
+        )
         return json_candidates[-1]
-    logger.debug(
+    logger.warning(
         "gptme fallback: no assistant message parsed as JSON (%d messages); "
-        "returning last message for caller to attempt extraction",
+        "returning last message for caller to attempt extraction: %.100r",
         len(contents),
+        contents[-1],
     )
     return contents[-1]

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -8,18 +8,21 @@ Covers:
   must scan all JSON-parseable assistant candidates and prefer the one
   containing a recognised summary key, with the final answer winning over an
   earlier preamble.
-- JSON draft then later prose: if a JSON candidate already has a summary key
-  but a later non-JSON message is real prose (not gptme's no-tool-call
-  trailer), the prose wins. The gptme trailer itself must not displace JSON.
+- JSON answer then later prose: later prose only wins if it *embeds* a
+  summary JSON object. Completion-ack messages ("I have completed the
+  analysis") and gptme trailers must not displace a JSON answer. This is
+  the 2026-08-30 dancing-sad-monster regression.
 - Logging paths that surface what was extracted (regression-guard for silent
   fallback failures where nothing was logged).
 """
 
 import json
 
+from gptme_activity_summary.cc_backend import extract_json_from_response
 from gptme_activity_summary.gptme_backend import (
     _DEFAULT_MODEL,
     _extract_assistant_text,
+    _has_summary_json,
     _strip_think_tags,
     call_gptme,
     is_enabled,
@@ -202,20 +205,46 @@ def test_no_json_candidate_falls_back_to_non_json_content():
     assert out == plain_answer
 
 
-def test_json_draft_then_later_prose_prefers_prose():
-    """JSON with a summary key is still a draft if later prose is the answer.
+def test_json_answer_then_completion_ack_keeps_json():
+    """Completion-ack prose must not displace a JSON summary.
 
-    A reasoning model can emit a preliminary JSON object that includes
-    ``narrative``, then the actual final answer as plain text. Returning the
-    draft would discard the real answer. gptme trailers are excluded from
-    this path (see ``test_json_answer_then_gptme_trailer_keeps_json``).
+    Live 2026-08-30 failure (gptme log ``dancing-sad-monster``): DeepSeek
+    emitted a complete ``narrative`` JSON, then "I have completed the
+    analysis. The full JSON summary ... was emitted in my previous
+    message." That ack mentions the word ``narrative`` but has no JSON
+    object. Preferring it made ``extract_json_from_response`` return {} and
+    the systemd unit failed 12/12 even though the real summary was in the
+    previous assistant message.
+    """
+    answer = json.dumps({"narrative": "REAL summary", "accomplishments": ["a"]})
+    ack = (
+        "I have completed the analysis. The full JSON summary for 2026-08-29 "
+        "was emitted in my previous message. The work is done — it has a "
+        "top-level narrative field as requested.\n\n```complete\n```"
+    )
+    ndjson = "\n".join([_msg(answer), _msg(ack)])
+    out = _extract_assistant_text(ndjson)
+    parsed = json.loads(out)
+    assert parsed.get("narrative") == "REAL summary"
+    assert "I have completed" not in out
+
+
+def test_json_draft_then_later_prose_with_summary_json_prefers_later():
+    """Later prose still wins when it *embeds* a summary JSON object.
+
+    A model can emit a JSON draft, then a fenced JSON revision. That later
+    payload is the real answer; keep preferring it over the draft.
     """
     draft = json.dumps({"narrative": "draft preamble", "accomplishments": ["x"]})
-    prose = "Bob shipped the think-tag parser and landed fourteen tests."
+    prose = "Final answer:\n" + json.dumps(
+        {"narrative": "revised summary", "accomplishments": ["y"]}
+    )
     ndjson = "\n".join([_msg(draft), _msg(prose)])
     out = _extract_assistant_text(ndjson)
     assert out == prose
-    assert "draft preamble" not in out
+    assert _has_summary_json(out)
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "revised summary"
 
 
 def test_json_answer_then_gptme_trailer_keeps_json():
@@ -238,14 +267,46 @@ def test_json_answer_then_gptme_trailer_keeps_json():
     assert parsed.get("narrative") == "REAL summary"
 
 
-def test_json_draft_then_prose_then_trailer_prefers_prose():
-    """Prose between a JSON draft and the gptme trailer still wins."""
-    draft = json.dumps({"narrative": "draft"})
-    prose = "The real final answer in plain text."
+def test_json_draft_then_ack_then_trailer_keeps_json():
+    """Completion-ack between a JSON answer and the gptme trailer still loses."""
+    draft = json.dumps({"narrative": "kept summary"})
+    ack = "I have completed the analysis. The full JSON summary was emitted above."
     trailer = "No tool call detected in last message."
-    ndjson = "\n".join([_msg(draft), _msg(prose), _msg(trailer)])
+    ndjson = "\n".join([_msg(draft), _msg(ack), _msg(trailer)])
     out = _extract_assistant_text(ndjson)
-    assert out == prose
+    parsed = json.loads(out)
+    assert parsed.get("narrative") == "kept summary"
+
+
+def test_truncated_think_json_then_complete_json_then_ack():
+    """Live shape: truncated think-JSON, complete think-JSON, then an ack.
+
+    Mirrors the 2026-08-30 dancing-sad-monster fallback: first assistant
+    message is cut off mid-JSON inside ``<think>``, second is a complete
+    summary JSON after a think block, third is a completion-ack. The
+    extractor must return the complete JSON, not the ack.
+    """
+    truncated = (
+        "<think>I'll emit JSON.</think>\n"
+        '{"accomplishments": ["partial"], "blockers": [{"issue": "unterminated"'
+    )
+    complete = "<think>I was cut off. Finishing the JSON.</think>\n" + json.dumps(
+        {
+            "narrative": "recovered daily summary",
+            "accomplishments": ["parser fix"],
+            "blockers": [{"issue": "oauth expired", "status": "active"}],
+        }
+    )
+    ack = (
+        "I have completed the analysis. The full JSON summary was emitted in "
+        "my previous message. It includes narrative, accomplishments, and "
+        "blockers."
+    )
+    ndjson = "\n".join([_msg(truncated), _msg(complete), _msg(ack)])
+    out = _extract_assistant_text(ndjson)
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "recovered daily summary"
+    assert parsed.get("accomplishments") == ["parser fix"]
 
 
 def test_thinking_json_then_prose_then_trailer_skips_trailer():

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -8,6 +8,9 @@ Covers:
   must scan all JSON-parseable assistant candidates and prefer the one
   containing a recognised summary key, with the final answer winning over an
   earlier preamble.
+- JSON draft then later prose: if a JSON candidate already has a summary key
+  but a later non-JSON message is real prose (not gptme's no-tool-call
+  trailer), the prose wins. The gptme trailer itself must not displace JSON.
 - Logging paths that surface what was extracted (regression-guard for silent
   fallback failures where nothing was logged).
 """
@@ -197,6 +200,52 @@ def test_no_json_candidate_falls_back_to_non_json_content():
     out = _extract_assistant_text(ndjson)
     # Should return the plain-text answer, not the JSON preamble
     assert out == plain_answer
+
+
+def test_json_draft_then_later_prose_prefers_prose():
+    """JSON with a summary key is still a draft if later prose is the answer.
+
+    A reasoning model can emit a preliminary JSON object that includes
+    ``narrative``, then the actual final answer as plain text. Returning the
+    draft would discard the real answer. gptme trailers are excluded from
+    this path (see ``test_json_answer_then_gptme_trailer_keeps_json``).
+    """
+    draft = json.dumps({"narrative": "draft preamble", "accomplishments": ["x"]})
+    prose = "Bob shipped the think-tag parser and landed fourteen tests."
+    ndjson = "\n".join([_msg(draft), _msg(prose)])
+    out = _extract_assistant_text(ndjson)
+    assert out == prose
+    assert "draft preamble" not in out
+
+
+def test_json_answer_then_gptme_trailer_keeps_json():
+    """gptme's no-tool-call auto-reply must not displace a JSON summary.
+
+    Production path: first assistant message is the JSON answer, then gptme
+    injects "No tool call detected ... use the `complete` tool". Preferring
+    that later prose would return the trailer instead of the real answer and
+    re-break the daily-summary fallback.
+    """
+    answer = json.dumps({"narrative": "REAL summary", "accomplishments": ["a"]})
+    trailer = (
+        "<system>No tool call detected in last message. Did you mean to finish? "
+        "If so, make sure you are completely done and then use the `complete` "
+        "tool to end the session.</system>"
+    )
+    ndjson = "\n".join([_msg(answer), _msg(trailer)])
+    out = _extract_assistant_text(ndjson)
+    parsed = json.loads(out)
+    assert parsed.get("narrative") == "REAL summary"
+
+
+def test_json_draft_then_prose_then_trailer_prefers_prose():
+    """Prose between a JSON draft and the gptme trailer still wins."""
+    draft = json.dumps({"narrative": "draft"})
+    prose = "The real final answer in plain text."
+    trailer = "No tool call detected in last message."
+    ndjson = "\n".join([_msg(draft), _msg(prose), _msg(trailer)])
+    out = _extract_assistant_text(ndjson)
+    assert out == prose
 
 
 def test_multipart_content_list():

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -1,15 +1,23 @@
 """Tests for the gptme fallback backend (gptme_backend.py).
 
-Covers the deepseek reasoning-model preamble gap: a JSON-shaped thinking
-preamble (e.g. ``{"thinking": "..."}``) emitted before the real answer must
-never be returned in place of the actual summary. The parser must scan all
-JSON-parseable assistant candidates and prefer the one containing a recognised
-summary key, with the final answer winning over an earlier preamble.
+Covers:
+- DeepSeek reasoning-model <think>...</think> tag stripping so that embedded
+  JSON inside think blocks does not confuse the downstream JSON extractor.
+- JSON-shaped preamble handling: a preamble emitted as a separate assistant
+  message must never be returned in place of the actual summary. The parser
+  must scan all JSON-parseable assistant candidates and prefer the one
+  containing a recognised summary key, with the final answer winning over an
+  earlier preamble.
+- Logging paths that surface what was extracted (regression-guard for silent
+  fallback failures where nothing was logged).
 """
+
+import json
 
 from gptme_activity_summary.gptme_backend import (
     _DEFAULT_MODEL,
     _extract_assistant_text,
+    _strip_think_tags,
     call_gptme,
     is_enabled,
 )
@@ -17,9 +25,93 @@ from gptme_activity_summary.gptme_backend import (
 
 def _msg(content) -> str:
     """Build a single gptme NDJSON assistant message line."""
-    import json
-
     return json.dumps({"type": "message", "role": "assistant", "content": content})
+
+
+# ---------------------------------------------------------------------------
+# _strip_think_tags
+# ---------------------------------------------------------------------------
+
+
+def test_strip_think_tags_basic():
+    """Simple <think>...</think> block is removed."""
+    raw = '<think>I\'ll think about this...</think>\n{"narrative": "done"}'
+    result = _strip_think_tags(raw)
+    assert "<think>" not in result
+    assert "narrative" in result
+
+
+def test_strip_think_tags_with_braces_inside():
+    """Think block containing {braces} is fully stripped."""
+    raw = '<think>let me use {"structure": "json"}</think>\n{"narrative": "ok"}'
+    result = _strip_think_tags(raw)
+    assert "<think>" not in result
+    assert '"structure"' not in result
+    assert '"narrative"' in result
+
+
+def test_strip_think_tags_multiline():
+    raw = '<think>\nLine one.\nLine two.\n</think>\n{"narrative": "result"}'
+    result = _strip_think_tags(raw)
+    assert "Line one." not in result
+    assert "narrative" in result
+
+
+def test_strip_think_tags_noop_when_absent():
+    """No <think> tags → string unchanged."""
+    raw = '{"narrative": "clean"}'
+    assert _strip_think_tags(raw) == raw
+
+
+def test_strip_think_tags_multiple_blocks():
+    """Multiple disjoint <think> blocks are all stripped."""
+    raw = "<think>first</think> middle <think>second</think> end"
+    result = _strip_think_tags(raw)
+    assert "first" not in result
+    assert "second" not in result
+    assert "middle" in result
+    assert "end" in result
+
+
+# ---------------------------------------------------------------------------
+# _extract_assistant_text — think tag in content
+# ---------------------------------------------------------------------------
+
+
+def test_think_tag_stripped_before_json_extraction():
+    """Content starting with <think>...</think> yields the JSON that follows."""
+    content = '<think>Analyzing the activities...</think>\n{"narrative": "Bob shipped fixes"}'
+    ndjson = _msg(content)
+    out = _extract_assistant_text(ndjson)
+    # After stripping the think block, the remaining text is valid JSON
+    assert "narrative" in out
+
+
+def test_think_tag_with_nested_braces_does_not_confuse_parser():
+    """Think block containing {key: val} JSON-shaped text is stripped cleanly."""
+    content = (
+        '<think>I should output {"type": "summary", "key": "val"}</think>\n'
+        '{"narrative": "real answer here"}'
+    )
+    ndjson = _msg(content)
+    out = _extract_assistant_text(ndjson)
+    # The real answer (not the think-block JSON) should be returned
+    parsed = json.loads(out)
+    assert parsed.get("narrative") == "real answer here"
+
+
+def test_pure_think_tag_with_no_trailing_content():
+    """If stripping a think block leaves nothing, fall back gracefully."""
+    content = "<think>All reasoning, no output.</think>"
+    ndjson = _msg(content)
+    # Should not raise; may return "" or last content
+    result = _extract_assistant_text(ndjson)
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _extract_assistant_text — JSON preamble (separate messages)
+# ---------------------------------------------------------------------------
 
 
 def test_returns_empty_on_no_assistant_messages():
@@ -91,6 +183,30 @@ def test_list_content_text_messages():
     )
     out = _extract_assistant_text(ndjson)
     assert "list format answer" in out
+
+
+def test_no_json_candidate_falls_back_to_non_json_content():
+    """When only the preamble is JSON and the answer is plain text, return plain text.
+
+    The plain text is returned so that extract_json_from_response can attempt
+    JSON extraction (e.g. via code blocks or embedded JSON regex).
+    """
+    preamble = json.dumps({"thinking": "reasoning"})
+    plain_answer = "Bob shipped many fixes today."
+    ndjson = "\n".join([_msg(preamble), _msg(plain_answer)])
+    out = _extract_assistant_text(ndjson)
+    # Should return the plain-text answer, not the JSON preamble
+    assert out == plain_answer
+
+
+def test_multipart_content_list():
+    """Content as a list of parts (multipart message format)."""
+    content_parts = [
+        {"type": "text", "text": '{"narrative": "from list content"}'},
+    ]
+    ndjson = json.dumps({"type": "message", "role": "assistant", "content": content_parts})
+    out = _extract_assistant_text(ndjson)
+    assert "narrative" in out
 
 
 def test_is_enabled_off_by_default(monkeypatch):

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -248,6 +248,34 @@ def test_json_draft_then_prose_then_trailer_prefers_prose():
     assert out == prose
 
 
+def test_thinking_json_then_prose_then_trailer_skips_trailer():
+    """No-summary JSON plus later prose must not lose to gptme's trailer.
+
+    When no JSON candidate has a summary key, the fallback used to return
+    ``non_json[-1]``, which is the trailer if gptme auto-replied after the
+    plain-text answer.
+    """
+    preamble = json.dumps({"thinking": "reasoning"})
+    prose = "Bob shipped many fixes today."
+    trailer = (
+        "<system>No tool call detected in last message. Did you mean to finish? "
+        "If so, make sure you are completely done and then use the `complete` "
+        "tool to end the session.</system>"
+    )
+    ndjson = "\n".join([_msg(preamble), _msg(prose), _msg(trailer)])
+    out = _extract_assistant_text(ndjson)
+    assert out == prose
+
+
+def test_plain_text_then_trailer_skips_trailer():
+    """With no JSON at all, skip gptme's trailer and return the last prose."""
+    prose = "Bob shipped the think-tag parser."
+    trailer = "No tool call detected in last message."
+    ndjson = "\n".join([_msg(prose), _msg(trailer)])
+    out = _extract_assistant_text(ndjson)
+    assert out == prose
+
+
 def test_multipart_content_list():
     """Content as a list of parts (multipart message format)."""
     content_parts = [


### PR DESCRIPTION
## Summary

Fixes the root cause of 0/12 daily summary failures when the gptme fallback
is active and deepseek-v4-flash-0731 emits reasoning-model output.

## Root cause

DeepSeek reasoning models prefix their response with a `<think>…</think>`
block. That block may itself contain JSON-shaped text (e.g. internal
reasoning about what JSON to emit). Two bugs combined to break the fallback:

1. **Greedy regex in `cc_backend.extract_json_from_response`** — the
   pattern `{[\s\S]*}` grabbed from the first `{` inside the think block
   all the way to the last `}` in the real answer, producing one large
   unparseable blob. Fix: replaced with a `json.JSONDecoder().raw_decode()`
   scan that finds all complete, valid JSON objects in the response, then
   picks the last one that has a recognised summary key (`narrative` /
   `month_narrative`).

2. **Think blocks not stripped in `gptme_backend._extract_assistant_text`**
   — even after assembling assistant-message content from the NDJSON stream,
   embedded JSON inside think tags could pass down to
   `extract_json_from_response` and trigger the same failure. Fix: added
   `_strip_think_tags()` (non-greedy DOTALL regex) applied to each content
   chunk before accumulation.

Also improves preamble handling: when no JSON candidate has a summary key
(e.g. only a `{"thinking": "…"}` preamble was emitted), the backend now
prefers non-JSON content (the prose answer) over returning the preamble.

## Tests

14 new unit tests in `tests/test_gptme_backend.py`:

- **`_strip_think_tags`**: basic, braces-inside-think, multiline, noop, multiple blocks
- **`_extract_assistant_text`**: think-in-content, braces-confusion, pure-think,
  empty input, preamble-then-answer, preamble-wins regression, non-json-fallback,
  multipart-content-list

242 tests pass total (14 new + 228 pre-existing, including the 9 from PR #1547).

## Relation to #1547

PR #1547 (session e972) adds a prompt-level instruction
(`The FIRST non-empty assistant message must be the final JSON object`) and
regression tests for the existing parser. This PR is complementary: it fixes
the parser so it handles models that ignore the instruction (or emit think
blocks anyway), making the fallback robust against both prompt non-compliance
and the greedy-regex bug.

Related task: `activity-summary-fallback-shipped-but-never-rescues`