### PR TITLE
fix(pm): stop treating AI-reviewer output as PM's own activity

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -392,6 +392,88 @@ class ProjectMonitoringRun(BaseRunLoop):
 
         return work_items
 
+    # The AI reviewer (scripts/github/ai-review.py) posts its output AS the
+    # agent's own GitHub account: a summary ISSUE comment carrying
+    # `<!-- bob-ai-review {...} -->` and per-finding INLINE review comments
+    # (pulls/{n}/comments) carrying `<!-- bob-ai-review-finding -->`. Both are
+    # INBOUND work for PM, not a response by the agent — treating them as "own
+    # activity" made self-review output invisible to dispatch (caught live on
+    # gptme/gptme#3669). Substring match covers every marker variant
+    # (bob-ai-review, -finding, -fp, -disposition, -unreviewable).
+    AI_REVIEW_MARKER = "bob-ai-review"
+
+    def _is_ai_reviewer_output(self, body: str | None) -> bool:
+        """True if a comment body is AI-reviewer output (inbound work)."""
+        return self.AI_REVIEW_MARKER in (body or "")
+
+    def _latest_inline_review_comment(self, repo: str, pr_number: int) -> dict | None:
+        """Fetch the newest inline review comment (pulls/{n}/comments).
+
+        `gh pr view --json comments` returns ISSUE comments only, and the AI
+        reviewer's summary issue comment is upserted in place (its createdAt
+        never moves) — so a fresh review pass can be visible ONLY through
+        inline review comments. Observed live on gptme/gptme#3669: last issue
+        comment was a plain self comment from 14:37Z while the fresh finding
+        landed inline at 15:58Z. One extra gh call, made only when the
+        issue-comment view alone would conclude "self".
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo}/pulls/{pr_number}/comments"
+                    "?sort=created&direction=desc&per_page=1",
+                    "--jq",
+                    '.[0] | {login: (.user.login // ""), '
+                    'body: (.body // ""), createdAt: (.created_at // "")}',
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                return None
+            comment = json.loads(result.stdout)
+            if not isinstance(comment, dict) or not comment.get("createdAt"):
+                return None
+            return comment
+        except Exception as e:
+            self.logger.warning(f"Error fetching inline review comments: {e}")
+            return None
+
+    def _last_activity_is_self_response(
+        self,
+        repo: str,
+        pr_number: int,
+        login: str,
+        body: str,
+        created_at: str,
+    ) -> bool:
+        """Classify the last ISSUE comment: is the PR's latest activity the
+        agent's own response (i.e. safe to skip dispatch for)?
+
+        AI-reviewer output posted under the agent's own login is inbound work,
+        never a response. And when the last issue comment is a plain self
+        comment, a newer INLINE review comment can still carry inbound
+        reviewer findings — check it before concluding "own activity".
+        """
+        if not self.author or login != self.author:
+            return False
+        if self._is_ai_reviewer_output(body):
+            # Reviewer output is inbound work, not a response.
+            return False
+        # Plain self issue comment. Inline review comments are invisible to
+        # `gh pr view --json comments`; a newer one may be inbound work.
+        inline = self._latest_inline_review_comment(repo, pr_number)
+        if inline and (not created_at or inline["createdAt"] > created_at):
+            # ISO-8601 UTC "Z" timestamps compare correctly as strings.
+            if inline.get("login") != self.author:
+                return False
+            if self._is_ai_reviewer_output(inline.get("body")):
+                return False
+        return True
+
     def _is_last_activity_by_self(self, repo: str, pr_number: int) -> bool:
         """Check if the last activity on the PR was by the agent.
 
@@ -400,10 +482,12 @@ class ProjectMonitoringRun(BaseRunLoop):
             pr_number: PR number
 
         Returns:
-            True if last comment/activity was by self (the configured author)
+            True if the latest activity is the agent's own RESPONSE. The AI
+            reviewer's output (posted under the same login) does not count —
+            see _last_activity_is_self_response.
         """
         try:
-            # Get last comment on PR
+            # Get last issue comment on PR (author + body + createdAt)
             result = subprocess.run(
                 [
                     "gh",
@@ -415,7 +499,9 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--json",
                     "comments",
                     "--jq",
-                    ".comments | sort_by(.createdAt) | last | .author.login",
+                    ".comments | sort_by(.createdAt) | last | "
+                    '{login: (.author.login // ""), body: (.body // ""), '
+                    'createdAt: (.createdAt // "")}',
                 ],
                 capture_output=True,
                 text=True,
@@ -426,8 +512,16 @@ class ProjectMonitoringRun(BaseRunLoop):
                 # No comments or error - assume not by self
                 return False
 
-            last_author = result.stdout.strip()
-            return last_author == self.author
+            last = json.loads(result.stdout)
+            if not isinstance(last, dict) or not last.get("login"):
+                return False
+            return self._last_activity_is_self_response(
+                repo,
+                pr_number,
+                last["login"],
+                last.get("body") or "",
+                last.get("createdAt") or "",
+            )
 
         except Exception as e:
             self.logger.warning(f"Error checking last activity author: {e}")
@@ -582,7 +676,10 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--json",
                     "updatedAt,comments",
                     "--jq",
-                    '{"updatedAt": .updatedAt, "lastCommentAuthor": (.comments | sort_by(.createdAt) | last | .author.login // "")}',
+                    '{"updatedAt": .updatedAt, "lastComment": '
+                    "(.comments | sort_by(.createdAt) | last | "
+                    '{login: (.author.login // ""), body: (.body // ""), '
+                    'createdAt: (.createdAt // "")})}',
                 ],
                 capture_output=True,
                 text=True,
@@ -595,7 +692,21 @@ class ProjectMonitoringRun(BaseRunLoop):
 
             pr_info = json.loads(result.stdout)
             current_updated = pr_info["updatedAt"]
-            last_activity_by_self = pr_info.get("lastCommentAuthor") == self.author
+            # "By self" means the agent's own RESPONSE — the AI reviewer posts
+            # under the same login, but its output (issue-comment summary or
+            # inline findings) is inbound work and must NOT suppress dispatch
+            # (gptme/gptme#3669). May cost one extra gh call in the ambiguous
+            # plain-self case; kept outside the lock below.
+            last_comment = pr_info.get("lastComment") or {}
+            last_activity_by_self = bool(
+                last_comment.get("login")
+            ) and self._last_activity_is_self_response(
+                repo,
+                pr_number,
+                last_comment.get("login") or "",
+                last_comment.get("body") or "",
+                last_comment.get("createdAt") or "",
+            )
 
             # Exclusive lock serializes concurrent sessions on this PR's state.
             # flock is released automatically when the file handle is closed.

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -398,13 +398,19 @@ class ProjectMonitoringRun(BaseRunLoop):
     # (pulls/{n}/comments) carrying `<!-- bob-ai-review-finding -->`. Both are
     # INBOUND work for PM, not a response by the agent — treating them as "own
     # activity" made self-review output invisible to dispatch (caught live on
-    # gptme/gptme#3669). Substring match covers every marker variant
-    # (bob-ai-review, -finding, -fp, -disposition, -unreviewable).
-    AI_REVIEW_MARKER = "bob-ai-review"
+    # gptme/gptme#3669). Same contract as activity-gate.sh AI_REVIEW_MARKER_RE:
+    # the marker must occupy a complete line. Quoting or inline-copying the
+    # marker in a reply stays self-chatter; a substring match classified those
+    # replies as inbound review and self-dispatched (P1 on gptme-contrib#1549).
+    _AI_REVIEWER_OUTPUT_RE = re.compile(r"^<!-- bob-ai-review(?:-finding| \{.*\}) -->$")
 
     def _is_ai_reviewer_output(self, body: str | None) -> bool:
         """True if a comment body is AI-reviewer output (inbound work)."""
-        return self.AI_REVIEW_MARKER in (body or "")
+        if not body:
+            return False
+        return any(
+            self._AI_REVIEWER_OUTPUT_RE.match(line) for line in body.splitlines()
+        )
 
     def _latest_inline_review_comment(self, repo: str, pr_number: int) -> dict | None:
         """Fetch the newest inline review comment (pulls/{n}/comments).

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -442,6 +442,45 @@ class ProjectMonitoringRun(BaseRunLoop):
             self.logger.warning(f"Error fetching inline review comments: {e}")
             return None
 
+    # Matches the machine-readable half of the reviewer's summary comment,
+    # `<!-- bob-ai-review {json} -->` (same regex as ai-review.py's _MARKER_RE).
+    _AI_REVIEW_STATE_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
+
+    def _marker_has_standing_findings(
+        self, marker_body: str | None, head_sha: str | None
+    ) -> bool:
+        """True if the AI-review summary marker records unaddressed findings
+        for the current head.
+
+        The summary comment is EDITED in place on re-review, so a fresh pass
+        with standing findings moves nothing in createdAt order — the PR's
+        newest-created comments can all be the agent's own replies while a
+        standing finding lives only in the marker JSON (gptme/gptme#3638: a
+        standing P1 at head sat undispatched for ~2.5 days behind three
+        self-authored comments). Non-empty findings[] whose marker sha matches
+        the current head = the reviewer's latest verdict on this exact code
+        still needs a response, regardless of who commented last.
+
+        A stale marker sha (agent pushed since the review) does not count:
+        the push is fresh activity in its own right and the review sweep will
+        re-review the new head.
+        """
+        if not marker_body:
+            return False
+        m = self._AI_REVIEW_STATE_RE.search(marker_body)
+        if not m:
+            return False
+        try:
+            state = json.loads(m.group(1))
+        except (ValueError, TypeError):
+            return False
+        if not state.get("findings"):
+            return False
+        marker_sha = state.get("sha") or ""
+        if head_sha and marker_sha and not head_sha.startswith(marker_sha):
+            return False
+        return True
+
     def _last_activity_is_self_response(
         self,
         repo: str,
@@ -449,19 +488,28 @@ class ProjectMonitoringRun(BaseRunLoop):
         login: str,
         body: str,
         created_at: str,
+        marker_body: str = "",
+        head_sha: str = "",
     ) -> bool:
         """Classify the last ISSUE comment: is the PR's latest activity the
         agent's own response (i.e. safe to skip dispatch for)?
 
         AI-reviewer output posted under the agent's own login is inbound work,
-        never a response. And when the last issue comment is a plain self
-        comment, a newer INLINE review comment can still carry inbound
-        reviewer findings — check it before concluding "own activity".
+        never a response. Three shapes (all observed live):
+        - the last comment IS reviewer output (marker in body)
+        - the summary marker was edited in place and carries standing
+          findings at head (gptme/gptme#3638)
+        - a newer INLINE review comment carries a finding, invisible to
+          `gh pr view --json comments` (gptme/gptme#3669)
         """
         if not self.author or login != self.author:
             return False
         if self._is_ai_reviewer_output(body):
             # Reviewer output is inbound work, not a response.
+            return False
+        if self._marker_has_standing_findings(marker_body, head_sha):
+            # Standing reviewer findings at head need a response no matter
+            # who commented last (in-place summary edit, gptme#3638).
             return False
         # Plain self issue comment. Inline review comments are invisible to
         # `gh pr view --json comments`; a newer one may be inbound work.
@@ -487,7 +535,8 @@ class ProjectMonitoringRun(BaseRunLoop):
             see _last_activity_is_self_response.
         """
         try:
-            # Get last issue comment on PR (author + body + createdAt)
+            # Last issue comment + head sha + latest AI-review summary marker
+            # comment, all from one call.
             result = subprocess.run(
                 [
                     "gh",
@@ -497,11 +546,15 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--repo",
                     repo,
                     "--json",
-                    "comments",
+                    "comments,headRefOid",
                     "--jq",
-                    ".comments | sort_by(.createdAt) | last | "
+                    '{"headSha": (.headRefOid // ""), '
+                    '"lastComment": (.comments | sort_by(.createdAt) | last | '
                     '{login: (.author.login // ""), body: (.body // ""), '
-                    'createdAt: (.createdAt // "")}',
+                    'createdAt: (.createdAt // "")}), '
+                    '"aiReviewMarker": (([.comments[] '
+                    '| select((.body // "") | contains("<!-- bob-ai-review "))'
+                    '] | last | .body) // "")}',
                 ],
                 capture_output=True,
                 text=True,
@@ -512,8 +565,11 @@ class ProjectMonitoringRun(BaseRunLoop):
                 # No comments or error - assume not by self
                 return False
 
-            last = json.loads(result.stdout)
-            if not isinstance(last, dict) or not last.get("login"):
+            info = json.loads(result.stdout)
+            if not isinstance(info, dict):
+                return False
+            last = info.get("lastComment") or {}
+            if not last.get("login"):
                 return False
             return self._last_activity_is_self_response(
                 repo,
@@ -521,6 +577,8 @@ class ProjectMonitoringRun(BaseRunLoop):
                 last["login"],
                 last.get("body") or "",
                 last.get("createdAt") or "",
+                marker_body=info.get("aiReviewMarker") or "",
+                head_sha=info.get("headSha") or "",
             )
 
         except Exception as e:
@@ -541,7 +599,9 @@ class ProjectMonitoringRun(BaseRunLoop):
             True if last comment is a mention of someone other than self
         """
         try:
-            # Get last comment body
+            # Get last comment body + createdAt (to detect a newer inline
+            # review comment below), plus head sha + AI-review summary marker
+            # (to detect standing findings behind an in-place comment edit).
             result = subprocess.run(
                 [
                     "gh",
@@ -551,9 +611,14 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--repo",
                     repo,
                     "--json",
-                    "comments",
+                    "comments,headRefOid",
                     "--jq",
-                    ".comments | sort_by(.createdAt) | last | .body",
+                    '{"headSha": (.headRefOid // ""), '
+                    '"lastComment": (.comments | sort_by(.createdAt) | last | '
+                    '{body: (.body // ""), createdAt: (.createdAt // "")}), '
+                    '"aiReviewMarker": (([.comments[] '
+                    '| select((.body // "") | contains("<!-- bob-ai-review "))'
+                    '] | last | .body) // "")}',
                 ],
                 capture_output=True,
                 text=True,
@@ -563,7 +628,22 @@ class ProjectMonitoringRun(BaseRunLoop):
             if result.returncode != 0 or not result.stdout.strip():
                 return False
 
-            body = result.stdout.strip()
+            info = json.loads(result.stdout)
+            if not isinstance(info, dict):
+                return False
+            last = info.get("lastComment") or {}
+            body = (last.get("body") or "").strip()
+            created_at = last.get("createdAt") or ""
+            if not body:
+                return False
+
+            # Standing AI-review findings at head are inbound work — never
+            # skip on a bot-invocation comment while they exist (same class
+            # as gptme/gptme#3638).
+            if self._marker_has_standing_findings(
+                info.get("aiReviewMarker") or "", info.get("headSha") or ""
+            ):
+                return False
 
             # Check if comment is short (likely just a bot invocation)
             # Long comments with mentions are probably real discussions
@@ -588,6 +668,17 @@ class ProjectMonitoringRun(BaseRunLoop):
             # If all mentions are to someone other than self, skip
             # (allows comments that mention self along with others)
             if self.author not in mentions:
+                # Same blindness as the self gate (gptme/gptme#3669): the
+                # bot-invocation issue comment may not be the PR's latest
+                # activity — a NEWER inline review comment can carry an
+                # inbound AI-review finding invisible to
+                # `gh pr view --json comments`. Don't skip in that case.
+                inline = self._latest_inline_review_comment(repo, pr_number)
+                if inline and (not created_at or inline["createdAt"] > created_at):
+                    if inline.get(
+                        "login"
+                    ) != self.author or self._is_ai_reviewer_output(inline.get("body")):
+                        return False
                 self.logger.info(
                     f"PR {repo}#{pr_number} last comment mentions others ({mentions}), not {self.author} - skipping"
                 )
@@ -674,12 +765,17 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--repo",
                     repo,
                     "--json",
-                    "updatedAt,comments",
+                    "updatedAt,comments,headRefOid",
                     "--jq",
-                    '{"updatedAt": .updatedAt, "lastComment": '
+                    '{"updatedAt": .updatedAt, '
+                    '"headSha": (.headRefOid // ""), '
+                    '"lastComment": '
                     "(.comments | sort_by(.createdAt) | last | "
                     '{login: (.author.login // ""), body: (.body // ""), '
-                    'createdAt: (.createdAt // "")})}',
+                    'createdAt: (.createdAt // "")}), '
+                    '"aiReviewMarker": (([.comments[] '
+                    '| select((.body // "") | contains("<!-- bob-ai-review "))'
+                    '] | last | .body) // "")}',
                 ],
                 capture_output=True,
                 text=True,
@@ -706,6 +802,8 @@ class ProjectMonitoringRun(BaseRunLoop):
                 last_comment.get("login") or "",
                 last_comment.get("body") or "",
                 last_comment.get("createdAt") or "",
+                marker_body=pr_info.get("aiReviewMarker") or "",
+                head_sha=pr_info.get("headSha") or "",
             )
 
             # Exclusive lock serializes concurrent sessions on this PR's state.

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -449,8 +449,11 @@ class ProjectMonitoringRun(BaseRunLoop):
             return None
 
     # Matches the machine-readable half of the reviewer's summary comment,
-    # `<!-- bob-ai-review {json} -->` (same regex as ai-review.py's _MARKER_RE).
-    _AI_REVIEW_STATE_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
+    # `<!-- bob-ai-review {...} -->`. Same complete-line contract as
+    # `_is_ai_reviewer_output` / activity-gate.sh: a reply that quotes or
+    # pastes the marker must not be parsed as standing reviewer state
+    # (P2 on gptme-contrib#1549). Applied per line, so DOTALL is not needed.
+    _AI_REVIEW_STATE_RE = re.compile(r"^<!-- bob-ai-review (\{.*\}) -->$")
 
     def _marker_has_standing_findings(
         self, marker_body: str | None, head_sha: str | None
@@ -473,11 +476,15 @@ class ProjectMonitoringRun(BaseRunLoop):
         """
         if not marker_body:
             return False
-        m = self._AI_REVIEW_STATE_RE.search(marker_body)
-        if not m:
+        payload = None
+        for line in marker_body.splitlines():
+            m = self._AI_REVIEW_STATE_RE.match(line)
+            if m:
+                payload = m.group(1)
+        if not payload:
             return False
         try:
-            state = json.loads(m.group(1))
+            state = json.loads(payload)
         except (ValueError, TypeError):
             return False
         if not state.get("findings"):
@@ -559,7 +566,8 @@ class ProjectMonitoringRun(BaseRunLoop):
                     '{login: (.author.login // ""), body: (.body // ""), '
                     'createdAt: (.createdAt // "")}), '
                     '"aiReviewMarker": (([.comments[] '
-                    '| select((.body // "") | contains("<!-- bob-ai-review "))'
+                    '| select(any((.body // "") | split("\\n")[]; '
+                    'startswith("<!-- bob-ai-review {")))'
                     '] | last | .body) // "")}',
                 ],
                 capture_output=True,
@@ -623,7 +631,8 @@ class ProjectMonitoringRun(BaseRunLoop):
                     '"lastComment": (.comments | sort_by(.createdAt) | last | '
                     '{body: (.body // ""), createdAt: (.createdAt // "")}), '
                     '"aiReviewMarker": (([.comments[] '
-                    '| select((.body // "") | contains("<!-- bob-ai-review "))'
+                    '| select(any((.body // "") | split("\\n")[]; '
+                    'startswith("<!-- bob-ai-review {")))'
                     '] | last | .body) // "")}',
                 ],
                 capture_output=True,
@@ -780,7 +789,8 @@ class ProjectMonitoringRun(BaseRunLoop):
                     '{login: (.author.login // ""), body: (.body // ""), '
                     'createdAt: (.createdAt // "")}), '
                     '"aiReviewMarker": (([.comments[] '
-                    '| select((.body // "") | contains("<!-- bob-ai-review "))'
+                    '| select(any((.body // "") | split("\\n")[]; '
+                    'startswith("<!-- bob-ai-review {")))'
                     '] | last | .body) // "")}',
                 ],
                 capture_output=True,

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -1049,6 +1049,21 @@ This PR ({repo}#{number}) hit the Greptile attempt cap: the escalation ledger re
 the maximum number of fix-session dispatches without the score clearing the floor. This session
 must adjudicate the remaining findings — **do NOT trigger another Greptile review**.
 
+**Freshness gate — run FIRST**: adjudication is only valid for a head the newest
+review pass has actually seen. Compare the current `headRefOid` against the
+newest review provenance: the `sha` field of the last `<!-- bob-ai-review {json} -->`
+marker comment, and Greptile's "Last reviewed commit" summary footer. If any
+commit postdates the newest review pass, **STOP — do not adjudicate**. The
+correct action is to await the re-review of the current head (ai-review-sweep
+re-reviews new heads automatically); a later monitoring cycle adjudicates once
+the review covers head.
+
+```bash
+gh pr view {number} --repo {repo} --json headRefOid --jq '.headRefOid'
+gh api repos/{repo}/issues/{number}/comments --paginate \\
+  --jq '[.[] | select(.body | contains("bob-ai-review ")) | .body] | last'
+```
+
 ```bash
 # Check the convergence state (round history, new-blocking count, stable rounds)
 python3 {workspace}/scripts/greptile-convergence.py --json {repo} {number}
@@ -1067,9 +1082,22 @@ gh pr checks {number} --repo {repo}
 
 **Action**: Classify each remaining finding (blocking bug / security / nitpick / false positive).
 Fix blocking ones. Dismiss non-blocking ones with explicit, checkable reasons.
+A dismissal is a reply on the **inline thread** plus a resolve — posting to
+`issues/{number}/comments` does not touch the thread and is scored
+`effect=none` (gptme/gptme-contrib#1485). For our own reviewer:
+
+```bash
+python3 {workspace}/scripts/github/ai-review-dispose.py {repo} {number} --list
+python3 {workspace}/scripts/github/ai-review-dispose.py {repo} {number} \\
+    --fingerprint FP --reason rejected --reply-file /tmp/why.md
+```
+
+Never resolve a human's thread. Do not finish while our unresolved threads remain.
+
 Post **one** structured merge recommendation:
 - Fixed: list of findings addressed in this session
 - Remaining: non-blocking findings plus the dismissal reason for each
+- Verified against: the head sha each classification above was checked on
 - CI: current status
 - Domain risk: any fragile area warranting a maintainer manual test
 - Convergence: quote the `round_convergence` stable-round count from the detector

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -1051,7 +1051,7 @@ must adjudicate the remaining findings — **do NOT trigger another Greptile rev
 
 **Freshness gate — run FIRST**: adjudication is only valid for a head the newest
 review pass has actually seen. Compare the current `headRefOid` against the
-newest review provenance: the `sha` field of the last `<!-- bob-ai-review {json} -->`
+newest review provenance: the `sha` field of the last `<!-- bob-ai-review {...} -->`
 marker comment, and Greptile's "Last reviewed commit" summary footer. If any
 commit postdates the newest review pass, **STOP — do not adjudicate**. The
 correct action is to await the re-review of the current head (ai-review-sweep

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -520,6 +520,42 @@ def test_is_last_activity_by_self_standing_marker_findings(workspace):
         assert mock_run.call_count == 1
 
 
+def test_quoted_standing_marker_is_not_standing_findings(workspace):
+    """A self-reply that blockquotes a standing marker must not be parsed
+    as the reviewer's outstanding state (P2 on gptme-contrib#1549).
+
+    The old substring/DOTALL search treated a quoted
+    `<!-- bob-ai-review {...} -->` as live findings at head, which flipped
+    `_last_activity_is_self_response` to inbound and re-dispatched.
+    """
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    quoted = (
+        "Looked at this.\n"
+        '> <!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 3, '
+        '"engine": "agent", "findings": [{"fp": "071a049d9d84", '
+        '"severity": "P1"}], "suppressed": [], "auto_resolved": []} -->\n'
+        "Waiting on the next pass."
+    )
+    assert run._marker_has_standing_findings(quoted, _HEAD_3638) is False
+    assert run._marker_has_standing_findings(_MARKER_3638, _HEAD_3638) is True
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0,
+                stdout=_last_comment_json(
+                    SELF,
+                    quoted,
+                    "2026-08-30T10:00:00Z",
+                    marker=quoted,
+                    head_sha=_HEAD_3638,
+                ),
+                stderr="",
+            ),
+            MagicMock(returncode=0, stdout="null", stderr=""),
+        ]
+        assert run._is_last_activity_by_self("gptme/gptme", 1549) is True
+
+
 def test_is_last_activity_by_self_stale_marker_findings(workspace):
     """Marker findings recorded against an OLDER head do not count: the push
     since the review is fresh activity and the sweep will re-review it."""

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -351,8 +351,17 @@ def test_should_post_comment_stale(workspace):
 SELF = "TimeToBuildBob"
 
 
-def _last_comment_json(login, body, created_at="2026-08-29T14:00:00Z"):
-    return json.dumps({"login": login, "body": body, "createdAt": created_at})
+def _last_comment_json(
+    login, body, created_at="2026-08-29T14:00:00Z", marker="", head_sha=""
+):
+    """Mock stdout for the _is_last_activity_by_self gh pr view call."""
+    return json.dumps(
+        {
+            "headSha": head_sha,
+            "lastComment": {"login": login, "body": body, "createdAt": created_at},
+            "aiReviewMarker": marker,
+        }
+    )
 
 
 def test_is_last_activity_by_self_plain_self_comment(workspace):
@@ -448,6 +457,87 @@ def test_is_last_activity_by_self_older_inline_finding(workspace):
         assert run._is_last_activity_by_self("gptme/gptme", 123) is True
 
 
+_MARKER_3638 = (
+    "## AI code review\n\nreview body...\n\n"
+    '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 3, "engine": "agent", '
+    '"findings": [{"fp": "071a049d9d84", "severity": "P1"}], '
+    '"suppressed": [], "auto_resolved": []} -->'
+)
+_HEAD_3638 = "7bb89e6c544c12c15fbfd224ab40f690e7a11401"
+
+
+def test_is_last_activity_by_self_standing_marker_findings(workspace):
+    """The gptme#3638 shape: reviewer EDITED its summary in place (createdAt
+    never moves), so the last-created comments are all plain self replies —
+    but the marker records a standing finding at head. Inbound -> False."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_last_comment_json(
+                SELF,
+                "## Greptile Convergence Adjudication\n\nAll threads resolved.",
+                "2026-08-26T19:56:40Z",
+                marker=_MARKER_3638,
+                head_sha=_HEAD_3638,
+            ),
+            stderr="",
+        )
+        assert run._is_last_activity_by_self("gptme/gptme", 3638) is False
+        # Standing findings short-circuit before the inline lookup.
+        assert mock_run.call_count == 1
+
+
+def test_is_last_activity_by_self_stale_marker_findings(workspace):
+    """Marker findings recorded against an OLDER head do not count: the push
+    since the review is fresh activity and the sweep will re-review it."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0,
+                stdout=_last_comment_json(
+                    SELF,
+                    "Fixed the finding in deadbeef.",
+                    "2026-08-27T10:00:00Z",
+                    marker=_MARKER_3638,
+                    head_sha="deadbeef00001111222233334444555566667777",
+                ),
+                stderr="",
+            ),
+            # No newer inline review comments
+            MagicMock(returncode=0, stdout="null", stderr=""),
+        ]
+        assert run._is_last_activity_by_self("gptme/gptme", 3638) is True
+
+
+def test_should_post_comment_standing_marker_findings_posts(workspace):
+    """The live gptme#3638 gate path: PR updated, last three actors all self,
+    standing P1 only in the in-place-edited marker JSON -> should POST."""
+    from datetime import datetime, timedelta
+
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    prev_time = (datetime.now() - timedelta(hours=1)).isoformat()
+    state_file = run.state_dir / "gptme-gptme-pr-3638-comment.state"
+    state_file.write_text(f"update {prev_time} 2026-08-26T15:00:00Z")
+
+    payload = json.dumps(
+        {
+            "updatedAt": "2026-08-26T20:21:00Z",
+            "headSha": _HEAD_3638,
+            "lastComment": {
+                "login": SELF,
+                "body": "## Greptile Convergence Adjudication\n\nAll resolved.",
+                "createdAt": "2026-08-26T19:56:40Z",
+            },
+            "aiReviewMarker": _MARKER_3638,
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=payload, stderr="")
+        assert run.should_post_comment("gptme/gptme", 3638, "update") is True
+
+
 def test_should_post_comment_pr_updated_ai_review_summary(workspace):
     """PR updated + last comment is the self-authored AI-review summary ->
     inbound work, should POST (dispatch), not skip."""
@@ -539,6 +629,77 @@ def test_should_post_comment_pr_updated_newer_inline_finding_posts(workspace):
         assert run.should_post_comment("gptme/gptme", 3669, "update") is True
 
 
+def _mention_view_json(body, created_at="2026-08-29T14:37:34Z", marker="", head_sha=""):
+    """Mock stdout for the _is_mention_of_someone_else gh pr view call."""
+    return json.dumps(
+        {
+            "headSha": head_sha,
+            "lastComment": {"body": body, "createdAt": created_at},
+            "aiReviewMarker": marker,
+        }
+    )
+
+
+def test_is_mention_of_someone_else_plain(workspace):
+    """Bot invocation with no newer inline review comment -> True (skip)."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0, stdout=_mention_view_json("@greptileai review"), stderr=""
+            ),
+            # No inline review comments
+            MagicMock(returncode=0, stdout="null", stderr=""),
+        ]
+        assert run._is_mention_of_someone_else("gptme/gptme", 123) is True
+
+
+def test_is_mention_of_someone_else_newer_inline_finding(workspace):
+    """The other half of the gptme#3669 blindness: last issue comment is a bot
+    invocation, but a NEWER inline AI-review finding is inbound work -> False
+    (do not skip)."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    inline = json.dumps(
+        {
+            "login": SELF,
+            "body": "<!-- bob-ai-review-finding -->\nPossible bug",
+            "createdAt": "2026-08-29T15:58:39Z",
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0, stdout=_mention_view_json("@greptileai review"), stderr=""
+            ),
+            MagicMock(returncode=0, stdout=inline, stderr=""),
+        ]
+        assert run._is_mention_of_someone_else("gptme/gptme", 3669) is False
+
+
+def test_is_mention_of_someone_else_standing_marker_findings(workspace):
+    """Bot invocation last, but the (in-place-edited) AI-review summary marker
+    carries standing findings at head -> inbound work, False (gptme#3638
+    class)."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    marker = (
+        "## AI code review\n\n"
+        '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 3, '
+        '"findings": [{"fp": "071a049d9d84", "severity": "P1"}]} -->'
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_mention_view_json(
+                "@greptileai review",
+                marker=marker,
+                head_sha="7bb89e6c544c12c15fbfd224ab40f690e7a11401",
+            ),
+            stderr="",
+        )
+        assert run._is_mention_of_someone_else("gptme/gptme", 3638) is False
+        assert mock_run.call_count == 1
+
+
 def test_should_post_comment_concurrent_first_time(workspace):
     """Race condition: two sessions on the same PR with no prior state.
 
@@ -595,7 +756,7 @@ def test_check_pr_updates_new_pr(mock_run, workspace):
     comment_state = '{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}'
 
     def side_effect(args, **kwargs):
-        if "updatedAt,comments" in args:
+        if "updatedAt,comments,headRefOid" in args or "comments,headRefOid" in args:
             return MagicMock(returncode=0, stdout=comment_state, stderr="")
         return MagicMock(returncode=0, stdout=pr_data, stderr="")
 
@@ -627,7 +788,7 @@ def test_check_pr_updates_no_change(mock_run, workspace):
     comment_state = '{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}'
 
     def side_effect(args, **kwargs):
-        if "updatedAt,comments" in args:
+        if "updatedAt,comments,headRefOid" in args or "comments,headRefOid" in args:
             return MagicMock(returncode=0, stdout=comment_state, stderr="")
         return MagicMock(returncode=0, stdout=pr_data, stderr="")
 
@@ -667,7 +828,7 @@ def test_check_pr_updates_surfaces_draft(mock_run, workspace):
     comment_state = '{"updatedAt": "2026-05-12T20:17:24Z", "lastCommentAuthor": ""}'
 
     def side_effect(args, **kwargs):
-        if "updatedAt,comments" in args:
+        if "updatedAt,comments,headRefOid" in args or "comments,headRefOid" in args:
             return MagicMock(returncode=0, stdout=comment_state, stderr="")
         return MagicMock(returncode=0, stdout=pr_data, stderr="")
 
@@ -735,7 +896,7 @@ def test_check_ci_failures(mock_run, workspace):
     comment_state = '{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}'
 
     def side_effect(args, **kwargs):
-        if "updatedAt,comments" in args:
+        if "updatedAt,comments,headRefOid" in args or "comments,headRefOid" in args:
             return MagicMock(returncode=0, stdout=comment_state, stderr="")
         return MagicMock(returncode=0, stdout=pr_data, stderr="")
 

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -394,6 +394,38 @@ def test_is_last_activity_by_self_ai_review_marker(workspace):
         assert mock_run.call_count == 1
 
 
+def test_is_ai_reviewer_output_quoted_marker_is_self_chatter(workspace):
+    """Quoting a finding marker must not classify Bob's reply as inbound review.
+
+    The reviewer emits the HTML comment as a standalone line. A reply that
+    blockquotes that line, or mentions the token in prose, is still Bob
+    talking — substring matching used to self-dispatch those (P1 on #1549).
+    """
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    quoted = (
+        "Fixed the matcher.\n"
+        "> <!-- bob-ai-review-finding -->\n"
+        "> quoted P1 text\n"
+        "Also mentioning bob-ai-review in prose."
+    )
+    assert run._is_ai_reviewer_output(quoted) is False
+    finding = "<!-- bob-ai-review-finding -->\nPossible bug here"
+    assert run._is_ai_reviewer_output(finding) is True
+    summary = 'Review summary\n\n<!-- bob-ai-review {"head_sha": "abc"} -->'
+    assert run._is_ai_reviewer_output(summary) is True
+
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0,
+                stdout=_last_comment_json(SELF, quoted),
+                stderr="",
+            ),
+            MagicMock(returncode=0, stdout="null", stderr=""),
+        ]
+        assert run._is_last_activity_by_self("gptme/gptme", 1549) is True
+
+
 def test_is_last_activity_by_self_other_author(workspace):
     """Last comment by someone else -> False (inbound)."""
     run = ProjectMonitoringRun(workspace, author=SELF)

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -285,7 +285,7 @@ def test_should_post_comment_pr_updated(workspace):
     with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout='{"updatedAt": "2025-11-25T11:00:00Z", "lastCommentAuthor": "other-user"}',  # Newer than state file, not by self
+            stdout='{"updatedAt": "2025-11-25T11:00:00Z", "lastComment": {"login": "other-user", "body": "please fix", "createdAt": "2025-11-25T10:59:00Z"}}',  # Newer than state file, not by self
             stderr="",
         )
 
@@ -340,6 +340,203 @@ def test_should_post_comment_stale(workspace):
         # Should post (stale comment)
         should_post = run.should_post_comment("gptme/gptme", 123, "update")
         assert should_post is True
+
+
+# --- last-activity-by-self classification (AI reviewer posts as self) ------
+#
+# The AI reviewer posts under the agent's own login; its output (bob-ai-review
+# markers) is inbound work, never a self-response. Regression: gptme/gptme#3669
+# — a fresh inline finding sat undispatched because PM read "own activity".
+
+SELF = "TimeToBuildBob"
+
+
+def _last_comment_json(login, body, created_at="2026-08-29T14:00:00Z"):
+    return json.dumps({"login": login, "body": body, "createdAt": created_at})
+
+
+def test_is_last_activity_by_self_plain_self_comment(workspace):
+    """Plain self comment last, no newer inline review comment -> True."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            # gh pr view --json comments (last issue comment)
+            MagicMock(
+                returncode=0,
+                stdout=_last_comment_json(SELF, "Fixed in abc123."),
+                stderr="",
+            ),
+            # gh api pulls/N/comments (no inline review comments)
+            MagicMock(returncode=0, stdout="null", stderr=""),
+        ]
+        assert run._is_last_activity_by_self("gptme/gptme", 123) is True
+
+
+def test_is_last_activity_by_self_ai_review_marker(workspace):
+    """Self-authored comment carrying a bob-ai-review marker is inbound work."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    body = 'Review summary\n\n<!-- bob-ai-review {"head_sha": "abc"} -->'
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=_last_comment_json(SELF, body), stderr=""
+        )
+        assert run._is_last_activity_by_self("gptme/gptme", 123) is False
+        # Marker short-circuits before the inline review comment lookup.
+        assert mock_run.call_count == 1
+
+
+def test_is_last_activity_by_self_other_author(workspace):
+    """Last comment by someone else -> False (inbound)."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=_last_comment_json("erikbjare", "Looks good"),
+            stderr="",
+        )
+        assert run._is_last_activity_by_self("gptme/gptme", 123) is False
+        assert mock_run.call_count == 1
+
+
+def test_is_last_activity_by_self_newer_inline_finding(workspace):
+    """The gptme#3669 shape: plain self issue comment, but a NEWER inline
+    review comment carries an AI-review finding -> inbound, False."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    inline = json.dumps(
+        {
+            "login": SELF,
+            "body": "<!-- bob-ai-review-finding -->\nPossible bug here",
+            "createdAt": "2026-08-29T15:58:39Z",
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0,
+                stdout=_last_comment_json(
+                    SELF, "@greptileai review", "2026-08-29T14:37:34Z"
+                ),
+                stderr="",
+            ),
+            MagicMock(returncode=0, stdout=inline, stderr=""),
+        ]
+        assert run._is_last_activity_by_self("gptme/gptme", 3669) is False
+
+
+def test_is_last_activity_by_self_older_inline_finding(workspace):
+    """An inline finding OLDER than the self reply does not flip the verdict:
+    the agent already responded after the finding."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    inline = json.dumps(
+        {
+            "login": SELF,
+            "body": "<!-- bob-ai-review-finding -->\nPossible bug here",
+            "createdAt": "2026-08-29T10:00:00Z",
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0,
+                stdout=_last_comment_json(
+                    SELF, "Addressed the finding in abc123.", "2026-08-29T14:00:00Z"
+                ),
+                stderr="",
+            ),
+            MagicMock(returncode=0, stdout=inline, stderr=""),
+        ]
+        assert run._is_last_activity_by_self("gptme/gptme", 123) is True
+
+
+def test_should_post_comment_pr_updated_ai_review_summary(workspace):
+    """PR updated + last comment is the self-authored AI-review summary ->
+    inbound work, should POST (dispatch), not skip."""
+    from datetime import datetime, timedelta
+
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    prev_time = (datetime.now() - timedelta(hours=1)).isoformat()
+    state_file = run.state_dir / "gptme-gptme-pr-123-comment.state"
+    state_file.write_text(f"update {prev_time} 2026-08-29T09:00:00Z")
+
+    payload = json.dumps(
+        {
+            "updatedAt": "2026-08-29T11:00:00Z",
+            "lastComment": {
+                "login": SELF,
+                "body": 'Findings...\n\n<!-- bob-ai-review {"score": 3} -->',
+                "createdAt": "2026-08-29T10:59:00Z",
+            },
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=payload, stderr="")
+        assert run.should_post_comment("gptme/gptme", 123, "update") is True
+
+
+def test_should_post_comment_pr_updated_plain_self_skips(workspace):
+    """PR updated + last comment is a plain self response (and no newer inline
+    review comment) -> still skips and records state."""
+    from datetime import datetime, timedelta
+
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    prev_time = (datetime.now() - timedelta(hours=1)).isoformat()
+    state_file = run.state_dir / "gptme-gptme-pr-123-comment.state"
+    state_file.write_text(f"update {prev_time} 2026-08-29T09:00:00Z")
+
+    payload = json.dumps(
+        {
+            "updatedAt": "2026-08-29T11:00:00Z",
+            "lastComment": {
+                "login": SELF,
+                "body": "Rebased and fixed.",
+                "createdAt": "2026-08-29T10:59:00Z",
+            },
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=payload, stderr=""),
+            # No inline review comments
+            MagicMock(returncode=0, stdout="null", stderr=""),
+        ]
+        assert run.should_post_comment("gptme/gptme", 123, "update") is False
+    # State advanced so the same self-update isn't re-checked
+    assert "2026-08-29T11:00:00Z" in state_file.read_text()
+
+
+def test_should_post_comment_pr_updated_newer_inline_finding_posts(workspace):
+    """The live gptme#3669 gate path: plain self issue comment last, fresh
+    inline AI-review finding -> should POST (dispatch)."""
+    from datetime import datetime, timedelta
+
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    prev_time = (datetime.now() - timedelta(hours=1)).isoformat()
+    state_file = run.state_dir / "gptme-gptme-pr-3669-comment.state"
+    state_file.write_text(f"update {prev_time} 2026-08-29T09:00:00Z")
+
+    payload = json.dumps(
+        {
+            "updatedAt": "2026-08-29T15:58:39Z",
+            "lastComment": {
+                "login": SELF,
+                "body": "@greptileai review",
+                "createdAt": "2026-08-29T14:37:34Z",
+            },
+        }
+    )
+    inline = json.dumps(
+        {
+            "login": SELF,
+            "body": "<!-- bob-ai-review-finding -->\nPossible bug",
+            "createdAt": "2026-08-29T15:58:39Z",
+        }
+    )
+    with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=payload, stderr=""),
+            MagicMock(returncode=0, stdout=inline, stderr=""),
+        ]
+        assert run.should_post_comment("gptme/gptme", 3669, "update") is True
 
 
 def test_should_post_comment_concurrent_first_time(workspace):

--- a/packages/gptme-runloops/tests/test_run_item_rollback.py
+++ b/packages/gptme-runloops/tests/test_run_item_rollback.py
@@ -363,9 +363,15 @@ class TestAdjudicationTimeoutTier:
         assert "do NOT trigger another Greptile review" in out
         assert "greptile-helper.sh trigger" in out  # named as forbidden
         # Token substitution must be complete and jq objects left intact.
+        # `{json}` is a substitutable token shape (`_TOKEN_RE`); the marker
+        # description uses `{...}` so `_substitute` cannot eat it (P1 on
+        # gptme-contrib#1549). `{{json}}` is the str.format escape and would
+        # survive here as a literal `{{`, which this assertion also forbids.
         assert "{repo}" not in out and "{number}" not in out
+        assert "{json}" not in out
         assert "{{" not in out
         assert "{id, path, line" in out
+        assert "<!-- bob-ai-review {...} -->" in out
 
 
 class TestConvergedBackoffEarlyExit:

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -477,7 +477,7 @@ has_actionable_update() {
     standing_findings=$(echo "$pr_data" | jq -r '
         (.headRefOid // "") as $head
         | [ .comments[]? | (.body // "")
-            | select(test("<!-- bob-ai-review \\{"))
+            | select(any(split("\n")[]; startswith("<!-- bob-ai-review {")))
             | (try (capture("<!-- bob-ai-review (?<j>\\{.*?\\}) -->"; "s").j
                     | fromjson) catch empty) ]
         | last

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -461,7 +461,36 @@ fetch_pr_noncomment_actor() {
 # (.latestReviews) since either can bump updatedAt.
 has_actionable_update() {
     local pr_data=$1
+    local repo=${2:-}
     # pr_data is a JSON object with comments and latestReviews already included
+
+    # Standing AI-review findings at the CURRENT head are inbound work no
+    # matter who acted last. The reviewer upserts its summary comment in
+    # place, so a re-review with unaddressed findings moves nothing in
+    # createdAt order — the newest-created comments can all be the agent's
+    # own replies while a standing finding lives only in the marker JSON
+    # (gptme/gptme#3638: a standing P1 at head sat undispatched ~2.5 days
+    # behind three self-authored comments). A stale marker sha (the agent
+    # pushed since the review) does not count: the push is fresh activity
+    # and the review sweep re-reviews the new head.
+    local standing_findings
+    standing_findings=$(echo "$pr_data" | jq -r '
+        (.headRefOid // "") as $head
+        | [ .comments[]? | (.body // "")
+            | select(test("<!-- bob-ai-review \\{"))
+            | (try (capture("<!-- bob-ai-review (?<j>\\{.*?\\}) -->"; "s").j
+                    | fromjson) catch empty) ]
+        | last
+        | if . == null then "no"
+          else (.sha // "") as $sha
+            | if (((.findings // []) | length) > 0)
+                 and ($sha != "") and ($head | startswith($sha))
+              then "yes" else "no" end
+          end
+    ' 2>/dev/null)
+    if [ "$standing_findings" = "yes" ]; then
+        return 0
+    fi
 
     # Determine the most recent actor across both comments and reviews.
     # .comments are issue-style comments (chronological).
@@ -513,6 +542,45 @@ has_actionable_update() {
     if [ "$last_actor" = "$AUTHOR" ] && printf '%s\n' "$last_body" \
         | grep -qE "$AI_REVIEW_MARKER_RE"; then
         is_ai_review=0
+    fi
+    # A fresh AI-review pass can be ENTIRELY invisible in pr_data: inline
+    # findings are review comments (not in .comments), and GraphQL's
+    # latestReviews omits the PR author's OWN reviews — on a Bob-authored PR
+    # the reviewer's whole pass (an empty-body review wrapping the marked
+    # inline comments) leaves no trace here. Live case gptme/gptme#3669: a
+    # finding landed 15:58Z while the last VISIBLE activity was Bob's plain
+    # "@greptileai review" comment from 14:37Z, so the update was silenced as
+    # self-chatter. Before silencing a plain self last-activity, consult the
+    # newest inline review comment (one extra gh call, only on this shape):
+    # if it is NEWER and is either someone else's or carries the reviewer
+    # marker, the update is inbound work. Bob's own inline thread replies
+    # (self login, no marker) stay silenced.
+    if [ "$is_ai_review" -ne 0 ] && [ "$last_actor" = "$AUTHOR" ] && [ -n "$repo" ]; then
+        local pr_num_inline last_time inline_json inline_login inline_time inline_body
+        pr_num_inline=$(echo "$pr_data" | jq -r '.number // empty' 2>/dev/null)
+        last_time=$(echo "$pr_data" | jq -r '
+            [
+                (.comments[-1] | select(. != null) | .createdAt),
+                (.latestReviews | sort_by(.submittedAt) | last | select(. != null) | .submittedAt)
+            ]
+            | map(select(. != null)) | max // ""
+        ' 2>/dev/null)
+        if [ -n "$pr_num_inline" ]; then
+            inline_json=$(timeout 30 gh api \
+                "repos/$repo/pulls/$pr_num_inline/comments?sort=created&direction=desc&per_page=1" \
+                --jq '.[0] | {login: (.user.login // ""), time: (.created_at // ""), body: (.body // "")}' \
+                2>/dev/null || true)
+            inline_login=$(echo "$inline_json" | jq -r '.login // empty' 2>/dev/null)
+            inline_time=$(echo "$inline_json" | jq -r '.time // empty' 2>/dev/null)
+            inline_body=$(echo "$inline_json" | jq -r '.body // empty' 2>/dev/null)
+            # ISO-8601 UTC "Z" timestamps compare correctly as strings.
+            if [ -n "$inline_time" ] && { [ -z "$last_time" ] || [[ "$inline_time" > "$last_time" ]]; }; then
+                if [ "$inline_login" != "$AUTHOR" ] \
+                    || printf '%s\n' "$inline_body" | grep -qE "$AI_REVIEW_MARKER_RE"; then
+                    is_ai_review=0
+                fi
+            fi
+        fi
     fi
     if [ "$last_actor" = "$AUTHOR" ] && [ "$is_ai_review" -ne 0 ]; then
         return 1
@@ -616,7 +684,7 @@ check_pr_updates() {
                 fi
 
                 # Check if the update was from someone we should respond to
-                if has_actionable_update "$pr_data"; then
+                if has_actionable_update "$pr_data" "$repo"; then
                     local pr_title priority_tokens item_detail
                     pr_title=$(echo "$pr_data" | jq -r '.title')
                     # Human-priority tokens (§7b human > bot): let the

--- a/scripts/github/greptile-merge-signal.py
+++ b/scripts/github/greptile-merge-signal.py
@@ -38,6 +38,18 @@ SCORE_PATTERNS = (
     re.compile(r"confidence\s+score[^0-9]*(?P<score>[0-5])\s*/\s*5", re.IGNORECASE),
     re.compile(r"\bscore[^0-9]*(?P<score>[0-5])\s*/\s*5", re.IGNORECASE),
 )
+# Greptile's summary footer names the head its review actually covered, e.g.:
+#   <sub>Reviews (8): Last reviewed commit: ["fix(...)"](https://github.com/o/r/commit/<sha>)
+# Greptile edits the summary comment in place, so "latest summary" alone says
+# nothing about WHICH head the score belongs to (gptme/gptme#3656: three
+# commits postdated the score a handoff comment then attributed to the new
+# head). The footer sha is the provenance that makes the score checkable.
+REVIEWED_COMMIT_RE = re.compile(
+    r"last\s+reviewed\s+commit.{0,400}?/commit/(?P<sha>[0-9a-f]{40})",
+    re.IGNORECASE | re.DOTALL,
+)
+# Prefix comparisons shorter than this are not evidence of identity.
+MIN_SHA_PREFIX_LEN = 7
 
 
 @dataclass
@@ -54,11 +66,21 @@ class SignalResult:
     bot_login: str | None = None
     comment_id: int | None = None
     reviewed_at: str | None = None
+    reviewed_commit: str | None = None
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True)
+    parser.add_argument(
+        "--head-sha",
+        default=None,
+        help=(
+            "Current PR head sha. When given and the summary's 'Last reviewed "
+            "commit' footer names a different commit, the signal is ineligible "
+            "(reason summary_stale_for_head): the score belongs to an older head."
+        ),
+    )
     parser.add_argument("pr_number", type=int)
     return parser.parse_args()
 
@@ -141,6 +163,20 @@ def _extract_score(body: str) -> int | None:
     return None
 
 
+def _extract_reviewed_commit(body: str) -> str | None:
+    match = REVIEWED_COMMIT_RE.search(body)
+    return match.group("sha").lower() if match else None
+
+
+def _sha_matches(reviewed: str, head: str) -> bool:
+    """Prefix-match either way with a minimum-length guard (mirrors self-merge-check)."""
+    reviewed = reviewed.strip().lower()
+    head = head.strip().lower()
+    if len(reviewed) < MIN_SHA_PREFIX_LEN or len(head) < MIN_SHA_PREFIX_LEN:
+        return False
+    return head.startswith(reviewed) or reviewed.startswith(head)
+
+
 def _latest_allowlisted_summary(
     comments: list[dict[str, Any]], allowlist: set[str]
 ) -> dict[str, Any] | None:
@@ -165,7 +201,9 @@ def _latest_allowlisted_summary(
     )
 
 
-def evaluate_summary_signal(repo: str, pr_number: int) -> SignalResult:
+def evaluate_summary_signal(
+    repo: str, pr_number: int, head_sha: str | None = None
+) -> SignalResult:
     threshold = _parse_threshold()
     if _env_var_is_active(DISABLE_ENV):
         return SignalResult(
@@ -193,6 +231,7 @@ def evaluate_summary_signal(repo: str, pr_number: int) -> SignalResult:
     login = str((latest_summary.get("user") or {}).get("login") or "").strip()
     body = str(latest_summary.get("body") or "")
     score = _extract_score(body)
+    reviewed_commit = _extract_reviewed_commit(body)
     safe_to_merge = bool(SAFE_TO_MERGE_RE.search(body))
     result = SignalResult(
         eligible=False,
@@ -212,7 +251,16 @@ def evaluate_summary_signal(repo: str, pr_number: int) -> SignalResult:
             latest_summary.get("updated_at") or latest_summary.get("created_at") or ""
         )
         or None,
+        reviewed_commit=reviewed_commit,
     )
+
+    # Provenance gate first: a score for a head this PR no longer has is not a
+    # score for this PR. Fail-open when the footer sha is absent/unparseable —
+    # older summary formats carry no provenance, and the thread/category gates
+    # in self-merge-check still apply.
+    if head_sha and reviewed_commit and not _sha_matches(reviewed_commit, head_sha):
+        result.reason = "summary_stale_for_head"
+        return result
 
     if not safe_to_merge:
         result.reason = "safe_to_merge_missing"
@@ -231,7 +279,7 @@ def evaluate_summary_signal(repo: str, pr_number: int) -> SignalResult:
 
 def main() -> int:
     args = _parse_args()
-    result = evaluate_summary_signal(args.repo, args.pr_number)
+    result = evaluate_summary_signal(args.repo, args.pr_number, head_sha=args.head_sha)
     print(json.dumps(asdict(result), sort_keys=True))
     return 0 if result.eligible else 1
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2426,6 +2426,37 @@ def greptile_summary_score(repo: str, pr_number: int) -> int | None:
     return int(score) if isinstance(score, int) else None
 
 
+def greptile_summary_reviewed_commit(repo: str, pr_number: int) -> str | None:
+    """Head sha named by the latest Greptile summary's "Last reviewed commit" footer.
+
+    Greptile edits its summary comment in place, so the "latest summary" score
+    can belong to an older head (gptme/gptme#3656: three commits postdated the
+    5/5 a handoff comment then attributed to the new head). This provenance is
+    what lets the score floor reject a score for a head the PR no longer has.
+
+    Returns None when the footer is absent or unparseable — older summary
+    formats carry no provenance, and the caller must fail open on None.
+    """
+    signal = Path(__file__).with_name("greptile-merge-signal.py")
+    if not signal.exists():
+        return None
+    try:
+        env = os.environ.copy()
+        env.pop("GREPTILE_MERGE_SIGNAL_DISABLED", None)
+        proc = subprocess.run(
+            [sys.executable, str(signal), "--repo", repo, str(pr_number)],
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=30,
+        )
+        data = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+    reviewed = data.get("reviewed_commit")
+    return reviewed if isinstance(reviewed, str) and reviewed else None
+
+
 def _parse_self_merge_min_greptile_score() -> int:
     raw = os.environ.get("SELF_MERGE_MIN_GREPTILE_SCORE", "").strip()
     if not raw:
@@ -2648,6 +2679,20 @@ def evaluate_pr(
         score = greptile_summary_score(repo, number)
         if score is not None and score < min_score:
             result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
+        elif score is not None and result.head_sha:
+            # Provenance gate (gptme/gptme#3656 class): Greptile edits its
+            # summary in place, so the "latest summary" score can belong to an
+            # older head. A clearing score only counts when the summary's
+            # "Last reviewed commit" footer names the current head. Fails open
+            # when provenance is absent (None) — older summary formats carry no
+            # footer, and the thread/category gates still apply.
+            reviewed = greptile_summary_reviewed_commit(repo, number)
+            if reviewed and not _sha_matches_head(reviewed, result.head_sha):
+                result.reasons.append(
+                    f"Greptile score {score}/5 is stale (summary reviewed "
+                    f"{reviewed[:12]}, head is {result.head_sha[:12]}) — "
+                    "re-review of head required"
+                )
 
     # An explicit abstention blocks in its own right. If the structured review
     # state cannot be read, fail closed rather than silently removing the gate.

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -199,6 +199,52 @@ def test_standing_marker_findings_at_head_actionable():
     assert _actionable_pr(_pr_3638_shape())
 
 
+def test_quoted_standing_marker_reply_is_silenced():
+    """A later self-reply that blockquotes the standing marker is not itself
+    reviewer state. Without a complete-line marker comment, last-actor=self
+    stays silenced (P2 on gptme-contrib#1549)."""
+    quoted = (
+        "Looked at this.\n"
+        f'> {MARKER} {{"sha": "7bb89e6c544c", "score": 3, '
+        f'"findings": [{{"fp": "x", "severity": "P1"}}]}} -->\n'
+        "Waiting on the next pass."
+    )
+    pr = {
+        "number": 1549,
+        "headRefOid": HEAD,
+        "comments": [
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-08-30T10:00:00Z",
+                "body": quoted,
+            },
+        ],
+        "latestReviews": [],
+    }
+    assert not _actionable_pr(pr)
+
+
+def test_real_marker_still_actionable_when_later_reply_quotes_it():
+    """The jq selector must keep the real complete-line marker even if a
+    later self-reply quotes it. Otherwise the #3638 standing-findings
+    check would go blind the moment anyone quotes the marker."""
+    quoted = (
+        "Looked at this.\n"
+        f'> {MARKER} {{"sha": "7bb89e6c544c", "score": 3, '
+        f'"findings": [{{"fp": "x", "severity": "P1"}}]}} -->\n'
+        "Waiting on the next pass."
+    )
+    pr = _pr_3638_shape()
+    pr["comments"].append(
+        {
+            "author": {"login": BOT},
+            "createdAt": "2026-08-30T10:00:00Z",
+            "body": quoted,
+        }
+    )
+    assert _actionable_pr(pr)
+
+
 def test_standing_marker_findings_stale_sha_silenced():
     """A marker recorded against an older head does not count — the push
     since the review is fresh activity and the sweep re-reviews it."""

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -123,3 +123,139 @@ def test_human_comment_still_actionable():
 def test_greptile_review_still_actionable():
     """Do not regress the reviewer PM already listened to."""
     assert _actionable("<h3>Security Review</h3> looks fine", "greptile-apps[bot]")
+
+
+# --- 2026-08-29 regressions: gptme/gptme#3638 and #3669 -------------------
+#
+# #3638: the reviewer upserts its summary comment IN PLACE, so a re-review
+# with standing findings moves nothing in createdAt order — the marker JSON
+# is the only trace. Non-empty findings[] at the current head = inbound.
+# #3669: on a Bob-authored PR the reviewer's whole pass (empty-body review +
+# marked inline comments) is invisible in pr_data (latestReviews omits the
+# PR author's own reviews); the newest inline review comment must be checked
+# before silencing a plain self comment.
+
+HEAD = "7bb89e6c544c12c15fbfd224ab40f690e7a11401"
+MARKER_WITH_FINDINGS = (
+    "## AI code review\n\n"
+    f'{MARKER} {{"sha": "7bb89e6c544c", "score": 3, '
+    f'"findings": [{{"fp": "071a049d9d84", "severity": "P1"}}]}} -->'
+)
+
+
+def _actionable_pr(pr: dict, repo: str | None = None, gh_stdout: str = "") -> bool:
+    """Run has_actionable_update on a full pr_data dict, optionally with a
+    repo argument and a stubbed `gh` binary whose stdout is canned."""
+    import os
+    import tempfile
+
+    repo_arg = f" '{repo}'" if repo else ""
+    with tempfile.TemporaryDirectory() as td:
+        gh_stub = Path(td) / "gh"
+        gh_stub.write_text("#!/bin/bash\ncat <<'GHEOF'\n" + gh_stdout + "\nGHEOF\n")
+        gh_stub.chmod(0o755)
+        script = f"""
+set -uo pipefail
+export PATH="{td}:$PATH"
+AUTHOR={BOT}
+{_extract_shell_assignment("AI_REVIEW_MARKER_RE")}
+{_extract_function("has_actionable_update")}
+if has_actionable_update '{json.dumps(pr)}'{repo_arg}; then echo YES; else echo NO; fi
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ},
+        )
+    return "YES" in proc.stdout
+
+
+def _pr_3638_shape(head: str = HEAD) -> dict:
+    """Marker comment with standing findings, then two plain self replies."""
+    return {
+        "number": 3638,
+        "headRefOid": head,
+        "comments": [
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-08-26T16:25:07Z",
+                "body": MARKER_WITH_FINDINGS,
+            },
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-08-26T19:56:40Z",
+                "body": "## Greptile Convergence Adjudication\n\nAll resolved.",
+            },
+        ],
+        "latestReviews": [],
+    }
+
+
+def test_standing_marker_findings_at_head_actionable():
+    """gptme#3638: standing P1 in the in-place-edited marker, last actors all
+    self -> inbound work."""
+    assert _actionable_pr(_pr_3638_shape())
+
+
+def test_standing_marker_findings_stale_sha_silenced():
+    """A marker recorded against an older head does not count — the push
+    since the review is fresh activity and the sweep re-reviews it."""
+    pr = _pr_3638_shape(head="deadbeef00000000000000000000000000000000")
+    assert not _actionable_pr(pr)
+
+
+def _pr_3669_shape() -> dict:
+    """Plain self bot-invocation comment is the only visible activity."""
+    return {
+        "number": 3669,
+        "headRefOid": "a0eb591ec0ea0b11812fa7285d24448cf7dcad72",
+        "comments": [
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-08-29T14:37:34Z",
+                "body": "@greptileai review",
+            },
+        ],
+        "latestReviews": [],
+    }
+
+
+def test_newer_inline_finding_is_actionable():
+    """gptme#3669: the reviewer's pass is invisible in pr_data; the newest
+    inline review comment carries the finding marker -> inbound work."""
+    inline = json.dumps(
+        {
+            "login": BOT,
+            "time": "2026-08-29T15:58:39Z",
+            "body": f"{MARKER}-finding -->\nP1 — file write not under flock",
+        }
+    )
+    assert _actionable_pr(_pr_3669_shape(), repo="gptme/gptme", gh_stdout=inline)
+
+
+def test_newer_inline_self_reply_is_silenced():
+    """Bob's own inline thread replies (self login, no marker) must stay
+    silenced — that is the self-trigger loop the guard exists to stop."""
+    inline = json.dumps(
+        {
+            "login": BOT,
+            "time": "2026-08-29T15:58:39Z",
+            "body": "Fixed in abc123, thanks.",
+        }
+    )
+    assert not _actionable_pr(_pr_3669_shape(), repo="gptme/gptme", gh_stdout=inline)
+
+
+def test_older_inline_finding_is_silenced():
+    """An inline finding OLDER than the last visible self activity does not
+    flip the verdict — the agent already responded after it."""
+    inline = json.dumps(
+        {
+            "login": BOT,
+            "time": "2026-08-29T10:00:00Z",
+            "body": f"{MARKER}-finding -->\nP1 — already handled",
+        }
+    )
+    assert not _actionable_pr(_pr_3669_shape(), repo="gptme/gptme", gh_stdout=inline)

--- a/tests/test_greptile_merge_signal_provenance.py
+++ b/tests/test_greptile_merge_signal_provenance.py
@@ -1,0 +1,109 @@
+"""Provenance tests for scripts/github/greptile-merge-signal.py.
+
+Greptile edits its summary comment in place, so "latest summary" says nothing
+about WHICH head a score belongs to. gptme/gptme#3656: three commits postdated
+the last review pass and a handoff comment attributed the old 5/5 to the new
+head. The summary footer ("Last reviewed commit: [...](…/commit/<sha>)") is the
+provenance that makes the score checkable; these tests pin its extraction and
+the ``head_sha`` staleness gate built on it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).parent.parent / "scripts" / "github" / "greptile-merge-signal.py"
+)
+_spec = importlib.util.spec_from_file_location("greptile_merge_signal", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+gms = importlib.util.module_from_spec(_spec)
+# @dataclass resolves the defining module through sys.modules; register before exec.
+sys.modules["greptile_merge_signal"] = gms
+_spec.loader.exec_module(gms)
+
+HEAD = "62ec507d022bc1548201a874636742308b7453cc"
+OLD = "aface374b55e2f818336156745eb503bcb132036"
+
+FOOTER = (
+    '<sub>Reviews (8): Last reviewed commit: ["fix(harness): gate dispatch..."]'
+    "(https://github.com/gptme/gptme/commit/{sha}) | "
+    "[Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=1)</sub>"
+)
+
+
+def _summary(sha: str | None) -> dict:
+    body = "<h3>Greptile Summary</h3>\n\nSafe to merge.\n\nConfidence Score: 5/5</h3>\n"
+    if sha is not None:
+        body += "\n" + FOOTER.format(sha=sha)
+    return {
+        "id": 1,
+        "user": {"login": "greptile-apps[bot]"},
+        "body": body,
+        "created_at": "2026-08-28T00:18:09Z",
+        "updated_at": "2026-08-29T14:10:08Z",
+    }
+
+
+def test_extract_reviewed_commit_from_footer() -> None:
+    assert gms._extract_reviewed_commit(_summary(HEAD)["body"]) == HEAD
+
+
+def test_extract_reviewed_commit_absent() -> None:
+    assert gms._extract_reviewed_commit(_summary(None)["body"]) is None
+
+
+def test_signal_reports_reviewed_commit() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(gms, "_load_comments", lambda repo, pr: [_summary(HEAD)])
+        result = gms.evaluate_summary_signal("gptme/gptme", 3656)
+    assert result.reviewed_commit == HEAD
+    assert result.eligible is True
+
+
+def test_signal_stale_for_head_blocks() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(gms, "_load_comments", lambda repo, pr: [_summary(OLD)])
+        result = gms.evaluate_summary_signal("gptme/gptme", 3656, head_sha=HEAD)
+    assert result.eligible is False
+    assert result.reason == "summary_stale_for_head"
+    assert result.reviewed_commit == OLD
+    # The stale score is still surfaced for diagnostics.
+    assert result.score == 5
+
+
+def test_signal_matching_head_stays_eligible() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(gms, "_load_comments", lambda repo, pr: [_summary(HEAD)])
+        result = gms.evaluate_summary_signal("gptme/gptme", 3656, head_sha=HEAD)
+    assert result.eligible is True
+    assert result.reason == "positive_summary_comment"
+
+
+def test_signal_no_provenance_fails_open() -> None:
+    """Old summary formats without the footer must not be blocked by head_sha."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(gms, "_load_comments", lambda repo, pr: [_summary(None)])
+        result = gms.evaluate_summary_signal("gptme/gptme", 3656, head_sha=HEAD)
+    assert result.eligible is True
+    assert result.reviewed_commit is None
+
+
+def test_signal_short_head_prefix_matches() -> None:
+    """A >=7-char head prefix of the reviewed commit is a match, not stale."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(gms, "_load_comments", lambda repo, pr: [_summary(HEAD)])
+        result = gms.evaluate_summary_signal("gptme/gptme", 3656, head_sha=HEAD[:10])
+    assert result.eligible is True
+
+
+def test_signal_without_head_sha_unchanged() -> None:
+    """Default CLI/API behavior (no head_sha) is exactly the old behavior."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(gms, "_load_comments", lambda repo, pr: [_summary(OLD)])
+        result = gms.evaluate_summary_signal("gptme/gptme", 3656)
+    assert result.eligible is True

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -473,6 +473,7 @@ def evaluate(monkeypatch: pytest.MonkeyPatch) -> Any:
             },
         )
         monkeypatch.setattr(smc, "greptile_summary_score", lambda r, n: 5)
+        monkeypatch.setattr(smc, "greptile_summary_reviewed_commit", lambda r, n: None)
         result = smc.evaluate_pr(
             "gptme/gptme-contrib", 1382, workspace_repos=["gptme/gptme-contrib"]
         )

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1700,6 +1700,9 @@ def test_evaluate_pr_captures_head_sha() -> None:
         ),
         patch.object(self_merge_check, "greptile_summary_score", return_value=5),
         patch.object(
+            self_merge_check, "greptile_summary_reviewed_commit", return_value=None
+        ),
+        patch.object(
             self_merge_check,
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
@@ -1712,6 +1715,76 @@ def test_evaluate_pr_captures_head_sha() -> None:
         )
 
     assert result.head_sha == "abc123def456"
+
+
+def _evaluate_with_score_provenance(reviewed_commit, head_sha="abc123def456789a"):
+    """Evaluate a has_review PR with score 5 and the given summary provenance."""
+    pr_data = {
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Test PR",
+        "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "headRefOid": head_sha,
+        "labels": [],
+    }
+
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=5),
+        patch.object(
+            self_merge_check,
+            "greptile_summary_reviewed_commit",
+            return_value=reviewed_commit,
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+    ):
+        return self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+
+def test_evaluate_pr_blocks_stale_summary_score() -> None:
+    """A clearing score whose summary reviewed an older head must not count.
+
+    gptme/gptme#3656 class: three commits landed after the last review pass,
+    and a handoff comment attributed the old 5/5 to the new head. The summary's
+    "Last reviewed commit" provenance makes the staleness detectable.
+    """
+    outcome = _evaluate_with_score_provenance("deadbeef" * 5)
+    assert any(
+        "is stale" in r and "re-review of head required" in r for r in outcome.reasons
+    )
+
+
+def test_evaluate_pr_accepts_score_reviewed_at_head() -> None:
+    """Provenance matching the current head adds no stale-score reason."""
+    outcome = _evaluate_with_score_provenance("abc123def456789a")
+    assert not any("is stale" in r for r in outcome.reasons)
+
+
+def test_evaluate_pr_score_provenance_absent_fails_open() -> None:
+    """No parseable provenance (None) must not block — old summary formats."""
+    outcome = _evaluate_with_score_provenance(None)
+    assert not any("is stale" in r for r in outcome.reasons)
 
 
 def test_evaluate_pr_head_sha_empty_when_missing() -> None:


### PR DESCRIPTION
## Problem

Erik caught two live instances of PM treating its own AI reviewer's output as "own activity":

- **gptme/gptme#3669**: a fresh `bob-ai-review` finding posted 15:58Z sat unaddressed with no dispatch. On a Bob-authored PR the reviewer's whole pass is INVISIBLE to the gate's data: inline findings are review comments (not `.comments`), and GraphQL `latestReviews` omits the PR author's own reviews entirely. The last visible activity was Bob's plain `@greptileai review` comment (14:37Z) → silenced as self-chatter, watermark advanced past the finding.
- **gptme/gptme#3638**: the reviewer re-reviewed head `7bb89e6c544c` by EDITING its summary comment in place (upsert), so createdAt order never moved — the last three created comments were all Bob's own replies while a standing P1 lived only in the marker JSON. Skipped for ~2.5 days.

Same identity-conflation class as workspace commit `53c6ace475` (pm_dispatch_recovery `bot_logins`).

## Fix (both the live shell gate and the runloops module)

**`scripts/github/activity-gate.sh`** (`has_actionable_update` — the LIVE PM discovery path):
- **Standing-findings check** (pure jq, no extra network): parse the last `<!-- bob-ai-review {...} -->` marker from `.comments`; non-empty `findings[]` whose `sha` prefixes the current head = actionable regardless of last actor. Stale sha (pushed since review) does not count — the push is fresh activity and the sweep re-reviews.
- **Inline visibility**: before silencing a plain self last-activity, consult the newest inline review comment (one extra `gh` call, only on that shape): newer + (other author or reviewer marker) = actionable. Bob's own inline replies (self login, no marker) stay silenced — the self-trigger guard survives.

**`packages/gptme-runloops/src/gptme_runloops/project_monitoring.py`** (same class, defense in depth for the Python path): shared `_last_activity_is_self_response` classifier used by `should_post_comment`, `_is_last_activity_by_self`, and `_is_mention_of_someone_else` — marker-bearing self comments are inbound, standing marker findings at head are inbound, newer inline review comments are checked before concluding "own activity". Both gate fetches pull `headRefOid` + the marker comment in the same `gh` call.

## Verification

- Live pr_data replay: raw #3669 and #3638 both flip to actionable; stale-marker + self-newer stays silenced; other-author stays actionable; Bob's plain/quoting comments stay silenced.
- `tests/test_activity_gate_ai_review_actionable.py`: 15 pass (6 new, incl. both live shapes + loop-guard controls).
- `packages/gptme-runloops/tests/test_project_monitoring.py`: 48 pass (14 new); full runloops suite 1143 pass; all 128 activity-gate tests pass.