### PR TITLE
fix(news): parse total stars when GitHub wraps the count in an octicon

### DIFF
--- a/scripts/fetch-github-trending.py
+++ b/scripts/fetch-github-trending.py
@@ -78,9 +78,12 @@ def parse_trending(html: str) -> list[dict]:
         )
         language = lang_match.group(1).strip() if lang_match else ""
 
-        # Total stars (in the stargazers link)
+        # Total stars (in the stargazers link). GitHub currently puts an
+        # octicon <svg> inside the <a> before the count; older markup had
+        # the digits immediately after the opening tag. Allow optional inner
+        # HTML, then take the comma-grouped integer that sits before </a>.
         stars_match = re.search(
-            r'href="/[^"]+/stargazers"[^>]*>\s*([\d,]+)\s*</a>',
+            r'href="/[^"]+/stargazers"[^>]*>.*?([\d,]+)\s*</a>',
             article,
             re.DOTALL,
         )

--- a/tests/test_fetch_github_trending.py
+++ b/tests/test_fetch_github_trending.py
@@ -18,6 +18,7 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
 parse_keywords = _mod.parse_keywords
+parse_trending = _mod.parse_trending
 format_compact = _mod.format_compact
 
 
@@ -88,3 +89,57 @@ class TestFilterRegression:
         out = format_compact([REPO_AGENT, REPO_WEB], keywords)
         assert "foo/agent-thing" in out
         assert "bar/web-app" in out
+
+
+def _article_legacy_stars(name: str = "owner/repo", stars: int = 1000) -> str:
+    """Pre-2026 GitHub trending markup: digits directly in the stargazers <a>."""
+    return f"""<article class="Box-row">
+  <h2 class="h3 lh-condensed">
+    <a href="/{name}">{name}</a>
+  </h2>
+  <p class="col-9 color-fg-muted my-1 pr-4">A test repo</p>
+  <div class="f6 color-fg-muted mt-2">
+    <span itemprop="programmingLanguage">Python</span>
+    <a href="/{name}/stargazers" class="Link--muted d-inline-block mr-3">
+      {stars:,}
+    </a>
+    <span class="d-inline-block float-sm-right">100 stars today</span>
+  </div>
+</article>"""
+
+
+def _article_svg_stars(name: str = "THU-MAIC/OpenMAIC", stars: int = 22230) -> str:
+    """Live 2026-08-30 markup: octicon SVG inside the stargazers <a>."""
+    return f"""<article class="Box-row">
+  <h2 class="h3 lh-condensed">
+    <a href="/{name}">{name}</a>
+  </h2>
+  <p class="col-9 color-fg-muted my-1 pr-4">Open Multi-Agent Interactive Classroom</p>
+  <div class="f6 color-fg-muted mt-2">
+    <span itemprop="programmingLanguage">TypeScript</span>
+    <a href="/{name}/stargazers" data-view-component="true" class="Link Link--muted d-inline-block"><svg aria-label="star" role="img" height="16" viewBox="0 0 16 16" width="16" class="octicon octicon-star">
+    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"></path>
+</svg>
+        {stars:,}</a>
+    <span class="d-inline-block float-sm-right">907 stars today</span>
+  </div>
+</article>"""
+
+
+class TestParseTrendingStars:
+    def test_legacy_digits_immediately_after_anchor(self) -> None:
+        repos = parse_trending(_article_legacy_stars(stars=1234))
+        assert repos[0]["stars"] == 1234
+        assert repos[0]["today_stars"] == 100
+
+    def test_octicon_svg_inside_stargazers_anchor(self) -> None:
+        repos = parse_trending(_article_svg_stars(stars=22230))
+        assert repos[0]["name"] == "THU-MAIC/OpenMAIC"
+        assert repos[0]["stars"] == 22230
+        assert repos[0]["today_stars"] == 907
+
+    def test_comma_grouped_count_inside_svg_anchor(self) -> None:
+        repos = parse_trending(
+            _article_svg_stars(name="bigskysoftware/htmx", stars=49117)
+        )
+        assert repos[0]["stars"] == 49117


### PR DESCRIPTION
## Summary

GitHub trending currently puts an octicon `<svg>` *inside* the stargazers `<a>` before the integer. `fetch-github-trending.py` required digits immediately after the opening tag, so every repo rendered as `★0` while today-stars still parsed.

Live 2026-08-30 markup:

```html
<a href="/THU-MAIC/OpenMAIC/stargazers" ...>
  <svg aria-label="star" ...></svg>
  22,230
</a>
```

That hid a 22k-star repo as `★0 +907` in Bob's news digest.

## Change

- Allow optional inner HTML in the stargazers `<a>`, then take the comma-grouped integer before `</a>`.
- Keep the legacy digits-only markup working.
- Tests for both shapes, including comma-grouped counts.

Live check after the patch (19 trending repos): 0 remaining `stars=0`. OpenMAIC 22236, ODS 4915, workweave/router 2716.

## Test plan

- [x] `uv run pytest tests/test_fetch_github_trending.py` (14 passed)
- [x] Parse live `github.com/trending` HTML: 19/19 non-zero totals