### PR TITLE
fix(gptme-activity-summary): isolate nested gptme logs from parent session

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -17,6 +17,8 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +94,21 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
     env = os.environ.copy()
     # Prevent recursion / contamination from a parent gptme invocation.
     env.pop("GPTME_SUBPROCESS", None)
+    # Nested gptme must not inherit the parent session's log dir or name.
+    # Incident 2026-08-30: a parent autonomous session had
+    # GPTME_LOGS_HOME=/tmp/gptme-logs-<id> and GPTME_NAME=autonomous-<id>;
+    # the fallback appended its JSON summary into that conversation.jsonl
+    # and stdout then mixed parent+child assistant messages so
+    # _extract_assistant_text preferred a completion-ack over the JSON.
+    for key in (
+        "GPTME_LOGS_HOME",
+        "GPTME_NAME",
+        "GPTME_AGENT_NAME",
+        "GPTME_WORKSPACE",
+    ):
+        env.pop(key, None)
+    isolated_logs = Path(tempfile.mkdtemp(prefix="gptme-activity-summary-"))
+    env["GPTME_LOGS_HOME"] = str(isolated_logs)
 
     try:
         result = subprocess.run(
@@ -108,6 +125,8 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
     except Exception as exc:  # noqa: BLE001 - best-effort adapter must not raise
         logger.warning("gptme fallback errored unexpectedly: %s", exc)
         return ""
+    finally:
+        shutil.rmtree(isolated_logs, ignore_errors=True)
 
     if result.returncode != 0:
         logger.warning(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -107,10 +107,13 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
         "GPTME_WORKSPACE",
     ):
         env.pop(key, None)
-    isolated_logs = Path(tempfile.mkdtemp(prefix="gptme-activity-summary-"))
-    env["GPTME_LOGS_HOME"] = str(isolated_logs)
 
+    # Create the private log dir inside the try so a full/unwritable temp
+    # filesystem returns "" instead of raising (never-raise contract).
+    isolated_logs = None
     try:
+        isolated_logs = Path(tempfile.mkdtemp(prefix="gptme-activity-summary-"))
+        env["GPTME_LOGS_HOME"] = str(isolated_logs)
         result = subprocess.run(
             cmd,
             input=prompt,
@@ -126,7 +129,8 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
         logger.warning("gptme fallback errored unexpectedly: %s", exc)
         return ""
     finally:
-        shutil.rmtree(isolated_logs, ignore_errors=True)
+        if isolated_logs is not None:
+            shutil.rmtree(isolated_logs, ignore_errors=True)
 
     if result.returncode != 0:
         logger.warning(

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -362,3 +362,50 @@ def test_call_gptme_returns_empty_when_disabled(monkeypatch):
     """call_gptme is best-effort and returns '' when the fallback is disabled."""
     monkeypatch.delenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", raising=False)
     assert call_gptme("ignored prompt") == ""
+
+
+def test_call_gptme_isolates_parent_session_logs(monkeypatch):
+    """Nested gptme must not inherit the parent session's GPTME_LOGS_HOME/NAME.
+
+    Incident 2026-08-30: a parent autonomous session exported
+    GPTME_LOGS_HOME=/tmp/gptme-logs-<id> and GPTME_NAME=autonomous-<id>.
+    call_gptme forwarded that env, so the fallback appended into the parent
+    conversation.jsonl and stdout mixed parent+child assistant messages.
+    """
+    import subprocess
+    from unittest.mock import patch
+
+    monkeypatch.setenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", "1")
+    monkeypatch.setenv("GPTME_LOGS_HOME", "/tmp/gptme-logs-parent-session")
+    monkeypatch.setenv("GPTME_NAME", "autonomous-parent")
+    monkeypatch.setenv("GPTME_AGENT_NAME", "bob")
+    monkeypatch.setenv("GPTME_WORKSPACE", "/home/bob/bob")
+    monkeypatch.setenv("GPTME_SUBPROCESS", "1")
+
+    captured: dict = {}
+
+    def fake_run(*args, **kwargs):
+        captured["env"] = kwargs.get("env") or {}
+        ndjson = _msg('{"narrative": "isolated"}')
+        return subprocess.CompletedProcess(args=["gptme"], returncode=0, stdout=ndjson)
+
+    with (
+        patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme"),
+        patch("gptme_activity_summary.gptme_backend.subprocess.run", side_effect=fake_run),
+    ):
+        out = call_gptme("summarize")
+
+    env = captured["env"]
+    assert out == '{"narrative": "isolated"}'
+    assert env.get("GPTME_SUBPROCESS") is None
+    assert env.get("GPTME_NAME") is None
+    assert env.get("GPTME_AGENT_NAME") is None
+    assert env.get("GPTME_WORKSPACE") is None
+    logs_home = env.get("GPTME_LOGS_HOME")
+    assert logs_home, "must set a private GPTME_LOGS_HOME"
+    assert logs_home != "/tmp/gptme-logs-parent-session"
+    assert "gptme-activity-summary-" in logs_home
+    # Isolated dir is cleaned up after the call.
+    from pathlib import Path
+
+    assert not Path(logs_home).exists()

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -409,3 +409,31 @@ def test_call_gptme_isolates_parent_session_logs(monkeypatch):
     from pathlib import Path
 
     assert not Path(logs_home).exists()
+
+
+def test_call_gptme_returns_empty_when_tempdir_fails(monkeypatch):
+    """mkdtemp OSError must not escape call_gptme (never-raise contract).
+
+    Greptile on gptme/gptme-contrib#1552: tempdir creation sat outside the
+    try, so a full/unwritable temp filesystem raised before the adapter's
+    error handler and crashed the activity-summary job instead of degrading.
+    """
+    from unittest.mock import patch
+
+    monkeypatch.setenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", "1")
+
+    with (
+        patch(
+            "gptme_activity_summary.gptme_backend.shutil.which",
+            return_value="/usr/bin/gptme",
+        ),
+        patch(
+            "gptme_activity_summary.gptme_backend.tempfile.mkdtemp",
+            side_effect=OSError("No space left on device"),
+        ),
+        patch("gptme_activity_summary.gptme_backend.subprocess.run") as run_mock,
+    ):
+        out = call_gptme("summarize")
+
+    assert out == ""
+    run_mock.assert_not_called()


### PR DESCRIPTION
## Problem

When `bob-activity-summary` falls back to `gptme`, `call_gptme` copied the parent process env. A parent autonomous session exports `GPTME_LOGS_HOME` / `GPTME_NAME`. The child then appended its JSON summary into the parent `conversation.jsonl`, and stdout mixed parent+child assistant messages. `_extract_assistant_text` preferred a completion-ack over the JSON, so the fallback reported "no recognized summary schema" even though DeepSeek had already emitted a valid `narrative`.

Live 2026-08-30: parser fix in #1548 extracts 708–970 chars of narrative from historical logs (`dancing-sad-monster`, `dancing-sleepy-dog`). A nested run from an autonomous session still failed because of this env leak.

## Change

- Give the child a private `GPTME_LOGS_HOME` tempdir
- Drop `GPTME_LOGS_HOME` / `GPTME_NAME` / `GPTME_AGENT_NAME` / `GPTME_WORKSPACE` / `GPTME_SUBPROCESS` from the forwarded env
- Clean up the tempdir in `finally`

## Tests

`test_call_gptme_isolates_parent_session_logs` — 104 passed in the package suite (`test_gptme_backend.py` + `test_cc_backend.py`).

## Related

- gptme/gptme-contrib#1548 (parser; merged)
- Bob task `activity-summary-fallback-shipped-but-never-rescues`