### PR TITLE
fix(activity-summary): recover malformed gptme summary JSON

### DIFF
--- a/packages/gptme-activity-summary/pyproject.toml
+++ b/packages/gptme-activity-summary/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "gptme-sessions",
     "click>=8.0",
     "aw-client>=0.5.0",
+    "json-repair>=0.61.0",
 ]
 
 [project.urls]

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -194,7 +194,7 @@ def _repair_summary_json(text: str) -> str | None:
 
     ``json_repair`` may return several top-level values when a wrong closing
     delimiter splits the root object. Reassemble that stream only when the
-    first value carries summary structure and a valid schema-key suffix carries
+    final value carries summary structure and a valid schema-key suffix carries
     the narrative field. This narrow gate avoids treating arbitrary prose or
     nested provider-error JSON as a successful summary.
     """
@@ -224,14 +224,25 @@ def _repair_summary_json(text: str) -> str | None:
             root.setdefault("decisions", []).append(value)
 
     # json_repair can split a malformed root into several top-level values and
-    # lose their field names. Find the earliest schema-key suffix that is valid
-    # JSON; that preserves every recoverable field after the malformed token
-    # without guessing names for anonymous values that came before it.
+    # lose their field names. Skip independently valid preamble objects, then
+    # find the earliest schema-key suffix in the remaining text. Never overwrite
+    # truthy fields already present on the selected final root — a preamble
+    # ``narrative``/``accomplishments`` would otherwise clobber the recovered
+    # activity record.
     decoder = json.JSONDecoder()
     suffix_keys = ("blockers", "themes", "work_in_progress", *_SUMMARY_KEYS)
+    search_start = 0
+    for _ in range(root_index):
+        preamble_start = text.find("{", search_start)
+        if preamble_start == -1:
+            break
+        try:
+            _, search_start = decoder.raw_decode(text, preamble_start)
+        except json.JSONDecodeError:
+            break
     for key in suffix_keys:
         marker = f'"{key}"'
-        start = text.find(marker)
+        start = text.find(marker, search_start)
         if start == -1:
             continue
         try:
@@ -239,7 +250,10 @@ def _repair_summary_json(text: str) -> str | None:
         except json.JSONDecodeError:
             continue
         if isinstance(suffix, dict) and any(suffix.get(k) for k in _SUMMARY_KEYS):
-            root.update(suffix)
+            for field, value in suffix.items():
+                if root.get(field):
+                    continue
+                root[field] = value
             break
     return json.dumps(root) if any(root.get(k) for k in _SUMMARY_KEYS) else None
 

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -201,13 +201,22 @@ def _repair_summary_json(text: str) -> str | None:
     repaired = repair_json(text, return_objects=True)
     if isinstance(repaired, dict):
         return json.dumps(repaired) if any(repaired.get(k) for k in _SUMMARY_KEYS) else None
-    if not isinstance(repaired, list) or not repaired or not isinstance(repaired[0], dict):
+    if not isinstance(repaired, list) or not repaired:
         return None
 
-    root = dict(repaired[0])
-    if not any(key in root for key in ("accomplishments", "decisions")):
+    root_index = next(
+        (
+            i
+            for i, value in enumerate(repaired)
+            if isinstance(value, dict)
+            and any(key in value for key in ("accomplishments", "decisions"))
+        ),
+        None,
+    )
+    if root_index is None:
         return None
-    for value in repaired[1:]:
+    root = dict(repaired[root_index])
+    for value in repaired[root_index + 1 :]:
         if isinstance(value, dict) and {"topic", "decision"}.issubset(value):
             root.setdefault("decisions", []).append(value)
 

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -20,6 +20,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from json_repair import repair_json
+
 logger = logging.getLogger(__name__)
 
 # Env switches to enable the fallback or pin a specific model.
@@ -148,6 +150,7 @@ _THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>", re.DOTALL)
 # gptme's no-tool-call auto-reply. Shared prefix of both variants in
 # gptme.tools.complete ("No tool call detected" / "... in last message").
 _GPTME_TRAILER_MARKER = "No tool call detected"
+_COMPLETE_TOOL_FENCE_RE = re.compile(r"^```complete\s*```$", re.DOTALL)
 _SUMMARY_KEYS = ("narrative", "month_narrative")
 
 
@@ -160,7 +163,7 @@ def _is_gptme_trailer(text: str) -> bool:
     already carries ``narrative``/``month_narrative`` re-breaks the
     daily-summary fallback.
     """
-    return _GPTME_TRAILER_MARKER in text
+    return _GPTME_TRAILER_MARKER in text or bool(_COMPLETE_TOOL_FENCE_RE.fullmatch(text.strip()))
 
 
 def _last_non_trailer(messages: list[str]) -> str:
@@ -184,6 +187,49 @@ def _strip_think_tags(text: str) -> str:
     extraction; stripping them before processing avoids greedy-regex traps.
     """
     return _THINK_TAG_RE.sub("", text).strip()
+
+
+def _repair_summary_json(text: str) -> str | None:
+    """Repair malformed model JSON when it still contains a root summary.
+
+    ``json_repair`` may return several top-level values when a wrong closing
+    delimiter splits the root object. Reassemble that stream only when the
+    first value carries summary structure and a valid schema-key suffix carries
+    the narrative field. This narrow gate avoids treating arbitrary prose or
+    nested provider-error JSON as a successful summary.
+    """
+    repaired = repair_json(text, return_objects=True)
+    if isinstance(repaired, dict):
+        return json.dumps(repaired) if any(repaired.get(k) for k in _SUMMARY_KEYS) else None
+    if not isinstance(repaired, list) or not repaired or not isinstance(repaired[0], dict):
+        return None
+
+    root = dict(repaired[0])
+    if not any(key in root for key in ("accomplishments", "decisions")):
+        return None
+    for value in repaired[1:]:
+        if isinstance(value, dict) and {"topic", "decision"}.issubset(value):
+            root.setdefault("decisions", []).append(value)
+
+    # json_repair can split a malformed root into several top-level values and
+    # lose their field names. Find the earliest schema-key suffix that is valid
+    # JSON; that preserves every recoverable field after the malformed token
+    # without guessing names for anonymous values that came before it.
+    decoder = json.JSONDecoder()
+    suffix_keys = ("blockers", "themes", "work_in_progress", *_SUMMARY_KEYS)
+    for key in suffix_keys:
+        marker = f'"{key}"'
+        start = text.find(marker)
+        if start == -1:
+            continue
+        try:
+            suffix, _ = decoder.raw_decode("{" + text[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(suffix, dict) and any(suffix.get(k) for k in _SUMMARY_KEYS):
+            root.update(suffix)
+            break
+    return json.dumps(root) if any(root.get(k) for k in _SUMMARY_KEYS) else None
 
 
 def _has_summary_json(text: str) -> bool:
@@ -309,10 +355,22 @@ def _extract_assistant_text(stdout: str) -> str:
             json_candidates[-1],
         )
         return json_candidates[-1]
+    for candidate in reversed(contents):
+        if _is_gptme_trailer(candidate):
+            continue
+        repaired = _repair_summary_json(candidate)
+        if repaired is not None:
+            logger.warning(
+                "gptme fallback: repaired malformed root summary JSON (%d -> %d chars)",
+                len(candidate),
+                len(repaired),
+            )
+            return repaired
+
     chosen = _last_non_trailer(contents)
     logger.warning(
         "gptme fallback: no assistant message parsed as JSON (%d messages); "
-        "returning last message for caller to attempt extraction: %.100r",
+        "returning last non-trailer message for caller to attempt extraction: %.100r",
         len(contents),
         chosen,
     )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -340,6 +340,18 @@ def _extract_assistant_text(stdout: str) -> str:
         # code blocks, etc.).
         non_json = [c for c in contents if c not in set(json_candidates)]
         if non_json:
+            for candidate in reversed(non_json):
+                if _is_gptme_trailer(candidate):
+                    continue
+                repaired = _repair_summary_json(candidate)
+                if repaired is not None:
+                    logger.warning(
+                        "gptme fallback: repaired malformed root summary JSON "
+                        "after JSON preamble (%d -> %d chars)",
+                        len(candidate),
+                        len(repaired),
+                    )
+                    return repaired
             chosen = _last_non_trailer(non_json)
             logger.warning(
                 "gptme fallback: no JSON candidate has summary key; "

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -207,9 +207,12 @@ def _repair_summary_json(text: str) -> str | None:
     root_index = next(
         (
             i
-            for i, value in enumerate(repaired)
-            if isinstance(value, dict)
-            and any(key in value for key in ("accomplishments", "decisions"))
+            for i in range(len(repaired) - 1, -1, -1)
+            if isinstance(repaired[i], dict)
+            and (
+                any(repaired[i].get(key) for key in _SUMMARY_KEYS)
+                or any(key in repaired[i] for key in ("accomplishments", "decisions"))
+            )
         ),
         None,
     )

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -345,6 +345,18 @@ def test_complete_tool_fence_is_gptme_trailer():
     assert _extract_assistant_text("\n".join([_msg("real prose"), _msg(trailer)])) == ("real prose")
 
 
+def test_json_preamble_then_malformed_summary_recovers_root_json():
+    """A valid JSON preamble must not prevent repair of a later summary."""
+    preamble = json.dumps({"thinking": "assemble the daily summary"})
+    malformed = '{"accomplishments": ["parser fix"], "narrative": "REAL summary"]'
+
+    out = _extract_assistant_text("\n".join([_msg(preamble), _msg(malformed)]))
+
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "REAL summary"
+    assert parsed.get("accomplishments") == ["parser fix"]
+
+
 def test_malformed_summary_then_complete_fence_recovers_root_json():
     """Recover a one-token malformed root summary before a complete trailer.
 

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -371,6 +371,20 @@ def test_same_message_json_preamble_then_malformed_summary_recovers_root_json():
     assert parsed.get("accomplishments") == ["parser fix"]
 
 
+def test_structural_preamble_then_malformed_summary_prefers_final_root():
+    """A summary-shaped preamble must not be merged into the final summary."""
+    content = (
+        '{"accomplishments": ["draft"], "decisions": []}\n'
+        '{"accomplishments": ["final"], "narrative": "REAL summary"]'
+    )
+
+    out = _extract_assistant_text(_msg(content))
+
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "REAL summary"
+    assert parsed.get("accomplishments") == ["final"]
+
+
 def test_malformed_summary_then_complete_fence_recovers_root_json():
     """Recover a one-token malformed root summary before a complete trailer.
 

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -23,6 +23,7 @@ from gptme_activity_summary.gptme_backend import (
     _DEFAULT_MODEL,
     _extract_assistant_text,
     _has_summary_json,
+    _is_gptme_trailer,
     _strip_think_tags,
     call_gptme,
     is_enabled,
@@ -335,6 +336,54 @@ def test_plain_text_then_trailer_skips_trailer():
     ndjson = "\n".join([_msg(prose), _msg(trailer)])
     out = _extract_assistant_text(ndjson)
     assert out == prose
+
+
+def test_complete_tool_fence_is_gptme_trailer():
+    """A bare complete tool fence is a gptme protocol trailer, not content."""
+    trailer = "```complete\n```"
+    assert _is_gptme_trailer(trailer)
+    assert _extract_assistant_text("\n".join([_msg("real prose"), _msg(trailer)])) == ("real prose")
+
+
+def test_malformed_summary_then_complete_fence_recovers_root_json():
+    """Recover a one-token malformed root summary before a complete trailer.
+
+    Live 2026-08-30 failure (gptme log ``running-hungry-monster``): DeepSeek
+    closed one object in the root ``decisions`` array with ``]`` instead of
+    ``}``, then emitted a bare ``complete`` fence. Returning that fence made
+    the caller find an unrelated nested news object rather than the root
+    summary.
+    """
+    malformed = json.dumps(
+        {
+            "accomplishments": ["parser fix"],
+            "decisions": [
+                {
+                    "topic": "fallback parser",
+                    "decision": "repair one closing delimiter",
+                    "rationale": "the rest of the root JSON is complete",
+                }
+            ],
+            "blockers": [{"issue": "quota", "status": "active"}],
+            "themes": ["reliability"],
+            "work_in_progress": ["missing-day live verification"],
+            "narrative": "REAL summary",
+            "interactions": [{"type": "conversation", "person": "Erik"}],
+        }
+    )
+    bad_delimiter = malformed.index("}", malformed.index('"rationale"'))
+    malformed = malformed[:bad_delimiter] + "]" + malformed[bad_delimiter + 1 :]
+    trailer = "```complete\n```"
+
+    out = _extract_assistant_text("\n".join([_msg(malformed), _msg(trailer)]))
+
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "REAL summary"
+    assert parsed.get("decisions", [{}])[0].get("topic") == "fallback parser"
+    assert parsed.get("blockers") == [{"issue": "quota", "status": "active"}]
+    assert parsed.get("themes") == ["reliability"]
+    assert parsed.get("work_in_progress") == ["missing-day live verification"]
+    assert parsed.get("interactions") == [{"type": "conversation", "person": "Erik"}]
 
 
 def test_multipart_content_list():

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -357,6 +357,20 @@ def test_json_preamble_then_malformed_summary_recovers_root_json():
     assert parsed.get("accomplishments") == ["parser fix"]
 
 
+def test_same_message_json_preamble_then_malformed_summary_recovers_root_json():
+    """A JSON preamble in the same message must not hide a malformed summary."""
+    content = (
+        '{"thinking": "assemble the daily summary"}\n'
+        '{"accomplishments": ["parser fix"], "narrative": "REAL summary"]'
+    )
+
+    out = _extract_assistant_text(_msg(content))
+
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "REAL summary"
+    assert parsed.get("accomplishments") == ["parser fix"]
+
+
 def test_malformed_summary_then_complete_fence_recovers_root_json():
     """Recover a one-token malformed root summary before a complete trailer.
 

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -385,6 +385,29 @@ def test_structural_preamble_then_malformed_summary_prefers_final_root():
     assert parsed.get("accomplishments") == ["final"]
 
 
+def test_narrative_preamble_then_split_summary_keeps_final_narrative():
+    """A preamble narrative must not overwrite a later concatenated summary root.
+
+    json-repair returns both independently valid objects. Last-match selects the
+    final root, but ``text.find('"narrative"')`` still lands in the preamble and
+    ``root.update(suffix)`` would persist the draft narrative and accomplishments.
+    """
+    content = (
+        '{"accomplishments": ["draft"], "blockers": [], '
+        '"narrative": "DRAFT summary"}\n'
+        '{"accomplishments": ["final"], "decisions": '
+        '[{"topic": "x", "decision": "y"}],\n'
+        '"blockers": [], "narrative": "REAL summary"}'
+    )
+
+    out = _extract_assistant_text(_msg(content))
+
+    parsed = extract_json_from_response(out)
+    assert parsed.get("narrative") == "REAL summary"
+    assert parsed.get("accomplishments") == ["final"]
+    assert parsed.get("decisions") == [{"topic": "x", "decision": "y"}]
+
+
 def test_malformed_summary_then_complete_fence_recovers_root_json():
     """Recover a one-token malformed root summary before a complete trailer.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1694,6 +1694,7 @@ dependencies = [
     { name = "click" },
     { name = "gptme" },
     { name = "gptme-sessions" },
+    { name = "json-repair" },
 ]
 
 [package.optional-dependencies]
@@ -1713,6 +1714,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
     { name = "gptme-sessions", editable = "packages/gptme-sessions" },
+    { name = "json-repair", specifier = ">=0.61.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },


### PR DESCRIPTION
## Problem

The live 2026-08-30 `bob-activity-summary` fallback (`running-hungry-monster`) emitted a structurally complete daily summary with one wrong delimiter in `decisions[5]` (`]` instead of `}`). gptme then emitted a bare `complete` fence. The parser treated that fence as content and the downstream raw decoder selected a nested news object, losing the root `narrative`.

This follows merged #1552, which isolates nested session logs. This PR handles the actual malformed model payload observed after isolation. The original stacked PR #1553 auto-closed when its base merged and GitHub would not reopen it; this replacement preserves the same tested branch.

## Change

- Treat a bare `complete` tool fence as a gptme protocol trailer.
- Use `json-repair` when no assistant message parses cleanly.
- Gate salvage on activity-summary schema and reconstruct the malformed root from the repaired prefix plus the earliest valid schema-key suffix.
- Handle valid JSON reasoning preambles in separate or same assistant messages.
- Preserve recoverable blockers, themes, work-in-progress, narrative, interactions, and external signals instead of accepting a nested object.

## Verification

- RED confirmed for the bare trailer, malformed-root, separate-preamble, and same-message-preamble regressions before each fix.
- `260 passed` across `packages/gptme-activity-summary/tests` after rebasing onto merged #1552.
- Ruff clean and mypy clean for the changed parser.
- Exact `running-hungry-monster` replay recovered 14 accomplishments, 8 decisions, 8 blockers, 7 themes, 12 WIP items, 1,138-char narrative, 8 interactions, and 4 external signals.
- Greptile reviewed the final pre-rebase code at 5/5 with no blocking findings on #1553; this branch differs only by rebasing onto #1552.
