### PR TITLE
fix(browser-semantic): label benchmark as static proxy

### DIFF
--- a/packages/gptme-browser-semantic/README.md
+++ b/packages/gptme-browser-semantic/README.md
@@ -8,24 +8,24 @@ backend that agents already have.
 
 ## Why
 
-The stock `browser` tool is screenshot-and-snapshot based. On a multi-step
-page task an agent pays an LLM call on every step:
+The stock `browser` tool exposes snapshots and deterministic actions. The
+outer agent model normally interprets each fresh snapshot before choosing the
+next action:
 
-```
-snapshot_page()   # 1 LLM: interpret ARIA
+```text
+snapshot_page()   # outer model interprets ARIA
 click_element()   # 0
-snapshot_page()   # 1 LLM: re-interpret
+snapshot_page()   # outer model re-interprets
 fill_element()    # 0
-snapshot_page()   # 1 LLM: verify
+snapshot_page()   # outer model verifies
 ```
 
-The semantic pattern collapses that cost:
+The semantic pattern makes selector discovery reusable:
 
-```
-browser_observe("the submit button")   # 1 LLM-equivalent hop, returns selectors
-browser_act(observed[0])               # 0 — reuses the cached selector
-browser_act(observed[1], fill="x")     # 0
-browser_extract()                      # 0 (raw ARIA)
+```python
+observed = browser_observe("the submit button")
+browser_act(observed[0])
+browser_extract()
 ```
 
 `browser_observe` is the load-bearing primitive: one call produces a ranked
@@ -69,40 +69,39 @@ actions act on for **zero** extra interpretation cost.
 
 - **Path A (this package)**: implement the semantic interface directly over
   gptme's ARIA snapshot + Playwright. Shippable today, zero new dependencies.
-- **Path B**: once `stagehand` exposes a usable local-only Python mode
-  (`stagehand.local_browser.launch()`, not yet on PyPI), these same tool
-  signatures wrap stagehand and inherit its real semantic model. The
-  `ObserveResult` shape is deliberately stagehand-compatible so the swap is
-  mechanical.
+- **Stagehand evaluation path**: `stagehand==3.23.0` now exposes a local API
+  server and local browser. It is not a mechanical swap: Stagehand requires a
+  CDP browser/session boundary, while gptme's current Playwright page is
+  private, thread-bound state. Keep Path A native until a supported shared-page
+  seam and an executed end-to-end benchmark justify the extra server and inner
+  model calls.
 
 ## Benchmark
 
-`benchmark.py` counts LLM calls across 5 representative page tasks against a
-static, deterministic `fixtures/hn.html` (HN clone — no live web, no browser
-launch). Recorded result under the conservative production-path proxy
-(observe and instructed extract counted as 1 LLM each, as if rerank/typed
-extract were on):
+`benchmark.py` preserves five representative action sequences and applies a
+static counting heuristic. It does not open `fixtures/hn.html`, invoke a
+browser or model, or record success. The historical scenario proxy is:
 
-| | LLM calls |
+| | Proxy units |
 |---|---:|
 | Raw `browser` path | 11 |
 | Path A semantic path | 7 |
-| **Reduction** | **−36.4%** |
+| **Difference** | **-4** |
 
-Path A's default implementation is cheaper than this proxy (0-LLM
-token-overlap observe, raw-ARIA extract). The −36% figure is therefore a
-lower bound. Run it:
+This is not a measured LLM, token, latency, or success-rate result. A verdict
+requires both paths to execute against the same page while recording outer
+agent turns and any inner provider calls separately. Run the proxy with:
 
-```
+```bash
 make benchmark
 ```
 
-`tests/test_benchmark.py` pins these totals so the design-doc claim can't
-rot silently.
+`tests/test_benchmark.py` pins the scenario arithmetic and its explicit
+limitations so it cannot silently become a performance claim again.
 
 ## Tests
 
-```
+```bash
 make test
 ```
 
@@ -132,5 +131,4 @@ The original Path A prototype lived only in
 `/tmp/worktrees/gptme-browser-semantic/` and was lost when that worktree
 was removed. This package reconstructs it from the committed design
 (`browser-tool-act-observe-extract.md`) and the 5d08 benchmark table.
-The 11→7 LLM-call claim is the conservative proxy from that design; it is
-pinned here rather than re-invented.
+The 11→7 result is retained only as the historical static scenario proxy.

--- a/packages/gptme-browser-semantic/benchmark.py
+++ b/packages/gptme-browser-semantic/benchmark.py
@@ -1,24 +1,15 @@
-"""
-Benchmark browser_semantic primitives vs the raw ``browser`` tool.
+"""Preserve the static five-scenario browser operation proxy.
 
-This counts LLM calls on 5 representative page tasks using a static
-HTML fixture (no live web dependency, deterministic output).
+This script does not execute the HTML fixture, a browser, either implementation,
+or an LLM. It assigns proxy units to hard-coded action strings so the original
+11→7 scenario arithmetic stays reproducible without being mislabeled as measured
+performance.
 
-The numbers are a *conservative production-path proxy*, matching the
-Path A design-doc table:
-
-- raw path: every ``snapshot_page()`` is 1 LLM call (interpret ARIA).
-  ``open_page`` / click / fill / scroll are 0.
-- semantic path: every ``browser_observe`` is counted as 1 LLM call
-  (as if ``llm_rerank=True``), and ``browser_extract`` with an
-  instruction is counted as 1 (typed extract). Selector-reuse
-  ``browser_act(<observed>)`` is 0.
-
-Path A's default implementation is cheaper than this proxy: observe is
-token-overlap (0 LLM) and extract returns raw ARIA (0 LLM). The 11→7
-claim is therefore a lower bound on the savings, not an overclaim.
-If a change to the action sequences or this heuristic moves the totals,
-update the design doc rather than letting the pin rot.
+The two columns are intentionally not comparable LLM-call counts: the raw side
+stands in for outer-agent snapshot interpretation, while the semantic side
+stands in for semantic resolution operations. A real benchmark must execute
+both paths against the same page and report success, outer turns, inner provider
+requests/tokens, and latency separately.
 
 Usage (from this package directory)::
 
@@ -29,6 +20,7 @@ Usage (from this package directory)::
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -47,12 +39,12 @@ TASKS: list[Task] = [
         name="click_first_headline",
         description="Click the first headline link on the page",
         raw_actions=[
-            "snapshot_page()",  # 1 LLM
+            "snapshot_page()",  # 1 raw proxy unit
             "click_element(text='First story')",  # 0
-            "snapshot_page()",  # 1 LLM (verify)
+            "snapshot_page()",  # 1 raw proxy unit (verify)
         ],
         semantic_actions=[
-            "browser_observe('the first headline link')",  # 1 LLM (proxy)
+            "browser_observe('the first headline link')",  # 1 semantic proxy unit
             "browser_act(<observed>)",  # 0
         ],
     ),
@@ -60,26 +52,26 @@ TASKS: list[Task] = [
         name="read_all_comment_counts",
         description="Read every comment count visible on the page",
         raw_actions=[
-            "snapshot_page()",  # 1 LLM
+            "snapshot_page()",  # 1 raw proxy unit
             "# agent parses comment counts by hand from snapshot text",
         ],
         semantic_actions=[
-            "browser_extract('all comment counts')",  # 1 LLM (typed proxy)
+            "browser_extract('all comment counts')",  # 1 semantic proxy unit
         ],
     ),
     Task(
         name="submit_search_query",
         description="Type 'rust async' into the search box and submit",
         raw_actions=[
-            "snapshot_page()",  # 1 LLM
+            "snapshot_page()",  # 1 raw proxy unit
             "fill_element([name='q'], 'rust async')",  # 0
-            "snapshot_page()",  # 1 LLM (verify typed)
+            "snapshot_page()",  # 1 raw proxy unit (verify)
             "click_element(text='Search')",  # 0
         ],
         semantic_actions=[
-            "browser_observe('the search box')",  # 1 LLM
+            "browser_observe('the search box')",  # 1 semantic proxy unit
             "browser_act(<observed>, method='fill', arguments=['rust async'])",  # 0
-            "browser_act('click the Search button')",  # 1 LLM (new observe)
+            "browser_act('click the Search button')",  # 1 semantic proxy unit
         ],
     ),
     Task(
@@ -87,14 +79,14 @@ TASKS: list[Task] = [
         description="Open page, click 'more' link, scroll down 2 screens",
         raw_actions=[
             "open_page(url)",  # 0 LLM (navigation only in this heuristic)
-            "snapshot_page()",  # 1 LLM
+            "snapshot_page()",  # 1 raw proxy unit
             "click_element(text='more')",  # 0
-            "snapshot_page()",  # 1 LLM (verify)
+            "snapshot_page()",  # 1 raw proxy unit (verify)
             "scroll_page(down, 1000)",  # 0
-            "snapshot_page()",  # 1 LLM (verify)
+            "snapshot_page()",  # 1 raw proxy unit (verify)
         ],
         semantic_actions=[
-            "browser_observe('the more link')",  # 1 LLM
+            "browser_observe('the more link')",  # 1 semantic proxy unit
             "browser_act(<observed>)",  # 0
             "scroll_page(down, 1000)",  # 0
         ],
@@ -104,42 +96,38 @@ TASKS: list[Task] = [
         description="Open, click, then read state to verify result",
         raw_actions=[
             "open_page(url)",  # 0
-            "snapshot_page()",  # 1 LLM
+            "snapshot_page()",  # 1 raw proxy unit
             "click_element(text='Submit')",  # 0
-            "snapshot_page()",  # 1 LLM (verify)
-            "snapshot_page()",  # 1 LLM (re-verify state changed)
+            "snapshot_page()",  # 1 raw proxy unit (verify)
+            "snapshot_page()",  # 1 raw proxy unit (re-verify)
         ],
         semantic_actions=[
-            "browser_observe('the submit button')",  # 1 LLM
+            "browser_observe('the submit button')",  # 1 semantic proxy unit
             "browser_act(<observed>)",  # 0
-            "browser_extract('the current page state')",  # 1 LLM (typed proxy)
+            "browser_extract('the current page state')",  # 1 semantic proxy unit
         ],
     ),
 ]
 
 
-def count_llm_calls(actions: list[str], is_semantic: bool) -> int:
-    """Count LLM calls in an action sequence.
+def count_proxy_units(actions: list[str], is_semantic: bool) -> int:
+    """Count historical interpretation units in an action sequence.
 
-    Heuristic (matches the design-doc narrative):
-      - raw path: snapshot_page() = 1 LLM (interpret ARIA)
-      - semantic path: browser_observe = 1 LLM, browser_extract WITH
-        instruction = 1 LLM (typed extraction is LLM-backed in production
-        accounting), browser_act with a string arg = 1 LLM (triggers an
-        observe), browser_act with an ObserveResult = 0, scroll = 0
+    This is scenario accounting only. It does not claim that a unit equals one
+    end-to-end LLM request.
     """
-    calls = 0
+    units = 0
     for action in actions:
         if is_semantic:
             if "browser_observe" in action:
-                calls += 1
+                units += 1
             elif "browser_extract" in action:
-                calls += 1
+                units += 1
             elif "browser_act(" in action and "<observed>" not in action:
-                calls += 1
+                units += 1
         elif "snapshot_page()" in action:
-            calls += 1
-    return calls
+            units += 1
+    return units
 
 
 def main() -> None:
@@ -150,38 +138,41 @@ def main() -> None:
     total_raw = 0
     total_sem = 0
     for task in TASKS:
-        raw_calls = count_llm_calls(task.raw_actions, is_semantic=False)
-        sem_calls = count_llm_calls(task.semantic_actions, is_semantic=True)
-        delta = sem_calls - raw_calls
-        total_raw += raw_calls
-        total_sem += sem_calls
-        rows.append((task.name, raw_calls, sem_calls, delta))
+        raw_units = count_proxy_units(task.raw_actions, is_semantic=False)
+        sem_units = count_proxy_units(task.semantic_actions, is_semantic=True)
+        delta = sem_units - raw_units
+        total_raw += raw_units
+        total_sem += sem_units
+        rows.append((task.name, raw_units, sem_units, delta))
 
-    print("# Browser semantic primitives — LLM-call benchmark\n")
-    print(f"Fixture: `{fixture.name}` (static, deterministic)\n")
-    print("| Task | Raw `browser` (LLM calls) | Path A semantic (LLM calls) | Δ |")
-    print("|------|---:|---:|---:|")
+    report = [
+        "# Browser semantic primitives — static operation proxy",
+        "",
+        f"Fixture: `{fixture.name}` (existence checked; not executed)",
+        "",
+        "| Task | Raw proxy units | Semantic proxy units | Δ |",
+        "|------|---:|---:|---:|",
+    ]
     for name, raw, sem, delta in rows:
-        print(f"| {name} | {raw} | {sem} | {delta:+d} |")
-    print(
-        f"| **Total** | **{total_raw}** | **{total_sem}** | **{total_sem - total_raw:+d}** |"
-    )
-    pct = (total_raw - total_sem) / total_raw * 100 if total_raw else 0
-    print(f"\n**Reduction**: {pct:.1f}% fewer LLM calls using semantic primitives.\n")
-    print(
-        "This is the conservative production-path proxy (observe/extract "
-        "counted as 1 LLM each). Path A's default implementation is 0-LLM "
-        "observe + raw-ARIA extract, so live savings are at least this large.\n"
+        report.append(f"| {name} | {raw} | {sem} | {delta:+d} |")
+    report.extend(
+        [
+            f"| **Total** | **{total_raw}** | **{total_sem}** | **{total_sem - total_raw:+d}** |",
+            "",
+            "This is static scenario accounting. It does not execute a browser or "
+            "model and does not measure success, turns, tokens, or latency.",
+        ]
     )
 
     out = {
         "fixture": str(fixture.name),
-        "accounting": "conservative_production_proxy",
+        "accounting": "static_scenario_proxy",
+        "executed": False,
         "tasks": [
             {
                 "name": r[0],
-                "raw_llm_calls": r[1],
-                "semantic_llm_calls": r[2],
+                "raw_proxy_units": r[1],
+                "semantic_proxy_units": r[2],
                 "delta": r[3],
             }
             for r in rows
@@ -190,12 +181,17 @@ def main() -> None:
             "raw": total_raw,
             "semantic": total_sem,
             "delta": total_sem - total_raw,
-            "pct_reduction": pct,
         },
+        "not_measured": [
+            "success",
+            "outer_turns",
+            "provider_calls",
+            "tokens",
+            "latency",
+        ],
     }
-    print("\n```json")
-    print(json.dumps(out, indent=2))
-    print("```")
+    report.extend(["", "```json", json.dumps(out, indent=2), "```", ""])
+    sys.stdout.write("\n".join(report))
 
 
 if __name__ == "__main__":

--- a/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
+++ b/packages/gptme-browser-semantic/src/gptme_browser_semantic/browser_semantic.py
@@ -1,10 +1,10 @@
 """
 Semantic browser primitives for gptme computer-use.
 
-Wraps the stagehand act/observe/extract pattern as three gptme tool functions:
-  - browser_act: execute an action on the current page (one LLM call, deterministic)
+Implements the stagehand act/observe/extract pattern as three library functions:
+  - browser_act: execute a deterministic action on the current page
   - browser_observe: return Playwright selectors matching an instruction (reusable)
-  - browser_extract: typed page data extraction (Pydantic schema optional)
+  - browser_extract: return the current raw ARIA snapshot
 
 Design intent (full justification in the "browser tool act/observe/extract"
 design doc, knowledge/technical-designs/browser-tool-act-observe-extract.md
@@ -15,35 +15,32 @@ in the workspace that prototyped this):
   selector, deterministic Playwright ops (`page.click`, `page.fill`) are zero-LLM
   calls. This is the headline gain over the existing `browser.snapshot` →
   `click_element(selector)` pattern, which already does this for ONE action at
-  a time; observe() enables chained deterministic actions after a single LLM hop.
+  a time; observe() enables chained deterministic actions from one snapshot.
 - act() with a pre-observed ObserveResult also goes deterministic (no LLM call).
   Reusing observed selectors across actions is the multi-step efficiency win.
-- extract() returns a typed schema (or raw text). Strictly optional; useful when
-  the downstream consumer is JSON-producing code (filling a form from a CSV,
-  pulling structured data off a list page).
+- extract() returns raw ARIA. Schema-aware extraction is deliberately rejected
+  in Path A rather than silently pretending to validate structured output.
 
 This module is the prototype. There are two implementation paths:
 
   Path A (this file): the *interface*. gptme tools are pure-Python functions
     that take the existing playwright page from `browser.py`. The semantic
     primitives are implemented over Playwright directly: observe() walks the
-    ARIA tree and uses LLM-ranked fuzzy matching; act() runs the selector;
-    extract() walks the DOM and applies schema validation.
-    Tradeoff: no stagehand dep, but you re-implement the AI bits.
+    ARIA tree and uses deterministic token-overlap ranking; act() runs the
+    selector; extract() returns the snapshot.
+    Tradeoff: no stagehand dependency, but no LLM reranking or typed extraction.
 
-  Path B (in design doc): when stagehand gains a usable local-only path OR
-    when we ship a small helper that runs the stagehand server locally, these
-    tools wrap stagehand.local_browser.launch() and inherit the real semantic
-    model. This is the recommended next step.
+  Stagehand evaluation path (in the design doc): stagehand==3.23.0 now has a
+    local server and local browser, but it requires a supported CDP/session
+    handoff to share gptme's current page. It is not a mechanical backend swap.
 
-This module implements Path A so we can benchmark today.
+This module implements Path A. The bundled benchmark is static scenario
+accounting, not an executed performance benchmark.
 
 Install notes:
 - Requires `pip install playwright` (already part of `gptme[browser]` extras).
 - `playwright install chromium` must have been run.
-- For the LLM-backed observe/extract paths, OPENAI_API_KEY (or any provider
-  gptme supports via its LLM router) must be set. Plumbed through gptme's
-  existing model client.
+- LLM-backed reranking and schema extraction are not implemented in Path A.
 """
 
 from __future__ import annotations
@@ -218,8 +215,8 @@ def browser_observe(
         instruction: natural-language description of what to find.
             Example: "the submit button at the bottom of the form".
         top_k: maximum number of results to return.
-        llm_rerank: if True, call the LLM to rerank the candidates. Adds
-            one LLM call per observe(). Default False keeps the path cheap.
+        llm_rerank: reserved for a future native reranker. Path A raises
+            ``NotImplementedError`` when this is True.
 
     Returns:
         list[ObserveResult]: ranked observations, best match first.
@@ -345,9 +342,8 @@ def browser_act(
     """Execute a single browser action.
 
     Two forms:
-      1. `browser_act("click the submit button")` — runs observe() internally
-         and dispatches the top match. One LLM call only when observe() needs
-         reranking.
+      1. `browser_act("click the submit button")` — runs the deterministic
+         observe() scorer internally and dispatches the top match.
       2. `browser_act(observed)` — pass an ObserveResult from a prior
          browser_observe() call. Zero LLM calls; uses the cached selector.
 
@@ -355,9 +351,8 @@ def browser_act(
     resolves — the page re-rendered, moved the element, or swapped refs — the
     dispatch fails and, with `retry_on_stale=True` (default), the element is
     re-observed once with the same query and retried with the fresh top
-    match. The re-observe is zero-LLM on the default token-scoring path, so
-    the retry costs nothing against the LLM-call budget. `retry_on_stale=False`
-    returns the first failure immediately.
+    match. The re-observe makes no model call on the token-scoring path.
+    `retry_on_stale=False` returns the first failure immediately.
 
     Returns ActResult with `success`, the selector used, and elapsed time.
     """

--- a/packages/gptme-browser-semantic/tests/test_benchmark.py
+++ b/packages/gptme-browser-semantic/tests/test_benchmark.py
@@ -1,11 +1,7 @@
-"""Regression test for the LLM-call benchmark claim.
+"""Regression tests for the static five-scenario operation proxy.
 
-Pins the numbers from the design doc: on the 5-task HN fixture the raw
-browser path costs 11 LLM calls, the Path A semantic path 7 (−36.4%)
-under the conservative production-path proxy. If a change to the action
-sequences or the counting heuristic moves these totals, the design-doc
-claim must be re-verified (and re-documented) rather than letting this
-test rot silently.
+Pins the historical 11→7 arithmetic and guards the output from presenting it as
+an executed LLM-call or success-rate result.
 """
 
 from __future__ import annotations
@@ -31,7 +27,7 @@ def test_benchmark_fixture_exists() -> None:
     assert (PACKAGE_ROOT / "fixtures" / "hn.html").exists()
 
 
-def test_benchmark_reproduces_recorded_claim() -> None:
+def test_benchmark_reproduces_recorded_proxy() -> None:
     bench = _load_benchmark()
     total_raw = 0
     total_sem = 0
@@ -43,8 +39,8 @@ def test_benchmark_reproduces_recorded_claim() -> None:
         "multi_step_with_verification": (3, 2),
     }
     for task in bench.TASKS:
-        raw = bench.count_llm_calls(task.raw_actions, is_semantic=False)
-        sem = bench.count_llm_calls(task.semantic_actions, is_semantic=True)
+        raw = bench.count_proxy_units(task.raw_actions, is_semantic=False)
+        sem = bench.count_proxy_units(task.semantic_actions, is_semantic=True)
         assert (raw, sem) == expected[task.name], task.name
         total_raw += raw
         total_sem += sem
@@ -52,5 +48,15 @@ def test_benchmark_reproduces_recorded_claim() -> None:
     assert len(bench.TASKS) == 5
     assert total_raw == 11
     assert total_sem == 7
-    pct = (total_raw - total_sem) / total_raw * 100
-    assert abs(pct - 36.4) < 0.1
+
+
+def test_benchmark_output_states_its_limitations(capsys) -> None:
+    bench = _load_benchmark()
+
+    bench.main()
+
+    output = capsys.readouterr().out
+    assert "static operation proxy" in output
+    assert "not executed" in output
+    assert "does not measure success, turns, tokens, or latency" in output
+    assert "fewer LLM calls" not in output


### PR DESCRIPTION
## Summary

- relabel the browser-semantic 11→7 result as static scenario accounting instead of measured LLM savings
- state explicitly that the fixture, browser, wrapper, model, and success rate are not executed
- update Path A docs to match the implementation and Stagehand v3.23's real local-server/session boundary
- add a regression test that prevents the CLI from presenting the proxy as "fewer LLM calls"

## Why

The existing benchmark counted markers in five hard-coded action-string lists. It mixed outer-agent snapshot interpretation with hypothetical inner semantic calls, then printed a 36.4% LLM reduction as if it were measured. That claim was too strong.

This keeps the useful five-scenario arithmetic while making its limits executable and obvious. It does not add Stagehand or change browser behavior.

## Verification

- `make -C packages/gptme-browser-semantic test` — 37 passed
- `make -C packages/gptme-browser-semantic typecheck`
- `make -C packages/gptme-browser-semantic benchmark`
- targeted Ruff and pre-commit hooks
- PR quality gate: 100/100
