### PR TITLE
feat(voice): bridge BobBrain vision into live calls

### DIFF
--- a/packages/gptme-vision-node/README.md
+++ b/packages/gptme-vision-node/README.md
@@ -52,6 +52,20 @@ pipeline = VisionPipeline(
 pipeline.start()
 ```
 
+## Voice bridge
+
+Install the vision extra next to the embedded voice node and point it at a
+camera or stream:
+
+```bash
+pip install 'gptme-voice-node[audio,vision]'
+GPTME_VOICE_NODE_VISION_SOURCE=camera:0 gptme-voice-node
+```
+
+The pipeline sends compact person/motion events over the existing `/local`
+WebSocket. It keeps the latest frame on-node until the realtime session calls
+`look`; only then is one JPEG sent to the host for VLM inference.
+
 ## Future (explicitly not v0)
 
 - **CLIP embeddings** for place recognition — a strict upgrade over the

--- a/packages/gptme-vision-node/README.md
+++ b/packages/gptme-vision-node/README.md
@@ -65,6 +65,7 @@ GPTME_VOICE_NODE_VISION_SOURCE=camera:0 gptme-voice-node
 The pipeline sends compact person/motion events over the existing `/local`
 WebSocket. It keeps the latest frame on-node until the realtime session calls
 `look`; only then is one JPEG sent to the host for VLM inference.
+Events are telemetry only in v0; they do not trigger unsolicited model speech.
 
 ## Future (explicitly not v0)
 

--- a/packages/gptme-vision-node/src/gptme_vision_node/__init__.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/__init__.py
@@ -5,6 +5,7 @@ place recognition (visual + WiFi fingerprints). See the BobBrain spec
 (ErikBjare/bob#730) — this is milestone 2 (vision v0).
 """
 
+from .bridge import VisionBridge
 from .detect import Detection, Detector, MotionDetector, PersonDetector
 from .frame_source import FrameSource, ImageFileSource, OpenCVCameraSource
 from .look import describe_frame
@@ -22,6 +23,7 @@ __all__ = [
     "OpenCVCameraSource",
     "PersonDetector",
     "PlaceRecognizer",
+    "VisionBridge",
     "VisionEvent",
     "VisionPipeline",
     "WifiSignature",

--- a/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
@@ -23,12 +23,13 @@ from .look import encode_frame_jpeg
 from .pipeline import VisionEvent, VisionPipeline
 
 logger = logging.getLogger(__name__)
+_MAX_PENDING_EVENT_SENDS = 4
 
 SendMessage = Callable[[str], Awaitable[None]]
 
 
-async def _await_send(awaitable: Awaitable[None]) -> None:
-    await awaitable
+async def _send_event(send_message: SendMessage, message: str) -> None:
+    await send_message(message)
 
 
 class VisionBridge:
@@ -68,6 +69,9 @@ class VisionBridge:
         send_message = self._send_message
         if send_message is None:
             return
+        if len(self._pending_sends) >= _MAX_PENDING_EVENT_SENDS:
+            logger.warning("dropping vision event while transport is backlogged")
+            return
         message = json.dumps(
             {
                 "type": "vision_event",
@@ -77,7 +81,7 @@ class VisionBridge:
             }
         )
         task: asyncio.Task[None] = asyncio.create_task(
-            _await_send(send_message(message))
+            _send_event(send_message, message)
         )
         self._pending_sends.add(task)
         task.add_done_callback(self._event_send_done)
@@ -109,7 +113,7 @@ class VisionBridge:
             logger.warning("ignoring vision look request without request_id")
             return True
 
-        frame = self.pipeline.latest_frame
+        frame = self.pipeline.latest_frame_copy()
         if frame is None:
             payload: dict[str, object] = {
                 "type": "vision_look_result",
@@ -151,6 +155,8 @@ class VisionBridge:
         self._send_message = None
         self._loop = None
         pending = list(self._pending_sends)
+        for task in pending:
+            task.cancel()
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
         self._pending_sends.clear()

--- a/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
@@ -1,0 +1,156 @@
+"""WebSocket bridge between a BobBrain camera and ``gptme-voice``.
+
+The bridge owns the camera on the edge node, runs cheap person/motion
+reflexes locally, and sends only compact event metadata unless the realtime
+model explicitly calls the ``look`` tool.  A look request captures the latest
+frame and sends one bounded JPEG over the existing voice-node WebSocket; VLM
+inference remains on the runtime host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from collections.abc import Awaitable, Callable
+
+import cv2
+
+from .detect import Detection, Detector
+from .frame_source import FrameSource
+from .look import encode_frame_jpeg
+from .pipeline import VisionEvent, VisionPipeline
+
+logger = logging.getLogger(__name__)
+
+SendMessage = Callable[[str], Awaitable[None]]
+
+
+async def _await_send(awaitable: Awaitable[None]) -> None:
+    await awaitable
+
+
+class VisionBridge:
+    """Run a vision pipeline and exchange events/look results over a WebSocket."""
+
+    def __init__(
+        self,
+        source: FrameSource,
+        detectors: list[Detector],
+        *,
+        interval_s: float = 1.0,
+        absent_frames_for_left: int = 3,
+        jpeg_quality: int = 75,
+    ) -> None:
+        if not 1 <= jpeg_quality <= 100:
+            raise ValueError("jpeg_quality must be between 1 and 100")
+        self.jpeg_quality = jpeg_quality
+        self.pipeline = VisionPipeline(
+            source,
+            detectors,
+            interval_s=interval_s,
+            on_event=self._on_event,
+            absent_frames_for_left=absent_frames_for_left,
+        )
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._send_message: SendMessage | None = None
+        self._pending_sends: set[asyncio.Task[None]] = set()
+
+    def _on_event(self, event: VisionEvent) -> None:
+        """Forward a pipeline-thread event to the asyncio WebSocket loop."""
+        loop = self._loop
+        if loop is None or self._send_message is None or loop.is_closed():
+            return
+        loop.call_soon_threadsafe(self._schedule_event, event)
+
+    def _schedule_event(self, event: VisionEvent) -> None:
+        send_message = self._send_message
+        if send_message is None:
+            return
+        message = json.dumps(
+            {
+                "type": "vision_event",
+                "event": event.kind,
+                "timestamp": event.timestamp,
+                "detections": [self._serialize_detection(d) for d in event.detections],
+            }
+        )
+        task: asyncio.Task[None] = asyncio.create_task(
+            _await_send(send_message(message))
+        )
+        self._pending_sends.add(task)
+        task.add_done_callback(self._event_send_done)
+
+    def _event_send_done(self, task: asyncio.Task[None]) -> None:
+        self._pending_sends.discard(task)
+        if task.cancelled():
+            return
+        try:
+            task.result()
+        except Exception:
+            logger.exception("failed to send vision event")
+
+    @staticmethod
+    def _serialize_detection(detection: Detection) -> dict[str, object]:
+        return {
+            "kind": detection.kind,
+            "box": list(detection.box),
+            "score": detection.score,
+        }
+
+    async def handle_message(self, data: object, send_message: SendMessage) -> bool:
+        """Handle a server message. Return true when it was a vision request."""
+        if not isinstance(data, dict) or data.get("type") != "vision_look_request":
+            return False
+
+        request_id = data.get("request_id")
+        if not isinstance(request_id, str) or not request_id:
+            logger.warning("ignoring vision look request without request_id")
+            return True
+
+        frame = self.pipeline.latest_frame
+        if frame is None:
+            payload: dict[str, object] = {
+                "type": "vision_look_result",
+                "request_id": request_id,
+                "error": "Camera has not produced a frame yet.",
+            }
+        else:
+            try:
+                jpeg = await asyncio.to_thread(
+                    encode_frame_jpeg, frame, quality=self.jpeg_quality
+                )
+                payload = {
+                    "type": "vision_look_result",
+                    "request_id": request_id,
+                    "image": base64.b64encode(jpeg).decode("ascii"),
+                    "media_type": "image/jpeg",
+                }
+            except (cv2.error, ValueError) as exc:
+                payload = {
+                    "type": "vision_look_result",
+                    "request_id": request_id,
+                    "error": f"Failed to encode camera frame: {exc}",
+                }
+        await send_message(json.dumps(payload))
+        return True
+
+    def start(self, loop: asyncio.AbstractEventLoop, send_message: SendMessage) -> None:
+        """Attach a connected transport and start the capture pipeline."""
+        self._loop = loop
+        self._send_message = send_message
+        self.pipeline.start()
+
+    async def stop(self) -> None:
+        """Stop capture, release the source, and drain pending event sends."""
+        self.pipeline.stop()
+        release = getattr(self.pipeline.source, "release", None)
+        if release is not None:
+            release()
+        self._send_message = None
+        self._loop = None
+        pending = list(self._pending_sends)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._pending_sends.clear()

--- a/packages/gptme-vision-node/src/gptme_vision_node/frame_source.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/frame_source.py
@@ -69,6 +69,8 @@ class OpenCVCameraSource:
     source is cheap and testable without hardware.
     """
 
+    stop_on_empty = False
+
     def __init__(self, source: int | str, *, read_attempts: int = 3) -> None:
         if read_attempts < 1:
             raise ValueError("read_attempts must be at least 1")

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -63,6 +63,7 @@ class VisionPipeline:
         self.absent_frames_for_left = absent_frames_for_left
 
         self.latest_frame: np.ndarray | None = None
+        self._latest_frame_lock = threading.Lock()
         self._person_present = False
         self._frames_without_person = 0
         self._thread: threading.Thread | None = None
@@ -78,9 +79,15 @@ class VisionPipeline:
         except Exception:
             logger.exception("event callback failed for %s", event.kind)
 
+    def latest_frame_copy(self) -> np.ndarray | None:
+        """Return a thread-safe snapshot for consumers outside the capture loop."""
+        with self._latest_frame_lock:
+            return None if self.latest_frame is None else self.latest_frame.copy()
+
     def _process_frame(self, frame: np.ndarray) -> list[VisionEvent]:
         """Run detectors and emit events for one captured frame."""
-        self.latest_frame = frame
+        with self._latest_frame_lock:
+            self.latest_frame = frame
 
         detections: list[Detection] = []
         for detector in self.detectors:
@@ -124,8 +131,10 @@ class VisionPipeline:
             try:
                 frame = self.source.get_frame()
                 if frame is None:
-                    break
-                self._process_frame(frame)
+                    if getattr(self.source, "stop_on_empty", True):
+                        break
+                else:
+                    self._process_frame(frame)
             except Exception:
                 logger.exception("pipeline step failed")
             elapsed = time.monotonic() - started

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -146,6 +146,9 @@ class VisionPipeline:
         self._stop.clear()
         self._person_present = False
         self._frames_without_person = 0
+        with self._latest_frame_lock:
+            # Drop the previous session's snapshot so look cannot describe a stale scene.
+            self.latest_frame = None
         self._thread = threading.Thread(
             target=self._run, name="vision-pipeline", daemon=True
         )

--- a/packages/gptme-vision-node/tests/test_bridge.py
+++ b/packages/gptme-vision-node/tests/test_bridge.py
@@ -92,6 +92,41 @@ async def test_look_before_first_frame_returns_bounded_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_event_send_queue_is_bounded(caplog) -> None:
+    bridge = VisionBridge(_Source(), [])
+    unblock = asyncio.Event()
+
+    async def blocked_send(_message: str) -> None:
+        await unblock.wait()
+
+    bridge._loop = asyncio.get_running_loop()
+    bridge._send_message = blocked_send
+    event = VisionEvent(PERSON_APPEARED)
+    for _ in range(10):
+        bridge._schedule_event(event)
+
+    assert len(bridge._pending_sends) == 4
+    assert "transport is backlogged" in caplog.text
+    unblock.set()
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_blocked_event_sends() -> None:
+    bridge = VisionBridge(_Source(), [])
+    blocked = asyncio.Event()
+
+    async def blocked_send(_message: str) -> None:
+        await blocked.wait()
+
+    bridge._send_message = blocked_send
+    bridge._schedule_event(VisionEvent(PERSON_APPEARED))
+
+    await asyncio.wait_for(bridge.stop(), timeout=0.1)
+    assert not bridge._pending_sends
+
+
+@pytest.mark.asyncio
 async def test_unrelated_server_message_is_not_consumed() -> None:
     bridge = VisionBridge(_Source(), [])
 

--- a/packages/gptme-vision-node/tests/test_bridge.py
+++ b/packages/gptme-vision-node/tests/test_bridge.py
@@ -1,0 +1,101 @@
+"""Tests for the edge-side camera/voice bridge."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import numpy as np
+import pytest
+from gptme_vision_node.bridge import VisionBridge
+from gptme_vision_node.detect import Detection
+from gptme_vision_node.pipeline import PERSON_APPEARED, VisionEvent
+
+
+class _Source:
+    def __init__(self) -> None:
+        self.released = False
+
+    def get_frame(self):
+        return None
+
+    def release(self) -> None:
+        self.released = True
+
+
+@pytest.mark.asyncio
+async def test_event_callback_crosses_into_websocket_loop() -> None:
+    bridge = VisionBridge(_Source(), [])
+    sent: list[str] = []
+
+    async def send(message: str) -> None:
+        sent.append(message)
+
+    bridge._loop = asyncio.get_running_loop()
+    bridge._send_message = send
+    bridge._on_event(
+        VisionEvent(
+            PERSON_APPEARED,
+            (Detection("person", (1, 2, 3, 4), 0.9),),
+            timestamp=123.0,
+        )
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert json.loads(sent[0]) == {
+        "type": "vision_event",
+        "event": "person_appeared",
+        "timestamp": 123.0,
+        "detections": [{"kind": "person", "box": [1, 2, 3, 4], "score": 0.9}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_look_request_returns_latest_frame_as_jpeg() -> None:
+    bridge = VisionBridge(_Source(), [])
+    bridge.pipeline.latest_frame = np.full((20, 20, 3), 127, dtype=np.uint8)
+    sent: list[str] = []
+
+    async def send(message: str) -> None:
+        sent.append(message)
+
+    handled = await bridge.handle_message(
+        {"type": "vision_look_request", "request_id": "req-1"}, send
+    )
+
+    assert handled is True
+    payload = json.loads(sent[0])
+    assert payload["type"] == "vision_look_result"
+    assert payload["request_id"] == "req-1"
+    assert payload["media_type"] == "image/jpeg"
+    assert base64.b64decode(payload["image"])[:2] == b"\xff\xd8"
+
+
+@pytest.mark.asyncio
+async def test_look_before_first_frame_returns_bounded_error() -> None:
+    bridge = VisionBridge(_Source(), [])
+    sent: list[str] = []
+
+    async def send(message: str) -> None:
+        sent.append(message)
+
+    assert await bridge.handle_message(
+        {"type": "vision_look_request", "request_id": "req-2"}, send
+    )
+    assert json.loads(sent[0]) == {
+        "type": "vision_look_result",
+        "request_id": "req-2",
+        "error": "Camera has not produced a frame yet.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_unrelated_server_message_is_not_consumed() -> None:
+    bridge = VisionBridge(_Source(), [])
+
+    async def send(_message: str) -> None:
+        raise AssertionError("must not send")
+
+    assert not await bridge.handle_message({"type": "audio_end"}, send)

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -233,6 +233,31 @@ def test_start_resets_presence_state_after_restart():
     pipeline.stop()
 
 
+def test_start_clears_stale_frame_until_new_capture():
+    """Reconnect/restart must not serve a frame from the previous session."""
+    first = solid_frame((10, 20, 30))
+    pipeline = VisionPipeline(ListSource([first]), [], interval_s=0.01)
+    pipeline.start()
+    thread = pipeline._thread
+    assert thread is not None
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert pipeline.latest_frame is not None
+
+    class EmptyLiveSource:
+        stop_on_empty = False
+
+        def get_frame(self):
+            return None
+
+    pipeline.source = EmptyLiveSource()
+    pipeline.start()
+    try:
+        assert pipeline.latest_frame_copy() is None
+    finally:
+        pipeline.stop()
+
+
 def test_stop_keeps_reference_to_blocked_thread():
     unblock = threading.Event()
 

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -75,6 +75,19 @@ def test_person_appeared_only_once_while_present():
     assert events[0].detections[0].kind == "person"
 
 
+def test_latest_frame_copy_is_an_independent_snapshot():
+    frame = solid_frame((60, 60, 60))
+    pipeline = VisionPipeline(ListSource([frame]), [])
+
+    pipeline.step()
+    snapshot = pipeline.latest_frame_copy()
+    assert snapshot is not None
+    snapshot[:] = 0
+
+    assert pipeline.latest_frame is not None
+    assert np.any(pipeline.latest_frame != 0)
+
+
 def test_motion_events_and_latest_frame():
     still = solid_frame((60, 60, 60))
     moved = still.copy()
@@ -160,6 +173,38 @@ def test_thread_stops_when_source_is_exhausted():
     thread.join(timeout=1)
     assert not thread.is_alive()
     pipeline.stop()
+
+
+def test_live_source_retries_after_empty_frame():
+    frame_seen = threading.Event()
+
+    class TransientLiveSource:
+        stop_on_empty = False
+
+        def __init__(self):
+            self.calls = 0
+
+        def get_frame(self):
+            self.calls += 1
+            if self.calls == 1:
+                return None
+            if self.calls == 2:
+                return solid_frame((60, 60, 60))
+            return None
+
+    class SeenDetector:
+        def detect(self, _frame):
+            frame_seen.set()
+            return []
+
+    pipeline = VisionPipeline(TransientLiveSource(), [SeenDetector()], interval_s=0.01)
+    pipeline.start()
+    try:
+        assert frame_seen.wait(timeout=1)
+        assert pipeline._thread is not None
+        assert pipeline._thread.is_alive()
+    finally:
+        pipeline.stop()
 
 
 def test_start_resets_presence_state_after_restart():

--- a/packages/gptme-voice-node/README.md
+++ b/packages/gptme-voice-node/README.md
@@ -30,6 +30,8 @@ All config is via environment variables (no CLI flags — systemd-friendly):
 |---|---|---|
 | `GPTME_VOICE_NODE_SERVER` | `ws://localhost:8080/local` | WebSocket URL of `bob-voice-server` |
 | `GPTME_VOICE_NODE_NAME` | `bobbrain-unknown` | Node identity used in local logs |
+| `GPTME_VOICE_NODE_VISION_SOURCE` | unset | Optional `camera:N`, RTSP/HTTP stream URL, or image path; enables the camera bridge |
+| `GPTME_VOICE_NODE_VISION_INTERVAL` | `1.0` | Seconds between local person/motion detection frames |
 
 The `ws://localhost` default is intended only for a server on the same host. Use
 `wss://` whenever microphone audio crosses a network; the client logs a warning
@@ -69,11 +71,17 @@ The node speaks the same WebSocket JSON protocol as `gptme-voice-client`:
 
 ```
 Client → Server: {"type": "audio", "audio": "<base64 PCM 16-bit 24kHz mono>"}
+Client → Server: {"type": "vision_event", "event": "person_appeared", ...}
+Client → Server: {"type": "vision_look_result", "request_id": "...", "image": "<base64 JPEG>"}
 Server → Client: {"type": "audio", "audio": "<base64>"}
 Server → Client: {"type": "audio_end"}
+Server → Client: {"type": "vision_look_request", "request_id": "..."}
 ```
 
-All inference happens on the host; the node is pure I/O plumbing.
+With the `vision` extra installed, set `GPTME_VOICE_NODE_VISION_SOURCE=camera:0`
+to run cheap person/motion detectors on the node. Events carry metadata only. A
+JPEG crosses the WebSocket only when the realtime model calls `look`; the host
+then runs VLM inference and returns the description to the same voice turn.
 
 ## Architecture
 

--- a/packages/gptme-voice-node/README.md
+++ b/packages/gptme-voice-node/README.md
@@ -82,6 +82,9 @@ With the `vision` extra installed, set `GPTME_VOICE_NODE_VISION_SOURCE=camera:0`
 to run cheap person/motion detectors on the node. Events carry metadata only. A
 JPEG crosses the WebSocket only when the realtime model calls `look`; the host
 then runs VLM inference and returns the description to the same voice turn.
+The node advertises camera capability on connect, so camera-less `/local`
+clients do not expose a `look` tool that can only time out. Vision events remain
+telemetry in v0 and never trigger unsolicited model speech.
 
 ## Architecture
 

--- a/packages/gptme-voice-node/pyproject.toml
+++ b/packages/gptme-voice-node/pyproject.toml
@@ -15,6 +15,9 @@ gptme-voice-node = "gptme_voice_node.node:main"
 audio = [
     "pyaudio>=0.2.13",
 ]
+vision = [
+    "gptme-vision-node>=0.1.0",
+]
 test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -7,10 +7,12 @@ Low memory footprint, systemd-managed lifecycle.
 Config (env vars):
   GPTME_VOICE_NODE_SERVER  — WebSocket URL of bob-voice-server (default: ws://localhost:8080/local)
   GPTME_VOICE_NODE_NAME    — Node identity string (default: bobbrain-unknown)
+  GPTME_VOICE_NODE_VISION_SOURCE — optional camera:N, stream URL, or image path
 
 Protocol:
   Client → Server: {"type": "audio", "audio": "<base64 PCM 16-bit 24kHz mono>"}
   Client → Server: {"type": "commit"}      (optional flush signal)
+  Client → Server: {"type": "vision_event", ...} / {"type": "vision_look_result", ...}
   Server → Client: {"type": "audio", "audio": "<base64>"}
   Server → Client: {"type": "audio_end"}
 """
@@ -40,6 +42,8 @@ except ImportError as e:
 # --- Config ---
 SERVER_URL = os.environ.get("GPTME_VOICE_NODE_SERVER", "ws://localhost:8080/local")
 NODE_NAME = os.environ.get("GPTME_VOICE_NODE_NAME", "bobbrain-unknown")
+VISION_SOURCE = os.environ.get("GPTME_VOICE_NODE_VISION_SOURCE")
+VISION_INTERVAL = float(os.environ.get("GPTME_VOICE_NODE_VISION_INTERVAL", "1.0"))
 
 # --- Audio constants (must match server) ---
 SAMPLE_RATE = 24000
@@ -122,9 +126,12 @@ class VoiceNode:
     and closed per-session so the OS sees a clean release on disconnect.
     """
 
-    def __init__(self, server_url: str, node_name: str) -> None:
+    def __init__(
+        self, server_url: str, node_name: str, *, vision_bridge: Any | None = None
+    ) -> None:
         self.server_url = server_url
         self.node_name = node_name
+        self.vision_bridge = vision_bridge
         pyaudio = _get_pyaudio()  # May raise ImportError if not installed
         self._pa = pyaudio.PyAudio()
         self._audio_format = pyaudio.paInt16
@@ -181,6 +188,8 @@ class VoiceNode:
                 mic_started = True
                 speaker.start_stream()
                 speaker_started = True
+                if self.vision_bridge is not None:
+                    self.vision_bridge.start(asyncio.get_running_loop(), ws.send)
                 send_task = asyncio.create_task(self._send_loop(ws, mic))
                 recv_task = asyncio.create_task(self._recv_loop(ws, speaker))
                 try:
@@ -190,6 +199,8 @@ class VoiceNode:
                         if not task.done():
                             task.cancel()
                     await asyncio.gather(send_task, recv_task, return_exceptions=True)
+                    if self.vision_bridge is not None:
+                        await self.vision_bridge.stop()
             finally:
                 _close_stream(speaker, speaker_started)
         finally:
@@ -233,6 +244,11 @@ class VoiceNode:
                 data = json.loads(raw_msg)
                 if not isinstance(data, dict):
                     raise TypeError("message must be a JSON object")
+                if (
+                    self.vision_bridge is not None
+                    and await self.vision_bridge.handle_message(data, ws.send)
+                ):
+                    continue
                 msg_type = data.get("type")
                 if msg_type == "audio":
                     audio = data.get("audio")
@@ -302,8 +318,36 @@ class VoiceNode:
         self._pa.terminate()
 
 
+def _build_vision_bridge(source_spec: str | None, interval_s: float):
+    if not source_spec:
+        return None
+    try:
+        from gptme_vision_node import (  # type: ignore[import-not-found]
+            MotionDetector,
+            OpenCVCameraSource,
+            PersonDetector,
+            VisionBridge,
+        )
+        from gptme_vision_node.cli import make_source  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "vision requires: pip install 'gptme-voice-node[vision]'"
+        ) from exc
+
+    source = make_source(source_spec)
+    if not isinstance(source, OpenCVCameraSource):
+        log.warning("vision source %s is not a live camera/stream", source_spec)
+    return VisionBridge(
+        source, [PersonDetector(), MotionDetector()], interval_s=interval_s
+    )
+
+
 async def _async_main(server_url: str, node_name: str) -> None:
-    node = VoiceNode(server_url, node_name)
+    node = VoiceNode(
+        server_url,
+        node_name,
+        vision_bridge=_build_vision_bridge(VISION_SOURCE, VISION_INTERVAL),
+    )
 
     loop = asyncio.get_event_loop()
     task = asyncio.ensure_future(node.run_forever())

--- a/packages/gptme-voice-node/src/gptme_voice_node/node.py
+++ b/packages/gptme-voice-node/src/gptme_voice_node/node.py
@@ -20,6 +20,7 @@ Protocol:
 import asyncio
 import base64
 import functools
+import importlib
 import json
 import logging
 import os
@@ -117,6 +118,15 @@ def _next_backoff(backoff: int, connected_at: float | None) -> int:
     ):
         return BACKOFF_INITIAL
     return min(backoff * 2, BACKOFF_MAX)
+
+
+def _with_vision_capability(server_url: str, enabled: bool) -> str:
+    """Tell the voice server whether this connection has a camera bridge."""
+    if not enabled:
+        return server_url
+    parsed = urlparse(server_url)
+    query = f"{parsed.query}&vision=1" if parsed.query else "vision=1"
+    return parsed._replace(query=query).geturl()
 
 
 class VoiceNode:
@@ -269,12 +279,15 @@ class VoiceNode:
     async def run_forever(self) -> None:
         """Connect and auto-reconnect with exponential backoff."""
         backoff = BACKOFF_INITIAL
+        connect_url = _with_vision_capability(
+            self.server_url, self.vision_bridge is not None
+        )
         while self._running:
             connected_at: float | None = None
             error: tuple[int, str] | None = None
             try:
                 async with websockets.connect(
-                    self.server_url,
+                    connect_url,
                     open_timeout=10,
                     ping_interval=20,
                     ping_timeout=20,
@@ -322,18 +335,18 @@ def _build_vision_bridge(source_spec: str | None, interval_s: float):
     if not source_spec:
         return None
     try:
-        from gptme_vision_node import (  # type: ignore[import-not-found]
-            MotionDetector,
-            OpenCVCameraSource,
-            PersonDetector,
-            VisionBridge,
-        )
-        from gptme_vision_node.cli import make_source  # type: ignore[import-not-found]
+        vision_node = importlib.import_module("gptme_vision_node")
+        vision_cli = importlib.import_module("gptme_vision_node.cli")
     except ImportError as exc:
         raise ImportError(
             "vision requires: pip install 'gptme-voice-node[vision]'"
         ) from exc
 
+    MotionDetector = getattr(vision_node, "MotionDetector")
+    OpenCVCameraSource = getattr(vision_node, "OpenCVCameraSource")
+    PersonDetector = getattr(vision_node, "PersonDetector")
+    VisionBridge = getattr(vision_node, "VisionBridge")
+    make_source = getattr(vision_cli, "make_source")
     source = make_source(source_spec)
     if not isinstance(source, OpenCVCameraSource):
         log.warning("vision source %s is not a live camera/stream", source_spec)

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -15,7 +15,12 @@ from websockets.exceptions import ConnectionClosed
 # ---------------------------------------------------------------------------
 
 
-def _make_node(server_url="ws://localhost:9999/local", node_name="test-node"):
+def _make_node(
+    server_url="ws://localhost:9999/local",
+    node_name="test-node",
+    *,
+    vision_bridge=None,
+):
     """Create a VoiceNode with pyaudio mocked out."""
     with patch("gptme_voice_node.node._get_pyaudio") as mock_get_pa:
         mock_pa_module = MagicMock()
@@ -24,7 +29,7 @@ def _make_node(server_url="ws://localhost:9999/local", node_name="test-node"):
         mock_get_pa.return_value = mock_pa_module
         from gptme_voice_node.node import VoiceNode
 
-        node = VoiceNode(server_url, node_name)
+        node = VoiceNode(server_url, node_name, vision_bridge=vision_bridge)
     return node
 
 
@@ -200,6 +205,21 @@ class TestRecvLoop:
         speaker.write.assert_not_called()
         assert "ignoring malformed message" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_vision_request_is_delegated_to_bridge(self):
+        bridge = MagicMock()
+        bridge.handle_message = AsyncMock(return_value=True)
+        node = _make_node(vision_bridge=bridge)
+        message = {"type": "vision_look_request", "request_id": "req-1"}
+        mock_ws = AsyncMock()
+        mock_ws.recv.side_effect = [json.dumps(message), ConnectionClosed(None, None)]
+        speaker = MagicMock()
+
+        await node._recv_loop(mock_ws, speaker)
+
+        bridge.handle_message.assert_awaited_once_with(message, mock_ws.send)
+        speaker.write.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Transport safety warning
@@ -304,6 +324,29 @@ class TestLifecycle:
         speaker.start_stream.assert_called_once()
         assert node._pa.open.call_args_list[0].kwargs["start"] is False
         assert node._pa.open.call_args_list[1].kwargs["start"] is False
+
+    @pytest.mark.asyncio
+    async def test_session_starts_and_stops_vision_with_audio(self):
+        vision = MagicMock()
+        vision.stop = AsyncMock()
+        node = _make_node(vision_bridge=vision)
+        mic = MagicMock()
+        speaker = MagicMock()
+        node._pa.open.side_effect = [mic, speaker]
+
+        async def stop_session(*_args):
+            node.stop()
+
+        websocket = AsyncMock()
+        with (
+            patch.object(node, "_send_loop", AsyncMock(side_effect=stop_session)),
+            patch.object(node, "_recv_loop", AsyncMock(side_effect=stop_session)),
+        ):
+            await node._session(websocket)
+
+        vision.start.assert_called_once()
+        assert vision.start.call_args.args[1] == websocket.send
+        vision.stop.assert_awaited_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("failing_stream", ["mic", "speaker"])

--- a/packages/gptme-voice-node/tests/test_voice_node.py
+++ b/packages/gptme-voice-node/tests/test_voice_node.py
@@ -453,6 +453,33 @@ class TestBackoff:
         with patch("gptme_voice_node.node.time.monotonic", return_value=100.0):
             assert _next_backoff(8, connected_at=60.0) == BACKOFF_INITIAL
 
+    def test_vision_capability_preserves_existing_query(self):
+        from gptme_voice_node.node import _with_vision_capability
+
+        url = "wss://voice.example/local?caller_id=erik"
+        assert _with_vision_capability(url, False) == url
+        assert (
+            _with_vision_capability(url, True)
+            == "wss://voice.example/local?caller_id=erik&vision=1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_vision_node_advertises_capability_on_connect(self):
+        vision = MagicMock()
+        node = _make_node(vision_bridge=vision)
+
+        async def stop_on_sleep(_delay):
+            node.stop()
+
+        connect = MagicMock(side_effect=OSError("offline"))
+        with (
+            patch("gptme_voice_node.node.websockets.connect", connect),
+            patch("gptme_voice_node.node.asyncio.sleep", side_effect=stop_on_sleep),
+        ):
+            await node.run_forever()
+
+        assert connect.call_args.args[0].endswith("/local?vision=1")
+
     @pytest.mark.asyncio
     async def test_retry_log_matches_sleep_delay(self, caplog):
         node = _make_node()

--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -11,6 +11,8 @@ Voice interface for gptme agents using OpenAI or xAI Grok Realtime APIs.
 - **Feedback loop prevention** by muting mic during playback
 - **Twilio integration** for phone call support via Media Streams
 - **Local testing** with direct microphone/speaker I/O
+- **BobBrain camera tool** — the `/local` session exposes `look` and runs VLM
+  inference only after the edge node returns an on-demand frame
 
 ## Installation
 
@@ -99,7 +101,8 @@ No need to export them as shell env vars if they're already configured in gptme.
 - **openai_client.py** - WebSocket client for OpenAI Realtime API with VAD, audio streaming, and event handling
 - **xai_client.py** - xAI Grok Voice Agent adapter (OpenAI-compatible WebSocket protocol)
 - **server.py** - Starlette WebSocket server bridging clients to OpenAI or xAI
-- **tool_bridge.py** - Async subagent dispatcher (runs `gptme --non-interactive` in background, injects results)
+- **tool_bridge.py** - Async subagent dispatcher plus body/vision tool routing
+- **vision.py** - Correlated camera-frame requests, edge-event handling, and host-side VLM inference
 - **audio.py** - Audio format conversion (PCM ↔ μ-law for Twilio)
 - **client.py** - Local client with mic/speaker I/O and feedback loop prevention
 

--- a/packages/gptme-voice/pyproject.toml
+++ b/packages/gptme-voice/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "twilio>=9.0.0",
     "audioop-lts>=0.2; python_version >= '3.13'",
     "gptme",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -34,6 +34,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from ..body import body_adapter_from_env, body_tool_schemas
 from ..handoff import HandoffWriter
+from ..vision import VisionSessionBridge, vision_tool_schema
 from .audio import AudioConverter
 from .openai_client import (
     OpenAIRealtimeClient,
@@ -2376,6 +2377,7 @@ class VoiceServer:
         initial_response_instructions: str = "",
         *,
         include_body_tools: bool = True,
+        include_vision_tools: bool = False,
     ) -> SessionConfig:
         """Build a SessionConfig with optional runtime overrides."""
         kwargs: dict = dict(
@@ -2393,8 +2395,13 @@ class VoiceServer:
             kwargs["output_speed"] = self.output_speed
         if self.openai_g711_passthrough:
             kwargs["g711_passthrough"] = True
+        extra_tools: list[dict] = []
         if include_body_tools and self.body_adapter is not None:
-            kwargs["extra_tools"] = body_tool_schemas(self.body_adapter)
+            extra_tools.extend(body_tool_schemas(self.body_adapter))
+        if include_vision_tools:
+            extra_tools.append(vision_tool_schema())
+        if extra_tools:
+            kwargs["extra_tools"] = extra_tools
         return SessionConfig(**kwargs)
 
     def _make_client(
@@ -2508,9 +2515,11 @@ class VoiceServer:
             body_adapter = self._body_adapter_for_websocket(
                 websocket, transport="local"
             )
+            vision_bridge = VisionSessionBridge(websocket.send_text)
             session_cfg = self._build_session_config(
                 instructions=instructions,
                 include_body_tools=body_adapter is not None,
+                include_vision_tools=True,
             )
             on_ai_transcript, on_user_transcript, _local_hangup = (
                 self._make_transcript_callbacks(
@@ -2537,6 +2546,7 @@ class VoiceServer:
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
                 body_adapter=body_adapter,
+                vision_bridge=vision_bridge,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -2545,6 +2555,8 @@ class VoiceServer:
             async for message in websocket.iter_text():
                 data = json.loads(message)
 
+                if await vision_bridge.handle_message(data):
+                    continue
                 if data.get("type") == "audio":
                     # Audio chunk from client (PCM 24kHz)
                     audio_b64 = data.get("audio", "")
@@ -2567,6 +2579,8 @@ class VoiceServer:
         except Exception as e:
             logger.exception("Error handling local connection: %s", e)
         finally:
+            if "vision_bridge" in locals():
+                vision_bridge.close()
             if realtime_client:
                 await self._disconnect_realtime_client(realtime_client)
             await self._on_call_end(

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -74,6 +74,13 @@ def _websocket_peer_host(websocket) -> str | None:
     return None
 
 
+def _websocket_has_vision(websocket) -> bool:
+    """Whether a local client advertised an attached camera bridge."""
+    query_params = getattr(websocket, "query_params", {})
+    value = query_params.get("vision") if query_params is not None else None
+    return isinstance(value, str) and value.lower() in {"1", "true", "yes"}
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -2505,6 +2512,7 @@ class VoiceServer:
         handoff_id = self._get_local_handoff_id(websocket)
         realtime_client: OpenAIRealtimeClient | None = None
         tool_bridge: GptmeToolBridge | None = None
+        vision_bridge: VisionSessionBridge | None = None
         transcript: list[TranscriptTurn] = []
 
         try:
@@ -2515,11 +2523,12 @@ class VoiceServer:
             body_adapter = self._body_adapter_for_websocket(
                 websocket, transport="local"
             )
-            vision_bridge = VisionSessionBridge(websocket.send_text)
+            if _websocket_has_vision(websocket):
+                vision_bridge = VisionSessionBridge(websocket.send_text)
             session_cfg = self._build_session_config(
                 instructions=instructions,
                 include_body_tools=body_adapter is not None,
-                include_vision_tools=True,
+                include_vision_tools=vision_bridge is not None,
             )
             on_ai_transcript, on_user_transcript, _local_hangup = (
                 self._make_transcript_callbacks(
@@ -2555,7 +2564,9 @@ class VoiceServer:
             async for message in websocket.iter_text():
                 data = json.loads(message)
 
-                if await vision_bridge.handle_message(data):
+                if vision_bridge is not None and await vision_bridge.handle_message(
+                    data
+                ):
                     continue
                 if data.get("type") == "audio":
                     # Audio chunk from client (PCM 24kHz)
@@ -2579,7 +2590,7 @@ class VoiceServer:
         except Exception as e:
             logger.exception("Error handling local connection: %s", e)
         finally:
-            if "vision_bridge" in locals():
+            if vision_bridge is not None:
                 vision_bridge.close()
             if realtime_client:
                 await self._disconnect_realtime_client(realtime_client)

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Sequence, TypeVar
 
 if TYPE_CHECKING:
     from ..body import BodyAdapter
+    from ..vision import VisionSessionBridge
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,7 @@ class GptmeToolBridge:
         on_handoff: Callable[[str, str, str | None], Awaitable[dict]] | None = None,
         transcript_provider: Callable[[], Sequence[object]] | None = None,
         body_adapter: "BodyAdapter | None" = None,
+        vision_bridge: "VisionSessionBridge | None" = None,
     ):
         self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
@@ -142,6 +144,7 @@ class GptmeToolBridge:
         self.on_handoff = on_handoff
         self.transcript_provider = transcript_provider
         self.body_adapter = body_adapter
+        self.vision_bridge = vision_bridge
         self.body_max_altitude_m = self._parse_env_float(
             "GPTME_VOICE_BODY_MAX_ALT_M", default=30.0, minimum=1.0
         )
@@ -947,6 +950,14 @@ class GptmeToolBridge:
                 }
             result = await self.on_handoff(to_agent, reason, context_summary)
             return result
+
+        if name == "look":
+            if self.vision_bridge is None:
+                return {"error": "No camera is connected to this session."}
+            prompt = arguments.get("prompt") or "Describe what you see, briefly."
+            if not isinstance(prompt, str):
+                return {"error": "Invalid arguments for look: prompt must be text."}
+            return await self.vision_bridge.look(prompt)
 
         if name.startswith("body_"):
             return await self._handle_body_call(name, arguments)

--- a/packages/gptme-voice/src/gptme_voice/vision.py
+++ b/packages/gptme-voice/src/gptme_voice/vision.py
@@ -1,0 +1,214 @@
+"""Host-side vision tool and event bridge for BobBrain voice sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import secrets
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_PROMPT = "Describe what you see in this image, briefly."
+_MAX_IMAGE_BYTES = 4 * 1024 * 1024
+_ALLOWED_EVENTS = frozenset({"person_appeared", "person_left", "motion"})
+
+SendMessage = Callable[[str], Awaitable[None]]
+EventCallback = Callable[[str], Awaitable[None] | None]
+
+
+def vision_tool_schema() -> dict[str, Any]:
+    """Realtime function schema for an on-demand camera look."""
+    return {
+        "type": "function",
+        "name": "look",
+        "description": (
+            "Look through the connected BobBrain camera and answer a visual "
+            "question. Use this whenever the caller asks what you see, who is "
+            "there, or asks about something currently in front of the camera."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "What to inspect or describe in the current view.",
+                }
+            },
+        },
+    }
+
+
+async def describe_image(
+    image: bytes,
+    prompt: str = DEFAULT_PROMPT,
+    *,
+    media_type: str = "image/jpeg",
+    model: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    timeout: float = 60.0,
+) -> str:
+    """Describe a JPEG via an OpenAI-compatible chat-completions endpoint."""
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+    if media_type != "image/jpeg":
+        raise ValueError(f"unsupported image media type: {media_type}")
+    encoded = base64.b64encode(image).decode("ascii")
+    body = {
+        "model": model or os.environ.get("VISION_MODEL", DEFAULT_MODEL),
+        "max_tokens": 500,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{media_type};base64,{encoded}"},
+                    },
+                ],
+            }
+        ],
+    }
+    url = (base_url or os.environ.get("OPENAI_BASE_URL", DEFAULT_BASE_URL)).rstrip("/")
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            f"{url}/chat/completions",
+            json=body,
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        response.raise_for_status()
+        data = response.json()
+    try:
+        content = data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ValueError(f"unexpected response shape: {data!r}") from exc
+    if not isinstance(content, str):
+        raise ValueError(f"unexpected response content type: {type(content)}")
+    return content
+
+
+@dataclass
+class _PendingLook:
+    future: asyncio.Future[tuple[bytes, str]]
+    created_at: float
+
+
+class VisionSessionBridge:
+    """Coordinate one voice WebSocket's vision events and look requests."""
+
+    def __init__(
+        self,
+        send_message: SendMessage,
+        *,
+        on_event: EventCallback | None = None,
+        look_timeout_s: float = 8.0,
+        describe: Callable[..., Awaitable[str]] = describe_image,
+    ) -> None:
+        self.send_message = send_message
+        self.on_event = on_event
+        self.look_timeout_s = look_timeout_s
+        self.describe = describe
+        self._pending: dict[str, _PendingLook] = {}
+
+    async def look(self, prompt: str = DEFAULT_PROMPT) -> dict[str, str]:
+        """Request a current frame from the edge node and describe it remotely."""
+        request_id = secrets.token_urlsafe(12)
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[tuple[bytes, str]] = loop.create_future()
+        self._pending[request_id] = _PendingLook(future, time.monotonic())
+        try:
+            await self.send_message(
+                json.dumps(
+                    {
+                        "type": "vision_look_request",
+                        "request_id": request_id,
+                    }
+                )
+            )
+            image, media_type = await asyncio.wait_for(
+                future, timeout=self.look_timeout_s
+            )
+            description = await self.describe(
+                image, prompt or DEFAULT_PROMPT, media_type=media_type
+            )
+            return {"status": "ok", "description": description}
+        except asyncio.TimeoutError:
+            return {"error": "Camera did not return a frame before the timeout."}
+        except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+            logger.warning("vision look failed: %s", exc)
+            return {"error": f"Could not inspect the camera frame: {exc}"}
+        finally:
+            pending = self._pending.pop(request_id, None)
+            if pending is not None and not pending.future.done():
+                pending.future.cancel()
+
+    async def handle_message(self, data: object) -> bool:
+        """Consume a vision protocol message from the edge node."""
+        if not isinstance(data, dict):
+            return False
+        message_type = data.get("type")
+        if message_type == "vision_look_result":
+            self._handle_look_result(data)
+            return True
+        if message_type == "vision_event":
+            await self._handle_event(data)
+            return True
+        return False
+
+    def _handle_look_result(self, data: dict[str, object]) -> None:
+        request_id = data.get("request_id")
+        if not isinstance(request_id, str):
+            return
+        pending = self._pending.get(request_id)
+        if pending is None or pending.future.done():
+            logger.debug("ignoring stale vision result %s", request_id)
+            return
+        error = data.get("error")
+        if isinstance(error, str) and error:
+            pending.future.set_exception(RuntimeError(error))
+            return
+        encoded = data.get("image")
+        media_type = data.get("media_type", "image/jpeg")
+        if not isinstance(encoded, str) or not isinstance(media_type, str):
+            pending.future.set_exception(ValueError("malformed vision image result"))
+            return
+        try:
+            image = base64.b64decode(encoded, validate=True)
+        except ValueError:
+            pending.future.set_exception(ValueError("invalid vision image encoding"))
+            return
+        if not image or len(image) > _MAX_IMAGE_BYTES:
+            pending.future.set_exception(ValueError("vision image size is invalid"))
+            return
+        pending.future.set_result((image, media_type))
+
+    async def _handle_event(self, data: dict[str, object]) -> None:
+        event = data.get("event")
+        if not isinstance(event, str) or event not in _ALLOWED_EVENTS:
+            logger.warning("ignoring unknown vision event: %r", event)
+            return
+        if self.on_event is None:
+            return
+        result = self.on_event(event)
+        if asyncio.iscoroutine(result):
+            await result
+
+    def close(self) -> None:
+        """Cancel look requests left behind by a disconnected node."""
+        for pending in self._pending.values():
+            if not pending.future.done():
+                pending.future.cancel()
+        self._pending.clear()

--- a/packages/gptme-voice/src/gptme_voice/vision.py
+++ b/packages/gptme-voice/src/gptme_voice/vision.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import json
 import logging
-import os
 import secrets
 import time
 from collections.abc import Awaitable, Callable
@@ -14,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from gptme.config import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -60,14 +60,15 @@ async def describe_image(
     timeout: float = 60.0,
 ) -> str:
     """Describe a JPEG via an OpenAI-compatible chat-completions endpoint."""
-    key = api_key or os.environ.get("OPENAI_API_KEY")
+    config = get_config()
+    key = api_key or config.get_env("OPENAI_API_KEY")
     if not key:
         raise RuntimeError("OPENAI_API_KEY is not set")
     if media_type != "image/jpeg":
         raise ValueError(f"unsupported image media type: {media_type}")
     encoded = base64.b64encode(image).decode("ascii")
     body = {
-        "model": model or os.environ.get("VISION_MODEL", DEFAULT_MODEL),
+        "model": model or config.get_env("VISION_MODEL") or DEFAULT_MODEL,
         "max_tokens": 500,
         "messages": [
             {
@@ -82,7 +83,9 @@ async def describe_image(
             }
         ],
     }
-    url = (base_url or os.environ.get("OPENAI_BASE_URL", DEFAULT_BASE_URL)).rstrip("/")
+    url = (base_url or config.get_env("OPENAI_BASE_URL") or DEFAULT_BASE_URL).rstrip(
+        "/"
+    )
     async with httpx.AsyncClient(timeout=timeout) as client:
         response = await client.post(
             f"{url}/chat/completions",
@@ -147,7 +150,7 @@ class VisionSessionBridge:
             return {"status": "ok", "description": description}
         except asyncio.TimeoutError:
             return {"error": "Camera did not return a frame before the timeout."}
-        except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        except (httpx.HTTPError, httpx.InvalidURL, RuntimeError, ValueError) as exc:
             logger.warning("vision look failed: %s", exc)
             return {"error": f"Could not inspect the camera frame: {exc}"}
         finally:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -30,6 +30,7 @@ from gptme_voice.realtime.server import (
     _prepend_activity_digest,
     _should_trigger_hangup_transcript_fallback,
     _truncate_resume_transcript,
+    _websocket_has_vision,
 )
 from gptme_voice.realtime.sounds import PCM_CUES, SAMPLE_RATE
 
@@ -44,6 +45,16 @@ class _DummyWebSocket:
 
     async def send_bytes(self, message: bytes) -> None:
         self.binary_messages.append(message)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("true", True), ("yes", True), ("0", False), (None, False)],
+)
+def test_local_vision_capability_is_explicit(value, expected) -> None:
+    websocket = _DummyWebSocket()
+    websocket.query_params = {} if value is None else {"vision": value}
+    assert _websocket_has_vision(websocket) is expected
 
 
 class _ClosableWebSocket(_DummyWebSocket):

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2398,6 +2398,15 @@ class TestTranscriptPromotion:
         assert len(calls) == 0
 
 
+def test_local_session_config_exposes_look_without_body_tools() -> None:
+    server = VoiceServer()
+    config = server._build_session_config(
+        "You are Bob.", include_body_tools=False, include_vision_tools=True
+    )
+
+    assert [tool["name"] for tool in config.extra_tools] == ["look"]
+
+
 def test_server_g711_passthrough_off_by_default() -> None:
     server = VoiceServer()
     assert server.openai_g711_passthrough is False

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1,12 +1,33 @@
 import asyncio
 import logging
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from gptme_voice.realtime.tool_bridge import (
     _TIMEOUT_BINARY_AVAILABLE,
     GptmeToolBridge,
 )
+
+
+@pytest.mark.asyncio
+async def test_look_routes_to_vision_bridge() -> None:
+    vision = AsyncMock()
+    vision.look.return_value = {"status": "ok", "description": "a room"}
+    bridge = GptmeToolBridge(workspace="/fake/workspace", vision_bridge=vision)
+
+    result = await bridge.handle_function_call("look", {"prompt": "Who is here?"})
+
+    assert result == {"status": "ok", "description": "a room"}
+    vision.look.assert_awaited_once_with("Who is here?")
+
+
+@pytest.mark.asyncio
+async def test_look_without_camera_fails_cleanly() -> None:
+    bridge = GptmeToolBridge(workspace="/fake/workspace")
+    assert await bridge.handle_function_call("look", {}) == {
+        "error": "No camera is connected to this session."
+    }
 
 
 class _FakeStream:

--- a/packages/gptme-voice/tests/test_vision.py
+++ b/packages/gptme-voice/tests/test_vision.py
@@ -1,0 +1,116 @@
+"""Tests for the host side of the BobBrain vision/voice bridge."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import pytest
+from gptme_voice.vision import VisionSessionBridge, describe_image, vision_tool_schema
+
+
+def test_vision_tool_schema_is_an_on_demand_look() -> None:
+    schema = vision_tool_schema()
+    assert schema["name"] == "look"
+    assert schema["parameters"]["properties"]["prompt"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_look_roundtrip_requests_frame_then_describes_it() -> None:
+    sent: list[dict] = []
+    described: list[tuple[bytes, str, str]] = []
+
+    async def send(message: str) -> None:
+        payload = json.loads(message)
+        sent.append(payload)
+        await bridge.handle_message(
+            {
+                "type": "vision_look_result",
+                "request_id": payload["request_id"],
+                "image": base64.b64encode(b"jpeg-bytes").decode(),
+                "media_type": "image/jpeg",
+            }
+        )
+
+    async def describe(image: bytes, prompt: str, *, media_type: str) -> str:
+        described.append((image, prompt, media_type))
+        return "Erik is standing by the table."
+
+    bridge = VisionSessionBridge(send, describe=describe)
+    result = await bridge.look("Who is in front of me?")
+
+    assert sent[0]["type"] == "vision_look_request"
+    assert result == {
+        "status": "ok",
+        "description": "Erik is standing by the table.",
+    }
+    assert described == [(b"jpeg-bytes", "Who is in front of me?", "image/jpeg")]
+
+
+@pytest.mark.asyncio
+async def test_look_times_out_without_a_camera_result() -> None:
+    async def send(_message: str) -> None:
+        return None
+
+    bridge = VisionSessionBridge(send, look_timeout_s=0.01)
+    result = await bridge.look()
+
+    assert result == {"error": "Camera did not return a frame before the timeout."}
+    assert bridge._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_vision_event_reaches_callback_without_triggering_vlm() -> None:
+    events: list[str] = []
+
+    async def send(_message: str) -> None:
+        return None
+
+    async def on_event(event: str) -> None:
+        events.append(event)
+
+    bridge = VisionSessionBridge(send, on_event=on_event)
+    assert await bridge.handle_message(
+        {"type": "vision_event", "event": "person_appeared"}
+    )
+    assert events == ["person_appeared"]
+
+
+@pytest.mark.asyncio
+async def test_describe_image_uses_async_openai_compatible_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"choices": [{"message": {"content": "a room"}}]}
+
+    class _Client:
+        def __init__(self, *, timeout: float) -> None:
+            captured["timeout"] = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url: str, *, json: dict, headers: dict):
+            captured.update(url=url, body=json, headers=headers)
+            return _Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    result = await describe_image(
+        b"jpeg", "what?", api_key="sk-test", base_url="https://vision.test/v1/"
+    )
+
+    assert result == "a room"
+    assert captured["url"] == "https://vision.test/v1/chat/completions"
+    assert captured["headers"] == {"Authorization": "Bearer sk-test"}
+    image_url = captured["body"]["messages"][0]["content"][1]["image_url"]["url"]
+    assert image_url == "data:image/jpeg;base64,anBlZw=="

--- a/packages/gptme-voice/tests/test_vision.py
+++ b/packages/gptme-voice/tests/test_vision.py
@@ -7,6 +7,7 @@ import json
 
 import httpx
 import pytest
+from gptme_voice import vision
 from gptme_voice.vision import VisionSessionBridge, describe_image, vision_tool_schema
 
 
@@ -78,6 +79,29 @@ async def test_vision_event_reaches_callback_without_triggering_vlm() -> None:
 
 
 @pytest.mark.asyncio
+async def test_look_returns_bounded_error_for_invalid_vision_url() -> None:
+    async def send(message: str) -> None:
+        payload = json.loads(message)
+        await bridge.handle_message(
+            {
+                "type": "vision_look_result",
+                "request_id": payload["request_id"],
+                "image": base64.b64encode(b"jpeg-bytes").decode(),
+                "media_type": "image/jpeg",
+            }
+        )
+
+    async def invalid_url(*_args, **_kwargs) -> str:
+        raise httpx.InvalidURL("bad vision URL")
+
+    bridge = VisionSessionBridge(send, describe=invalid_url)
+
+    assert await bridge.look() == {
+        "error": "Could not inspect the camera frame: bad vision URL"
+    }
+
+
+@pytest.mark.asyncio
 async def test_describe_image_uses_async_openai_compatible_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -104,13 +128,23 @@ async def test_describe_image_uses_async_openai_compatible_request(
             captured.update(url=url, body=json, headers=headers)
             return _Response()
 
+    class _Config:
+        values = {
+            "OPENAI_API_KEY": "sk-config",
+            "OPENAI_BASE_URL": "https://vision.test/v1/",
+            "VISION_MODEL": "vision-config-model",
+        }
+
+        def get_env(self, key: str) -> str | None:
+            return self.values.get(key)
+
     monkeypatch.setattr(httpx, "AsyncClient", _Client)
-    result = await describe_image(
-        b"jpeg", "what?", api_key="sk-test", base_url="https://vision.test/v1/"
-    )
+    monkeypatch.setattr(vision, "get_config", _Config)
+    result = await describe_image(b"jpeg", "what?")
 
     assert result == "a room"
     assert captured["url"] == "https://vision.test/v1/chat/completions"
-    assert captured["headers"] == {"Authorization": "Bearer sk-test"}
+    assert captured["headers"] == {"Authorization": "Bearer sk-config"}
+    assert captured["body"]["model"] == "vision-config-model"
     image_url = captured["body"]["messages"][0]["content"][1]["image_url"]["url"]
     assert image_url == "data:image/jpeg;base64,anBlZw=="

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ torch = { index = "pytorch-cpu" }
 # but noisy across machines. See alice journal 2026-08-18.
 numpy = { index = "pypi" }
 gptme = { git = "https://github.com/gptme/gptme.git", branch = "master" }
+gptme-vision-node = { workspace = true }
 gptme-sessions = { workspace = true }
 gptme-usage = { workspace = true }
 gptodo = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -2621,6 +2621,7 @@ dependencies = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "click" },
     { name = "gptme" },
+    { name = "httpx" },
     { name = "openai" },
     { name = "starlette" },
     { name = "twilio" },
@@ -2644,6 +2645,7 @@ requires-dist = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2" },
     { name = "click", specifier = ">=8.0" },
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mavsdk", marker = "extra == 'body'", specifier = ">=2.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pyaudio", marker = "extra == 'local'", specifier = ">=0.2.13" },
@@ -2671,15 +2673,19 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+vision = [
+    { name = "gptme-vision-node" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "gptme-vision-node", marker = "extra == 'vision'", editable = "packages/gptme-vision-node" },
     { name = "pyaudio", marker = "extra == 'audio'", specifier = ">=0.2.13" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["audio", "test"]
+provides-extras = ["audio", "vision", "test"]
 
 [[package]]
 name = "gptme-warpgrep"


### PR DESCRIPTION
## Summary

- multiplex BobBrain vision events and correlated `look` requests over the existing `/local` voice WebSocket
- expose `look` only when `gptme-voice-node` advertises an attached vision bridge
- keep frames on the edge until requested, then run one host-side OpenAI-compatible VLM call
- harden the bridge with bounded event sends, thread-safe frame snapshots, reconnect-safe camera retries, and clean cancellation
- resolve VLM credentials/model/base URL through normal gptme config

This is the integration follow-up to gptme/gptme-contrib#1528 and gptme/gptme-contrib#1529. It advances ErikBjare/bob#730 without creating a separate body-node abstraction.

## Deliberate limits

- Vision events are telemetry only in v0. They do not inject model context or trigger unsolicited speech; motion can fire every sample and upstream has not defined proactive behavior.
- No continuous frame streaming, local VLM inference, place-recognition tool, or `gptme-body-node` extraction.

## Verification

- `uv run pytest packages/gptme-vision-node packages/gptme-voice-node packages/gptme-voice -q` — 437 passed, 2 skipped
- `uv run ruff check` on all three package source/test trees
- vision-node mypy plus focused voice/voice-node mypy
- pre-commit hooks passed
- Bob PR quality gate: 100/100
