### PR TITLE
fix(activity-gate): treat round-capped P2-only reviews as clean

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -991,7 +991,26 @@ ai_review_verdict() {
 
     score=$(printf '%s' "$marker" | jq -r '.score // empty' 2>/dev/null)
     if [ -n "$score" ] && [ "$score" != "null" ]; then
-        [ "$score" -ge 5 ] 2>/dev/null && echo "clean" || echo "dirty"
+        if [ "$score" -ge 5 ] 2>/dev/null; then
+            echo "clean"
+            return 0
+        fi
+        # Round cap: after 5 reviews, P2-only (score 4) is informational.
+        # apply_round_cap uses review_round_count = len(history)+1 and fires
+        # when that is > 5; the posted marker includes the current round, so
+        # history length >= 6 means the cap has already been applied. Keep
+        # P0/P1 (score <= 3) dirty so they still dispatch.
+        # Incident: gptme/gptme#3646 — 23 PM sessions on a round-capped P2
+        # that had already been rejected, no open threads, same head.
+        if [ "$score" -eq 4 ] 2>/dev/null; then
+            local n_rounds
+            n_rounds=$(printf '%s' "$marker" | jq -r '(.history // []) | length' 2>/dev/null)
+            if [ -n "$n_rounds" ] && [ "$n_rounds" -gt 5 ] 2>/dev/null; then
+                echo "clean"
+                return 0
+            fi
+        fi
+        echo "dirty"
         return 0
     fi
     # Markers written before the score field shipped (2026-08-07/08) carry none,

--- a/tests/test_activity_gate_greptile_dark.py
+++ b/tests/test_activity_gate_greptile_dark.py
@@ -130,12 +130,31 @@ def _pr(head_sha: str = TEST_HEAD_SHA) -> dict:
     }
 
 
-def _bob_ai_review_comment(sha: str, score: int = 4) -> dict:
-    """A comment carrying Bob's ai-review marker (no Greptile signature)."""
+def _bob_ai_review_comment(
+    sha: str, score: int = 4, *, n_history: int | None = None
+) -> dict:
+    """A comment carrying Bob's ai-review marker (no Greptile signature).
+
+    ``n_history`` is the length of the marker's ``history`` array (includes the
+    current round, matching the live reviewer). Default ``None`` keeps the
+    original compact marker so existing tests stay byte-identical.
+    """
+    if n_history:
+        history = [
+            {"sha": f"{sha[:6]}{i:02d}", "score": score, "findings": 1}
+            for i in range(n_history)
+        ]
+        marker = json.dumps(
+            {"sha": sha, "score": score, "history": history},
+            separators=(",", ":"),
+        )
+        body = f"<!-- bob-ai-review {marker} -->"
+    else:
+        body = f'<!-- bob-ai-review {{"sha": "{sha}", "score": {score}}} -->'
     return {
         "id": 111,
         "user": {"login": BOT},
-        "body": f'<!-- bob-ai-review {{"sha": "{sha}", "score": {score}}} -->',
+        "body": body,
         "created_at": "2026-08-11T09:00:00Z",
     }
 
@@ -698,6 +717,85 @@ def test_dark_branch_high_dark_score_dirty_ai_emits_needs_fix() -> None:
         assert (
             improvement_items == []
         ), f"no improvement item expected when AI verdict is dirty; got: {improvement_items}"
+
+
+def test_round_capped_p2_score_4_is_clean() -> None:
+    """Score 4 with history length > 5 (round cap already applied) is clean.
+
+    gptme/gptme#3646: Greptile 5/5, our reviewer 4/5 with one round-capped P2,
+    all inline threads resolved, closed-loop already posted. ``ai_review_verdict``
+    returned dirty because score < 5, so the gate re-emitted reviewer_needs_fix
+    every cooldown hour — 23 PM sessions on the same head.
+
+    History length includes the current round; > 5 matches apply_round_cap
+    (review_round_count = len(history)+1 > 5 once the capped review is posted).
+    """
+    import time
+
+    short_sha = TEST_HEAD_SHA[:10]
+    fixture = {
+        "prs": [_pr()],
+        "comments": [_bob_ai_review_comment(short_sha, score=4, n_history=6)],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        state_file = _state_file(state_dir)
+        old_ts = int(time.time()) - 7200
+        # Prior cycle saw this as dirty; the new verdict must flip to clean
+        # and not emit.
+        state_file.write_text(f":{old_ts}:{TEST_HEAD_SHA}:dirty")
+
+        result = _run_gate(tmp, fixture, state_dir=state_dir)
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _greptile_items(result)
+        assert items == [], (
+            f"round-capped P2-only (score 4, history=6) must not emit; got {items}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        fields = state_file.read_text().strip().split(":")
+        assert fields[3] == "clean", (
+            f"verdict field must be clean after round-capped score 4; "
+            f"got: {state_file.read_text()!r}"
+        )
+
+
+def test_round_capped_p1_score_3_stays_dirty() -> None:
+    """P0/P1 (score <= 3) still dispatch after the round cap.
+
+    The cap only downgrades P2+. A P1 that survives 6 reviews is still work.
+    """
+    import time
+
+    short_sha = TEST_HEAD_SHA[:10]
+    fixture = {
+        "prs": [_pr()],
+        "comments": [_bob_ai_review_comment(short_sha, score=3, n_history=6)],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        state_file = _state_file(state_dir)
+        old_ts = int(time.time()) - 7200
+        state_file.write_text(f":{old_ts}:{TEST_HEAD_SHA}:dirty")
+
+        result = _run_gate(tmp, fixture, state_dir=state_dir)
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _greptile_items(result)
+        assert any(
+            i.get("type") in ("greptile_needs_fix", "reviewer_needs_fix") for i in items
+        ), (
+            f"score 3 (P1) after 6 rounds must still emit needs_fix; got {items}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
 
 
 def test_dark_branch_pending_ai_verdict_does_not_emit() -> None:


### PR DESCRIPTION
## Summary

`ai_review_verdict` treated any score < 5 as dirty. After the reviewer's round cap, a P2-only 4/5 is informational (non-blocking, no inline thread) — but the gate still re-emitted `reviewer_needs_fix` every cooldown hour.

**Incident**: [gptme/gptme#3646](https://github.com/gptme/gptme/pull/3646) burned 23 project-monitoring sessions on one rejected nested-fold-in P2. Head unchanged, all threads resolved, closed-loop already posted. Greptile 5/5; our reviewer 4/5 round-capped.

## Change

When the posted marker's `history` length is > 5 (current round included, matching `apply_round_cap` after the capped review is posted) **and** score is 4 (P2-only), return `clean`. Score <= 3 (P0/P1) stays dirty so blocking findings still dispatch. Uncapped 4/5 (history missing or ≤ 5) is unchanged.

Does not overlap [gptme/gptme-contrib#1549](https://github.com/gptme/gptme-contrib/pull/1549) (that PR edits `has_actionable_update`; this edits `ai_review_verdict`).

## Test plan

- [x] `python3 -m pytest tests/test_activity_gate_greptile_dark.py tests/test_activity_gate_greptile_score_not_poisoned.py -q` — 29 passed
- [x] New: score 4 + history=6 → no emit, verdict field `clean`
- [x] New: score 3 + history=6 → still `reviewer_needs_fix`
- [x] Existing score-4-without-history dirty path still emits
