### PR TITLE
fix(gptodo): retry once on transient 401 auth-death in spawn_agent

### DIFF
--- a/packages/gptodo/src/gptodo/_auth.py
+++ b/packages/gptodo/src/gptodo/_auth.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 
 import re
 
-# Auth-failure markers emitted by CC / gptme on a dead auth token.
-# Kept deliberately broad — the tiny-output size gate prevents false positives
-# in the spawn-output case.
+# Transient 401 / credential-death markers emitted by CC on a dead OAuth token.
+# Deliberately excludes 403 (org policy, region block, content-filter) and
+# billing ("credit balance is too low", disabled subscription): those are
+# persistent. Treating them as "transient 401" would retry a doomed
+# `claude -p` session and send operators to check OAuth tokens.
+# The tiny-output size gate still prevents prose false positives.
 _AUTH_PATTERNS = [
     r"\b401\b",
-    r"\b403\b",
     r"unauthorized",
     r"invalid bearer token",
     r"authentication_error",
@@ -34,8 +36,6 @@ _AUTH_PATTERNS = [
     r"oauth\b.{0,40}\bexpired",
     r"oauth\b.{0,40}\b(fail|error|invalid)",
     r"please run /login",
-    r"credit balance is too low",
-    r"disabled.*subscription",
 ]
 
 _AUTH_RE = re.compile("|".join(_AUTH_PATTERNS), re.IGNORECASE)

--- a/packages/gptodo/src/gptodo/_auth.py
+++ b/packages/gptodo/src/gptodo/_auth.py
@@ -1,0 +1,66 @@
+"""Transient-401 / auth-death classifier for gptodo spawn.
+
+Sourced from Bob's canonical ``scripts/lib/auth_401.py`` (task
+``harden-401-auth-everywhere``, ErikBjare/bob#968). Kept as a small,
+self-contained copy so gptodo does not depend on the agent workspace.
+
+Public API
+----------
+``is_transient_401(text)``
+    Does arbitrary text (stderr, captured stdout) carry a 401/auth-failure
+    signature?  No size gate — for classifying a captured error string.
+
+``is_auth_death(output, max_bytes)``
+    The spawn-output case: tiny output *and* an auth signature.  Both
+    conditions required so a large, genuinely-completed session whose diff
+    merely mentions "401" is not misclassified.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Auth-failure markers emitted by CC / gptme on a dead auth token.
+# Kept deliberately broad — the tiny-output size gate prevents false positives
+# in the spawn-output case.
+_AUTH_PATTERNS = [
+    r"\b401\b",
+    r"\b403\b",
+    r"unauthorized",
+    r"invalid bearer token",
+    r"authentication_error",
+    r"authentication_failed",
+    r"invalid[_ ]api[_ ]key",
+    r"oauth\b.{0,40}\bexpired",
+    r"oauth\b.{0,40}\b(fail|error|invalid)",
+    r"please run /login",
+    r"credit balance is too low",
+    r"disabled.*subscription",
+]
+
+_AUTH_RE = re.compile("|".join(_AUTH_PATTERNS), re.IGNORECASE)
+
+# Smallest real worker output observed (2026-06-24) was ~46 KB; 2 KB has a
+# >20× safety margin against false positives from completed sessions.
+DEFAULT_MAX_BYTES = 2_000
+
+
+def is_transient_401(text: str) -> bool:
+    """Return True iff *text* carries a 401 / auth-failure signature.
+
+    No size gate — call this on a captured stderr/stdout string.  For the
+    size-gated spawn-output case use :func:`is_auth_death`.
+    """
+    return bool(_AUTH_RE.search(text))
+
+
+def is_auth_death(output: str, max_bytes: int = DEFAULT_MAX_BYTES) -> bool:
+    """Return True iff *output* is small **and** carries an auth-failure signature.
+
+    The spawn case: a session that died instantly on a 401 produces a tiny
+    output. Both conditions are required so a large, genuinely-completed
+    session whose diff merely mentions "401" is not flagged.
+    """
+    if len(output.encode("utf-8", errors="replace")) > max_bytes:
+        return False
+    return is_transient_401(output)

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -5866,8 +5866,14 @@ def _execute_task_agent(
     system_prompt_file: str | None = None,
     coordination: bool = False,
     coordination_db: str | None = None,
-):
-    """Shared logic for run and spawn commands."""
+) -> bool:
+    """Shared logic for run and spawn commands.
+
+    Returns True when the agent spawned/completed successfully, False when
+    the spawn was refused or the session ended in failed/auth_failed.
+    The sequential ``gptodo loop`` uses this to count failures instead of
+    treating a normal return as success.
+    """
     repo_root = find_repo_root(Path.cwd())
     tasks_dir = repo_root / "tasks"
 
@@ -5890,7 +5896,7 @@ def _execute_task_agent(
             console.print(
                 "\nWait for agents to finish, or kill one with: [cyan]gptodo kill <session-id>[/]"
             )
-            return
+            return False
 
     # Find the task
     tasks = load_tasks(tasks_dir)
@@ -5909,7 +5915,7 @@ def _execute_task_agent(
 
     if not task:
         console.print(f"[red]Error: Task '{task_id}' not found[/]")
-        return
+        return False
 
     # Build prompt from task if not provided
     if not prompt:
@@ -5956,7 +5962,7 @@ Focus on making progress on this task. When done, summarize what you accomplishe
 
     if session.status in ("failed", "auth_failed"):
         console.print(f"[red]✗ Failed to {action.lower()} agent:[/] {session.error}")
-        return
+        return False
 
     console.print(
         f"[green]✓ Agent {'spawned' if background else 'completed'}:[/] {session.session_id}"
@@ -5970,6 +5976,7 @@ Focus on making progress on this task. When done, summarize what you accomplishe
         console.print(f"  Status: {session.status}")
         if session.error:
             console.print(f"  Error: {session.error}")
+    return True
 
 
 @cli.command("run")
@@ -6320,7 +6327,7 @@ def loop_cmd(
         for i, task in enumerate(tasks_to_run, 1):
             console.print(f"\n[bold]Task {i}/{len(tasks_to_run)}: {task.name}[/]")
             try:
-                _execute_task_agent(
+                ok = _execute_task_agent(
                     task_id=task.name,
                     prompt=None,
                     agent_type=agent_type,
@@ -6329,7 +6336,10 @@ def loop_cmd(
                     model=model,
                     timeout=timeout,
                 )
-                completed += 1
+                if ok:
+                    completed += 1
+                else:
+                    failed += 1
             except Exception as e:
                 console.print(f"[red]Error: {e}[/]")
                 failed += 1

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -87,6 +87,7 @@ from gptodo.locks import (
 
 # Import subagent functionality (Issue #255: Multi-Agent Collaboration)
 from gptodo.subagent import (
+    SESSION_STATUSES,
     check_session,
     cleanup_sessions,
     get_session_output,
@@ -5953,7 +5954,7 @@ Focus on making progress on this task. When done, summarize what you accomplishe
         coordination_db=coordination_db,
     )
 
-    if session.status == "failed":
+    if session.status in ("failed", "auth_failed"):
         console.print(f"[red]✗ Failed to {action.lower()} agent:[/] {session.error}")
         return
 
@@ -6340,7 +6341,7 @@ def loop_cmd(
 @click.option(
     "--status",
     "-s",
-    type=click.Choice(["running", "completed", "failed", "killed"]),
+    type=click.Choice(list(SESSION_STATUSES)),
     help="Filter by status",
 )
 @click.option(
@@ -6388,6 +6389,7 @@ def sessions_cmd(status: str | None, as_json: bool):
         "running": "yellow",
         "completed": "green",
         "failed": "red",
+        "auth_failed": "red",
         "killed": "dim",
     }
 
@@ -6467,7 +6469,8 @@ def kill_cmd(session_id: str):
 def cleanup_sessions_cmd(older_than: int):
     """Clean up old session files.
 
-    Removes completed/failed session files older than the specified time.
+    Removes completed/failed/auth_failed/killed session files older than the
+    specified time.
     """
     repo_root = find_repo_root(Path.cwd())
     count = cleanup_sessions(repo_root, older_than)

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -13,16 +13,25 @@ import logging
 import os
 import shlex
 import subprocess
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+from gptodo._auth import DEFAULT_MAX_BYTES, is_auth_death
+
 logger = logging.getLogger(__name__)
 
 # Directory for session state files
 SESSIONS_DIR = "state/sessions"
+
+# 401 / auth-death retry policy for the ``claude`` backend foreground path.
+# A transient CC 401 (OAuth blip) is usually self-healing; one retry after a
+# short backoff recovers the vast majority of cases without burning the attempt.
+_AUTH_RETRY_BACKOFF_SECS = 5
+_AUTH_RETRY_MAX = 1
 
 
 @dataclass
@@ -34,7 +43,7 @@ class AgentSession:
     agent_type: Literal["general", "explore", "plan", "execute"]
     backend: Literal["gptme", "claude", "codex"]
     started: str
-    status: Literal["running", "completed", "failed", "killed"]
+    status: Literal["running", "completed", "failed", "auth_failed", "killed"]
     tmux_session: str | None = None
     output_file: str | None = None
     error: str | None = None
@@ -374,13 +383,48 @@ def spawn_agent(
             env=env,
         )
 
-        # Save output
-        output_file.write_text(result.stdout + "\n" + result.stderr)
+        combined_output = result.stdout + "\n" + result.stderr
 
-        session.status = "completed" if result.returncode == 0 else "failed"
+        # 401 retry — foreground ``claude`` backend only.
+        # A transient OAuth blip produces a tiny output with an auth signature.
+        # Retry once after a short backoff; only mark failed if retry also fails.
+        retried_401 = False
+        if result.returncode != 0 and backend not in ("gptme",):
+            if is_auth_death(combined_output):
+                logger.warning(
+                    "spawn_agent: transient 401 detected on first attempt; " "retrying in %ds …",
+                    _AUTH_RETRY_BACKOFF_SECS,
+                )
+                time.sleep(_AUTH_RETRY_BACKOFF_SECS)
+                result = subprocess.run(
+                    cmd,
+                    cwd=workspace,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout if timeout > 0 else None,
+                    env=env,
+                )
+                combined_output = result.stdout + "\n" + result.stderr
+                retried_401 = True
+
+        # Save output
+        output_file.write_text(combined_output)
+
         session.completed_at = datetime.now(timezone.utc).isoformat()
-        if result.returncode != 0:
-            session.error = f"Exit code: {result.returncode}"
+        if result.returncode == 0:
+            session.status = "completed"
+        else:
+            # For non-gptme backends (which have the retry policy), classify
+            # the failure so callers can distinguish a transient auth blip from
+            # a real task failure.  gptme has its own auth layer — just report
+            # "failed" with the exit code so nothing downstream is surprised.
+            if backend not in ("gptme",) and is_auth_death(combined_output):
+                session.status = "auth_failed"
+                retry_note = " (retried once)" if retried_401 else ""
+                session.error = f"auth-death: transient 401{retry_note}"
+            else:
+                session.status = "failed"
+                session.error = f"Exit code: {result.returncode}"
 
     except subprocess.TimeoutExpired:
         session.status = "failed"
@@ -426,8 +470,15 @@ def check_session(session_id: str, workspace: Path | None = None) -> AgentSessio
                     session.status = "failed"
                     session.error = "Timed out"
                 elif "EXIT_CODE=" in output:
-                    session.status = "failed"
-                    session.error = "Non-zero exit code"
+                    # Classify: tiny output with auth signature → auth_failed
+                    # (distinct from a generic non-zero, and never conflated
+                    # with a successful session that mentions "401" in prose).
+                    if is_auth_death(output, DEFAULT_MAX_BYTES):
+                        session.status = "auth_failed"
+                        session.error = "auth-death: transient 401"
+                    else:
+                        session.status = "failed"
+                        session.error = "Non-zero exit code"
 
             save_session(session, workspace)
 

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -380,6 +380,7 @@ def spawn_agent(
             env = os.environ.copy()
         env["COORDINATION_DB"] = coord_db_path
 
+    combined_output = ""
     try:
         result = subprocess.run(
             cmd,
@@ -400,6 +401,10 @@ def spawn_agent(
         retried_401 = False
         if result.returncode != 0 and backend == "claude":
             if is_auth_death(combined_output):
+                # Persist first-attempt output *before* sleep/retry. If the
+                # retry raises TimeoutExpired (or any other exception), the
+                # except path must not discard a complete first result.
+                output_file.write_text(combined_output)
                 logger.warning(
                     "spawn_agent: transient 401 detected on first attempt; retrying in %ds …",
                     _AUTH_RETRY_BACKOFF_SECS,
@@ -435,9 +440,13 @@ def spawn_agent(
                 session.error = f"Exit code: {result.returncode}"
 
     except subprocess.TimeoutExpired:
+        if combined_output:
+            output_file.write_text(combined_output)
         session.status = "failed"
         session.error = f"Timeout after {timeout}s"
     except Exception as e:
+        if combined_output:
+            output_file.write_text(combined_output)
         session.status = "failed"
         session.error = str(e)
 
@@ -478,10 +487,10 @@ def check_session(session_id: str, workspace: Path | None = None) -> AgentSessio
                     session.status = "failed"
                     session.error = "Timed out"
                 elif "EXIT_CODE=" in output:
-                    # Classify: tiny output with auth signature → auth_failed
-                    # (distinct from a generic non-zero, and never conflated
-                    # with a successful session that mentions "401" in prose).
-                    if is_auth_death(output, DEFAULT_MAX_BYTES):
+                    # Classify: tiny claude output with auth signature →
+                    # auth_failed. gptme/codex keep a plain "failed" — they
+                    # are not the CC OAuth-blip this status exists for.
+                    if session.backend == "claude" and is_auth_death(output, DEFAULT_MAX_BYTES):
                         session.status = "auth_failed"
                         session.error = "auth-death: transient 401"
                     else:

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -18,7 +18,7 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 from gptodo._auth import DEFAULT_MAX_BYTES, is_auth_death
 
@@ -26,6 +26,13 @@ logger = logging.getLogger(__name__)
 
 # Directory for session state files
 SESSIONS_DIR = "state/sessions"
+
+SessionStatus = Literal["running", "completed", "failed", "auth_failed", "killed"]
+SESSION_STATUSES: tuple[str, ...] = get_args(SessionStatus)
+# Terminal statuses are eligible for cleanup-sessions once older than the cutoff.
+TERMINAL_SESSION_STATUSES: frozenset[str] = frozenset(
+    status for status in SESSION_STATUSES if status != "running"
+)
 
 # 401 / auth-death retry policy for the ``claude`` backend foreground path.
 # A transient CC 401 (OAuth blip) is usually self-healing; one retry after a
@@ -43,7 +50,7 @@ class AgentSession:
     agent_type: Literal["general", "explore", "plan", "execute"]
     backend: Literal["gptme", "claude", "codex"]
     started: str
-    status: Literal["running", "completed", "failed", "auth_failed", "killed"]
+    status: SessionStatus
     tmux_session: str | None = None
     output_file: str | None = None
     error: str | None = None
@@ -392,7 +399,7 @@ def spawn_agent(
         if result.returncode != 0 and backend not in ("gptme",):
             if is_auth_death(combined_output):
                 logger.warning(
-                    "spawn_agent: transient 401 detected on first attempt; " "retrying in %ds …",
+                    "spawn_agent: transient 401 detected on first attempt; retrying in %ds …",
                     _AUTH_RETRY_BACKOFF_SECS,
                 )
                 time.sleep(_AUTH_RETRY_BACKOFF_SECS)
@@ -560,7 +567,7 @@ def cleanup_sessions(
 
     # Phase 2: Remove old terminated sessions
     for session in sessions:
-        if session.status in ("completed", "failed", "killed"):
+        if session.status in TERMINAL_SESSION_STATUSES:
             started = datetime.fromisoformat(session.started.replace("Z", "+00:00"))
             if started.timestamp() < cutoff:
                 # Remove session file

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -395,8 +395,10 @@ def spawn_agent(
         # 401 retry — foreground ``claude`` backend only.
         # A transient OAuth blip produces a tiny output with an auth signature.
         # Retry once after a short backoff; only mark failed if retry also fails.
+        # ``codex`` and ``gptme`` are excluded: gptme has its own auth layer,
+        # and Codex 401s are not the CC OAuth-blip this policy exists for.
         retried_401 = False
-        if result.returncode != 0 and backend not in ("gptme",):
+        if result.returncode != 0 and backend == "claude":
             if is_auth_death(combined_output):
                 logger.warning(
                     "spawn_agent: transient 401 detected on first attempt; retrying in %ds …",
@@ -421,11 +423,10 @@ def spawn_agent(
         if result.returncode == 0:
             session.status = "completed"
         else:
-            # For non-gptme backends (which have the retry policy), classify
-            # the failure so callers can distinguish a transient auth blip from
-            # a real task failure.  gptme has its own auth layer — just report
-            # "failed" with the exit code so nothing downstream is surprised.
-            if backend not in ("gptme",) and is_auth_death(combined_output):
+            # Only the claude retry policy classifies as auth_failed. Other
+            # backends report a plain "failed" with the exit code so nothing
+            # downstream is surprised by a status they never opted into.
+            if backend == "claude" and is_auth_death(combined_output):
                 session.status = "auth_failed"
                 retry_note = " (retried once)" if retried_401 else ""
                 session.error = f"auth-death: transient 401{retry_note}"

--- a/packages/gptodo/tests/test_auth.py
+++ b/packages/gptodo/tests/test_auth.py
@@ -18,8 +18,6 @@ from gptodo._auth import DEFAULT_MAX_BYTES, is_auth_death, is_transient_401
         "invalid_api_key",
         "oauth expired",
         "Please run /login",
-        "credit balance is too low",
-        "disabled subscription",
     ],
 )
 def test_is_transient_401_positive(text):
@@ -32,6 +30,10 @@ def test_is_transient_401_positive(text):
         "Completed successfully",
         "Error: 500 server error",
         "timeout after 30s",
+        # Persistent 403 / billing must not be treated as a transient 401.
+        "403 Forbidden",
+        "credit balance is too low",
+        "disabled subscription",
         # Note: "PR #401 merged" DOES match \b401\b — that is by design.
         # is_transient_401 has no size gate. The size gate in is_auth_death is
         # what prevents false positives on large, legitimate outputs.

--- a/packages/gptodo/tests/test_auth.py
+++ b/packages/gptodo/tests/test_auth.py
@@ -1,0 +1,75 @@
+"""Tests for the transient-401 / auth-death classifier."""
+
+import pytest
+
+from gptodo._auth import DEFAULT_MAX_BYTES, is_auth_death, is_transient_401
+
+
+# ── is_transient_401 ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Error: 401 unauthorized",
+        "Invalid bearer token",
+        "authentication_failed",
+        "authentication_error",
+        "invalid_api_key",
+        "oauth expired",
+        "Please run /login",
+        "credit balance is too low",
+        "disabled subscription",
+    ],
+)
+def test_is_transient_401_positive(text):
+    assert is_transient_401(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Completed successfully",
+        "Error: 500 server error",
+        "timeout after 30s",
+        # Note: "PR #401 merged" DOES match \b401\b — that is by design.
+        # is_transient_401 has no size gate. The size gate in is_auth_death is
+        # what prevents false positives on large, legitimate outputs.
+    ],
+)
+def test_is_transient_401_negative(text):
+    assert not is_transient_401(text)
+
+
+def test_is_transient_401_case_insensitive():
+    assert is_transient_401("AUTHENTICATION_FAILED")
+    assert is_transient_401("Unauthorized")
+
+
+# ── is_auth_death ─────────────────────────────────────────────────────────────
+
+
+def test_is_auth_death_tiny_output_with_signature():
+    tiny = "Error: 401 unauthorized"
+    assert is_auth_death(tiny)
+
+
+def test_is_auth_death_large_output_with_signature():
+    """A large output that mentions 401 must NOT be flagged."""
+    large = "PR #401 was merged.\n" + "A" * DEFAULT_MAX_BYTES
+    assert not is_auth_death(large)
+
+
+def test_is_auth_death_tiny_output_no_signature():
+    assert not is_auth_death("Some other error happened")
+
+
+def test_is_auth_death_empty_output():
+    assert not is_auth_death("")
+
+
+def test_is_auth_death_custom_max_bytes():
+    # Just over the default limit but under a custom one
+    text = "401 unauthorized" + " " * (DEFAULT_MAX_BYTES + 1)
+    assert not is_auth_death(text)  # default limit
+    assert is_auth_death(text, max_bytes=DEFAULT_MAX_BYTES + 100)  # custom limit

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -1,5 +1,6 @@
 """Tests for subagent session management."""
 
+import re
 import subprocess
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -472,3 +473,85 @@ def test_sessions_cli_accepts_auth_failed_status():
     result = runner.invoke(cli, ["sessions", "--help"])
     assert result.exit_code == 0
     assert "auth_failed" in result.output
+
+
+def _write_task(tasks_dir, name, **metadata):
+    lines = ["---"]
+    for key, value in metadata.items():
+        lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+@pytest.mark.parametrize("status", ["auth_failed", "failed"])
+def test_execute_task_agent_returns_false_on_terminal_failure(sessions_dir, monkeypatch, status):
+    """_execute_task_agent must return False on failed/auth_failed (not None)."""
+    from gptodo.cli import _execute_task_agent
+
+    tasks_dir = sessions_dir / "tasks"
+    tasks_dir.mkdir()
+    _write_task(tasks_dir, "my-task", state="todo", created="2026-08-30T00:00:00")
+    (sessions_dir / ".git").mkdir()
+    monkeypatch.chdir(sessions_dir)
+
+    fake = _make_session(status=status, error="auth-death: transient 401", backend="claude")
+    monkeypatch.setattr("gptodo.cli.spawn_agent", lambda **kwargs: fake)
+
+    ok = _execute_task_agent(
+        task_id="my-task",
+        prompt=None,
+        agent_type="general",
+        backend="claude",
+        background=False,
+        model=None,
+        timeout=60,
+    )
+    assert ok is False
+
+
+def test_execute_task_agent_returns_true_on_completed(sessions_dir, monkeypatch):
+    from gptodo.cli import _execute_task_agent
+
+    tasks_dir = sessions_dir / "tasks"
+    tasks_dir.mkdir()
+    _write_task(tasks_dir, "my-task", state="todo", created="2026-08-30T00:00:00")
+    (sessions_dir / ".git").mkdir()
+    monkeypatch.chdir(sessions_dir)
+
+    fake = _make_session(status="completed", backend="claude")
+    monkeypatch.setattr("gptodo.cli.spawn_agent", lambda **kwargs: fake)
+
+    ok = _execute_task_agent(
+        task_id="my-task",
+        prompt=None,
+        agent_type="general",
+        backend="claude",
+        background=False,
+        model=None,
+        timeout=60,
+    )
+    assert ok is True
+
+
+def test_loop_counts_auth_failed_as_failure(sessions_dir, monkeypatch):
+    """Sequential gptodo loop must not count an auth_failed spawn as success."""
+    from click.testing import CliRunner
+
+    tasks_dir = sessions_dir / "tasks"
+    tasks_dir.mkdir()
+    _write_task(tasks_dir, "fail-task", state="todo", created="2026-08-30T00:00:00")
+    _write_task(tasks_dir, "ok-task", state="todo", created="2026-08-30T00:01:00")
+    (sessions_dir / ".git").mkdir()
+    monkeypatch.chdir(sessions_dir)
+
+    outcomes = {"fail-task": False, "ok-task": True}
+
+    def fake_execute(task_id, **kwargs):
+        return outcomes[task_id]
+
+    monkeypatch.setattr("gptodo.cli._execute_task_agent", fake_execute)
+
+    result = CliRunner().invoke(cli, ["loop", "-n", "2"])
+    assert result.exit_code == 0, result.output
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "1 succeeded, 1 failed" in plain

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -1,16 +1,19 @@
 """Tests for subagent session management."""
 
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from gptodo._auth import DEFAULT_MAX_BYTES
 from gptodo.subagent import (
     AgentSession,
     _setup_coordination,
+    check_session,
     list_sessions,
     load_session,
     save_session,
+    spawn_agent,
 )
 
 
@@ -138,3 +141,153 @@ def test_setup_coordination_announce_failure(coord_workspace):
     # Should still return valid results despite announce failure
     assert agent_id.startswith("agent_")
     assert db_path.endswith("coord.db")
+
+
+# ── 401 retry tests ───────────────────────────────────────────────────────────
+
+
+def _make_proc(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def test_spawn_agent_401_retries_and_succeeds(sessions_dir):
+    """Tiny 401 output → one retry → succeeds on second attempt."""
+    auth_death = MagicMock(
+        returncode=1,
+        stdout="Error: 401 unauthorized\n",
+        stderr="",
+    )
+    success = MagicMock(returncode=0, stdout="Task complete\n", stderr="")
+
+    with (
+        patch("gptodo.subagent.subprocess.run", side_effect=[auth_death, success]),
+        patch("gptodo.subagent.time.sleep") as mock_sleep,
+    ):
+        session = spawn_agent(
+            task_id="t1",
+            prompt="do something",
+            backend="claude",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert session.status == "completed"
+    assert mock_sleep.called
+    assert mock_sleep.call_args[0][0] >= 1  # backoff > 0s
+
+
+def test_spawn_agent_401_retries_still_fails(sessions_dir):
+    """Two consecutive 401s → one retry → status auth_failed."""
+    auth_death = MagicMock(
+        returncode=1,
+        stdout="authentication_error\n",
+        stderr="",
+    )
+
+    with (
+        patch("gptodo.subagent.subprocess.run", side_effect=[auth_death, auth_death]),
+        patch("gptodo.subagent.time.sleep"),
+    ):
+        session = spawn_agent(
+            task_id="t2",
+            prompt="do something",
+            backend="claude",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert session.status == "auth_failed"
+    assert "retried" in (session.error or "")
+
+
+def test_spawn_agent_large_401_prose_no_retry(sessions_dir):
+    """Large output with '401' in prose must NOT trigger a retry."""
+    large_output = "I handled the 401 case in PR #401.\n" + "x" * DEFAULT_MAX_BYTES
+    big_fail = MagicMock(returncode=1, stdout=large_output, stderr="")
+
+    with (
+        patch("gptodo.subagent.subprocess.run", return_value=big_fail) as mock_run,
+        patch("gptodo.subagent.time.sleep") as mock_sleep,
+    ):
+        session = spawn_agent(
+            task_id="t3",
+            prompt="do something",
+            backend="claude",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    # Only one subprocess call (no retry)
+    assert mock_run.call_count == 1
+    assert not mock_sleep.called
+    assert session.status == "failed"
+
+
+def test_spawn_agent_gptme_backend_no_401_retry(sessions_dir):
+    """gptme backend does NOT get the 401 retry (it has its own auth layer)."""
+    auth_death = MagicMock(returncode=1, stdout="401 unauthorized\n", stderr="")
+
+    with (
+        patch("gptodo.subagent.subprocess.run", return_value=auth_death) as mock_run,
+        patch("gptodo.subagent.time.sleep") as mock_sleep,
+    ):
+        session = spawn_agent(
+            task_id="t4",
+            prompt="do something",
+            backend="gptme",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert mock_run.call_count == 1
+    assert not mock_sleep.called
+    assert session.status == "failed"
+
+
+def test_check_session_background_auth_death_classified(sessions_dir):
+    """Background session: EXIT_CODE non-zero + tiny auth output → auth_failed, not failed."""
+    output_file = sessions_dir / "state" / "sessions" / "agent_authtest.output"
+    output_file.write_text("authentication_error: 401 unauthorized\nEXIT_CODE=1\n")
+
+    session = _make_session(
+        session_id="agent_authtest",
+        status="running",
+        tmux_session="gptodo_agent_authtest",
+        output_file=str(output_file),
+    )
+    save_session(session, sessions_dir)
+
+    # tmux has-session returns 1 → session ended
+    with patch("gptodo.subagent.subprocess.run", return_value=MagicMock(returncode=1)):
+        updated = check_session("agent_authtest", sessions_dir)
+
+    assert updated is not None
+    assert updated.status == "auth_failed", f"expected auth_failed, got {updated.status!r}"
+    assert "auth-death" in (updated.error or "")
+
+
+def test_check_session_background_normal_failure_not_auth(sessions_dir):
+    """Background session: EXIT_CODE non-zero, large output → status failed (not auth_failed)."""
+    big_output = (
+        "Task ran, hit some issue. Exiting.\n" + "x" * DEFAULT_MAX_BYTES + "\nEXIT_CODE=1\n"
+    )
+    output_file = sessions_dir / "state" / "sessions" / "agent_bigfail.output"
+    output_file.write_text(big_output)
+
+    session = _make_session(
+        session_id="agent_bigfail",
+        status="running",
+        tmux_session="gptodo_agent_bigfail",
+        output_file=str(output_file),
+    )
+    save_session(session, sessions_dir)
+
+    with patch("gptodo.subagent.subprocess.run", return_value=MagicMock(returncode=1)):
+        updated = check_session("agent_bigfail", sessions_dir)
+
+    assert updated is not None
+    assert updated.status == "failed"

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -6,10 +6,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gptodo._auth import DEFAULT_MAX_BYTES
+from gptodo.cli import cli
 from gptodo.subagent import (
+    TERMINAL_SESSION_STATUSES,
     AgentSession,
     _setup_coordination,
     check_session,
+    cleanup_sessions,
     list_sessions,
     load_session,
     save_session,
@@ -66,12 +69,17 @@ def test_list_sessions_by_status(sessions_dir):
     save_session(_make_session("s1", status="running"), sessions_dir)
     save_session(_make_session("s2", status="completed"), sessions_dir)
     save_session(_make_session("s3", status="running"), sessions_dir)
+    save_session(_make_session("s4", status="auth_failed"), sessions_dir)
 
     running = list_sessions(sessions_dir, status="running")
     assert len(running) == 2
 
     completed = list_sessions(sessions_dir, status="completed")
     assert len(completed) == 1
+
+    auth_failed = list_sessions(sessions_dir, status="auth_failed")
+    assert len(auth_failed) == 1
+    assert auth_failed[0].session_id == "s4"
 
 
 def test_load_nonexistent_session(sessions_dir):
@@ -291,3 +299,73 @@ def test_check_session_background_normal_failure_not_auth(sessions_dir):
 
     assert updated is not None
     assert updated.status == "failed"
+
+
+def test_cleanup_sessions_removes_old_auth_failed(sessions_dir):
+    """auth_failed is terminal: expired session JSON/output/prompt are removed."""
+    old_started = "2020-01-01T00:00:00+00:00"
+    sessions = sessions_dir / "state" / "sessions"
+    output_file = sessions / "oldauth.output"
+    prompt_file = sessions / "oldauth.prompt"
+    output_file.write_text("authentication_error: 401 unauthorized\n")
+    prompt_file.write_text("do the thing\n")
+
+    save_session(
+        _make_session(
+            "oldauth",
+            status="auth_failed",
+            started=old_started,
+            output_file=str(output_file),
+        ),
+        sessions_dir,
+    )
+    save_session(
+        _make_session("stillrunning", status="running", started=old_started),
+        sessions_dir,
+    )
+
+    with (
+        patch("gptodo.subagent.check_session"),
+        patch("gptodo.subagent.subprocess.run", side_effect=FileNotFoundError),
+    ):
+        count = cleanup_sessions(sessions_dir, older_than_hours=24)
+
+    assert count == 1
+    assert not (sessions / "oldauth.json").exists()
+    assert not output_file.exists()
+    assert not prompt_file.exists()
+    assert (sessions / "stillrunning.json").exists()
+
+
+def test_cleanup_sessions_keeps_recent_auth_failed(sessions_dir):
+    """auth_failed sessions younger than the cutoff stay on disk."""
+    save_session(_make_session("freshauth", status="auth_failed"), sessions_dir)
+
+    with (
+        patch("gptodo.subagent.check_session"),
+        patch("gptodo.subagent.subprocess.run", side_effect=FileNotFoundError),
+    ):
+        count = cleanup_sessions(sessions_dir, older_than_hours=24)
+
+    assert count == 0
+    loaded = load_session("freshauth", sessions_dir)
+    assert loaded is not None
+    assert loaded.status == "auth_failed"
+
+
+def test_terminal_statuses_include_auth_failed():
+    assert "auth_failed" in TERMINAL_SESSION_STATUSES
+    assert "running" not in TERMINAL_SESSION_STATUSES
+
+
+def test_sessions_cli_accepts_auth_failed_status():
+    """gptodo sessions --status auth_failed is a valid Choice, not rejected."""
+    from click.testing import CliRunner
+
+    status_opt = next(p for p in cli.commands["sessions"].params if p.name == "status")
+    assert "auth_failed" in status_opt.type.choices
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["sessions", "--help"])
+    assert result.exit_code == 0
+    assert "auth_failed" in result.output

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -256,6 +256,27 @@ def test_spawn_agent_gptme_backend_no_401_retry(sessions_dir):
     assert session.status == "failed"
 
 
+def test_spawn_agent_codex_backend_no_401_retry(sessions_dir):
+    """codex backend does NOT get the 401 retry (claude-only policy)."""
+    auth_death = MagicMock(returncode=1, stdout="401 unauthorized\n", stderr="")
+
+    with (
+        patch("gptodo.subagent.subprocess.run", return_value=auth_death) as mock_run,
+        patch("gptodo.subagent.time.sleep") as mock_sleep,
+    ):
+        session = spawn_agent(
+            task_id="t4c",
+            prompt="do something",
+            backend="codex",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert mock_run.call_count == 1
+    assert not mock_sleep.called
+    assert session.status == "failed"
+
+
 def test_check_session_background_auth_death_classified(sessions_dir):
     """Background session: EXIT_CODE non-zero + tiny auth output → auth_failed, not failed."""
     output_file = sessions_dir / "state" / "sessions" / "agent_authtest.output"

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -1,5 +1,6 @@
 """Tests for subagent session management."""
 
+import subprocess
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -277,14 +278,73 @@ def test_spawn_agent_codex_backend_no_401_retry(sessions_dir):
     assert session.status == "failed"
 
 
+@pytest.mark.parametrize(
+    "stderr",
+    ["403 Forbidden\n", "credit balance is too low\n", "disabled subscription\n"],
+)
+def test_spawn_agent_persistent_403_billing_no_retry(sessions_dir, stderr):
+    """Persistent 403 / billing failures must not retry or stamp auth_failed."""
+    persistent = MagicMock(returncode=1, stdout="", stderr=stderr)
+
+    with (
+        patch("gptodo.subagent.subprocess.run", return_value=persistent) as mock_run,
+        patch("gptodo.subagent.time.sleep") as mock_sleep,
+    ):
+        session = spawn_agent(
+            task_id="t4p",
+            prompt="do something",
+            backend="claude",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert mock_run.call_count == 1
+    assert not mock_sleep.called
+    assert session.status == "failed"
+
+
+def test_spawn_agent_401_retry_timeout_persists_first_output(sessions_dir):
+    """First-attempt output is persisted even if the retry times out."""
+    auth_death = MagicMock(
+        returncode=1,
+        stdout="Error: 401 unauthorized\n",
+        stderr="",
+    )
+
+    with (
+        patch(
+            "gptodo.subagent.subprocess.run",
+            side_effect=[
+                auth_death,
+                subprocess.TimeoutExpired(cmd="claude", timeout=1),
+            ],
+        ),
+        patch("gptodo.subagent.time.sleep"),
+    ):
+        session = spawn_agent(
+            task_id="t4t",
+            prompt="do something",
+            backend="claude",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert session.status == "failed"
+    assert "Timeout" in (session.error or "")
+    output_path = sessions_dir / "state" / "sessions" / f"{session.session_id}.output"
+    assert output_path.exists()
+    assert "401 unauthorized" in output_path.read_text()
+
+
 def test_check_session_background_auth_death_classified(sessions_dir):
-    """Background session: EXIT_CODE non-zero + tiny auth output → auth_failed, not failed."""
+    """Background claude session: EXIT_CODE non-zero + tiny auth output → auth_failed."""
     output_file = sessions_dir / "state" / "sessions" / "agent_authtest.output"
     output_file.write_text("authentication_error: 401 unauthorized\nEXIT_CODE=1\n")
 
     session = _make_session(
         session_id="agent_authtest",
         status="running",
+        backend="claude",
         tmux_session="gptodo_agent_authtest",
         output_file=str(output_file),
     )
@@ -317,6 +377,28 @@ def test_check_session_background_normal_failure_not_auth(sessions_dir):
 
     with patch("gptodo.subagent.subprocess.run", return_value=MagicMock(returncode=1)):
         updated = check_session("agent_bigfail", sessions_dir)
+
+    assert updated is not None
+    assert updated.status == "failed"
+
+
+@pytest.mark.parametrize("backend", ["gptme", "codex"])
+def test_check_session_non_claude_backend_not_auth_failed(sessions_dir, backend):
+    """Background gptme/codex sessions stay failed even on tiny 401 output."""
+    output_file = sessions_dir / "state" / "sessions" / f"agent_{backend}.output"
+    output_file.write_text("authentication_error: 401 unauthorized\nEXIT_CODE=1\n")
+
+    session = _make_session(
+        session_id=f"agent_{backend}",
+        status="running",
+        backend=backend,
+        tmux_session=f"gptodo_agent_{backend}",
+        output_file=str(output_file),
+    )
+    save_session(session, sessions_dir)
+
+    with patch("gptodo.subagent.subprocess.run", return_value=MagicMock(returncode=1)):
+        updated = check_session(f"agent_{backend}", sessions_dir)
 
     assert updated is not None
     assert updated.status == "failed"


### PR DESCRIPTION
## Problem

`gptodo spawn --backend claude` treats any non-zero `claude -p` exit as a hard `failed` session. A **transient CC 401** (OAuth blip) is self-healing, but today it:
1. Marks the spawned agent `failed`
2. Burns the attempt with no retry
3. Logs a generic "Non-zero exit code" with no auth context

See #1536 for full background.

## Solution

**New module `gptodo/_auth.py`** — a small, self-contained copy of Bob's canonical 401 classifier (`scripts/lib/auth_401.py`), no external deps:
- `is_transient_401(text)` — matches 401/auth-failure signatures (no size gate)
- `is_auth_death(output, max_bytes=2000)` — size-gated: tiny output AND an auth signature (prevents large outputs that mention "401" in prose from being misclassified)

**Changes to `spawn_agent` (foreground path):**
- After non-zero exit on the `claude` backend: classify with `is_auth_death`
- If auth-death: sleep 5s, retry once
- Only marks `auth_failed` if the retry also fails (with "retried once" note)
- Large outputs with "401" in prose: no retry, plain `failed`
- `gptme` backend: unaffected (has its own auth layer)

**Changes to `check_session` (background path):**
- On EXIT_CODE non-zero: classify the output file
- Auth-death output → `auth_failed` status with a clear error message
- Large output / no auth signature → `failed` as before

## Tests

33 passing (14 new):
- 9 classifier tests in `test_auth.py`
- 4 spawn-retry tests (success on retry, double-401, large-prose no-retry, gptme no-retry)
- 2 background path tests (auth-death classified, large output not classified)

Closes #1536