### PR TITLE
fix(gptme-voice): preserve remote-party identity with open/closed call groups

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/call.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/call.py
@@ -8,6 +8,7 @@ from .twilio_integration import (
     ConfigurationError,
     build_connect_stream_twiml,
     create_outbound_call,
+    outbound_identity_params,
     resolve_outbound_call_settings,
 )
 
@@ -47,7 +48,10 @@ def main(
     except ConfigurationError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    twiml = build_connect_stream_twiml(settings.stream_url)
+    twiml = build_connect_stream_twiml(
+        settings.stream_url,
+        outbound_identity_params(to_number, settings.custom_params),
+    )
     if dry_run:
         click.echo(twiml)
         return

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -198,6 +198,7 @@ class RecentCallRecord:
     subagent_timings: list[dict[str, object]] = field(default_factory=list)
     archive_record_paths: list[str] = field(default_factory=list)
     pending_post_call_unit: str | None = None
+    call_group_id: str | None = None
 
 
 @dataclass
@@ -849,6 +850,7 @@ class VoiceServer:
         self._connections: dict[str, tuple] = {}
         self._pending_post_calls: dict[str, str] = {}
         self._pending_archive_records: dict[str, list[Path]] = {}
+        self._pending_call_groups: dict[str, str] = {}
         # Pre-warmed realtime connections: from_number -> (client, created_at)
         # Keyed by from_number, claimed and discarded when the Twilio stream starts.
         self._prewarm_sessions: dict[str, tuple[OpenAIRealtimeClient, float]] = {}
@@ -1093,6 +1095,9 @@ class VoiceServer:
     def _call_archive_dir(self) -> Path:
         return self.state_dir / "archive"
 
+    def _call_group_manifest_dir(self) -> Path:
+        return self.state_dir / "call-groups"
+
     def _handoff_bootstrap_path(self, handoff_id: str) -> Path:
         safe_handoff_id = "".join(
             ch for ch in handoff_id if ch.isalnum() or ch in {"-", "_"}
@@ -1135,6 +1140,8 @@ class VoiceServer:
             payload["subagent_timings"] = record.subagent_timings
         if include_pending_state and record.archive_record_paths:
             payload["archive_record_paths"] = record.archive_record_paths
+        if record.call_group_id:
+            payload["call_group_id"] = record.call_group_id
         if include_pending_state and record.pending_post_call_unit:
             payload["pending_post_call_unit"] = record.pending_post_call_unit
         return payload
@@ -1214,6 +1221,12 @@ class VoiceServer:
                         and payload.get("pending_post_call_unit")
                         else None
                     ),
+                    call_group_id=(
+                        payload.get("call_group_id")
+                        if isinstance(payload.get("call_group_id"), str)
+                        and payload.get("call_group_id")
+                        else None
+                    ),
                 )
             except Exception as exc:
                 logger.warning(
@@ -1232,6 +1245,155 @@ class VoiceServer:
             if path.exists():
                 restored_paths.append(path)
         return self._dedupe_record_paths(restored_paths)
+
+    def _call_group_hold_seconds(self) -> int:
+        """Seconds a logical call stays open for resume before PM may consume it.
+
+        A first leg must not close while a reconnect is still in the resume
+        window, even if GPTME_VOICE_POST_CALL_DELAY_SECONDS is shorter.
+        """
+        return max(
+            int(self.post_call_delay_seconds), int(self.resume_window_seconds), 0
+        )
+
+    def _call_group_manifest_path(self, call_group_id: str) -> Path:
+        safe_id = "".join(
+            ch for ch in call_group_id if ch.isalnum() or ch in {"-", "_"}
+        )
+        if not safe_id:
+            safe_id = "call-group"
+        return self._call_group_manifest_dir() / f"{safe_id}.json"
+
+    def _build_call_group_id(self, caller_id: str, first_record_path: Path) -> str:
+        digest = hashlib.sha256()
+        digest.update(caller_id.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(first_record_path).encode("utf-8"))
+        return digest.hexdigest()[:16]
+
+    def _read_call_group_manifest(self, call_group_id: str) -> dict[str, object] | None:
+        path = self._call_group_manifest_path(call_group_id)
+        if not path.exists():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _call_group_is_closed(
+        manifest: dict[str, object], *, now: float | None = None
+    ) -> bool:
+        if manifest.get("status") == "closed":
+            return True
+        closes_at = manifest.get("closes_at")
+        if isinstance(closes_at, int | float):
+            return (time.time() if now is None else now) >= float(closes_at)
+        return False
+
+    def _write_call_group_manifest(
+        self,
+        *,
+        caller_id: str,
+        call_group_id: str,
+        record_paths: list[Path],
+        status: str = "open",
+        remote_party: str | None = None,
+        closes_at: float | None = None,
+    ) -> Path:
+        existing = self._read_call_group_manifest(call_group_id) or {}
+        now = time.time()
+        if closes_at is None:
+            if status == "open":
+                closes_at = now + self._call_group_hold_seconds()
+            else:
+                raw_closes_at = existing.get("closes_at")
+                closes_at = (
+                    float(raw_closes_at)
+                    if isinstance(raw_closes_at, int | float)
+                    else now
+                )
+        existing_remote = existing.get("remote_party")
+        payload: dict[str, object] = {
+            "schema_version": 1,
+            "call_group_id": call_group_id,
+            "status": status,
+            "caller_id": caller_id,
+            "remote_party": remote_party
+            or (
+                existing_remote
+                if isinstance(existing_remote, str) and existing_remote
+                else caller_id
+            ),
+            "archive_record_paths": [str(path) for path in record_paths],
+            "closes_at": closes_at,
+            "updated_at": now,
+        }
+        if status == "closed":
+            payload["closed_at"] = now
+        manifest_path = self._call_group_manifest_path(call_group_id)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return manifest_path
+
+    def _open_call_group(
+        self,
+        caller_id: str,
+        record_paths: list[Path],
+        *,
+        remote_party: str | None = None,
+    ) -> str | None:
+        deduped = self._dedupe_record_paths(record_paths)
+        if not deduped:
+            return None
+        call_group_id = self._pending_call_groups.get(caller_id)
+        existing_closed = False
+        if call_group_id:
+            existing = self._read_call_group_manifest(call_group_id)
+            if existing and self._call_group_is_closed(existing):
+                existing_closed = True
+                call_group_id = None
+        if not call_group_id:
+            seed = deduped[-1] if existing_closed else deduped[0]
+            call_group_id = self._build_call_group_id(caller_id, seed)
+        self._pending_call_groups[caller_id] = call_group_id
+        self._write_call_group_manifest(
+            caller_id=caller_id,
+            call_group_id=call_group_id,
+            record_paths=deduped,
+            status="open",
+            remote_party=remote_party or caller_id,
+        )
+        return call_group_id
+
+    def _close_call_group(
+        self,
+        caller_id: str,
+        record_paths: list[Path] | None = None,
+    ) -> str | None:
+        call_group_id = self._pending_call_groups.get(caller_id)
+        if not call_group_id:
+            return None
+        paths = list(record_paths or self._pending_archive_records.get(caller_id, []))
+        if not paths:
+            existing = self._read_call_group_manifest(call_group_id) or {}
+            raw_paths = existing.get("archive_record_paths") or []
+            if isinstance(raw_paths, list):
+                paths = [Path(str(item)) for item in raw_paths]
+        self._write_call_group_manifest(
+            caller_id=caller_id,
+            call_group_id=call_group_id,
+            record_paths=paths,
+            status="closed",
+            remote_party=caller_id,
+        )
+        self._pending_call_groups.pop(caller_id, None)
+        self._pending_archive_records.pop(caller_id, None)
+        return call_group_id
 
     def _build_post_call_unit_name(
         self, caller_id: str, record_paths: list[Path]
@@ -1680,8 +1842,15 @@ class VoiceServer:
         )
         if restored_archive_paths:
             self._pending_archive_records[caller_id] = restored_archive_paths
+            restored_group = recent_call.call_group_id
+            if not restored_group:
+                restored_group = self._build_call_group_id(
+                    caller_id, restored_archive_paths[0]
+                )
+            self._pending_call_groups[caller_id] = restored_group
         else:
             self._pending_archive_records.pop(caller_id, None)
+            self._pending_call_groups.pop(caller_id, None)
 
         # Delete the resume-state file(s) so a crash-resume can't re-inject the old
         # transcript, but keep archived per-call records for post-call analysis.
@@ -1783,12 +1952,16 @@ class VoiceServer:
         deduped_record_paths = self._dedupe_record_paths(record_paths)
         if not deduped_record_paths:
             self._pending_archive_records.pop(caller_id, None)
+            self._pending_call_groups.pop(caller_id, None)
             logger.warning(
                 "Ignoring post-call schedule for %s with no records", caller_id
             )
             return
 
         self._pending_archive_records[caller_id] = deduped_record_paths
+        call_group_id = self._open_call_group(caller_id, deduped_record_paths)
+        if self._call_group_hold_seconds() == 0 and call_group_id:
+            self._close_call_group(caller_id, deduped_record_paths)
 
         if not self.post_call_command:
             self._pending_post_calls.pop(caller_id, None)
@@ -1969,16 +2142,37 @@ class VoiceServer:
             except Exception as exc:  # defensive: never block archival on telemetry
                 logger.warning("Failed to collect subagent timings: %s", exc)
 
+        cleaned_metadata = {k: v for k, v in metadata.items() if v}
+        if caller_id:
+            cleaned_metadata.setdefault("remote_party", caller_id)
+
+        pending_record_paths = list(self._pending_archive_records.get(caller_id, []))
         record = RecentCallRecord(
             caller_id=caller_id,
             source=source,
             ended_at=time.time(),
             transcript=transcript,
-            metadata={k: v for k, v in metadata.items() if v},
+            metadata=cleaned_metadata,
             subagent_timings=subagent_timings,
         )
+        call_group_id = self._pending_call_groups.get(caller_id)
+        if call_group_id:
+            existing = self._read_call_group_manifest(call_group_id)
+            if existing and self._call_group_is_closed(existing):
+                call_group_id = None
+                pending_record_paths = []
+                self._pending_call_groups.pop(caller_id, None)
+                self._pending_archive_records.pop(caller_id, None)
+        if call_group_id is None:
+            seed = (
+                pending_record_paths[0]
+                if pending_record_paths
+                else self._call_record_path(record)
+            )
+            call_group_id = self._build_call_group_id(caller_id, seed)
+            self._pending_call_groups[caller_id] = call_group_id
+        record.call_group_id = call_group_id
         record_path = self._save_call_record(record)
-        pending_record_paths = list(self._pending_archive_records.get(caller_id, []))
         pending_record_paths.append(record_path)
         deduped_record_paths = self._dedupe_record_paths(pending_record_paths)
         record.archive_record_paths = [str(path) for path in deduped_record_paths]
@@ -2085,6 +2279,7 @@ class VoiceServer:
         custom_params: dict[str, str] = {}
         if from_number:
             custom_params["from_number"] = from_number
+            custom_params["remote_party"] = from_number
             # Body tools on /twilio must not trust client-supplied from_number.
             # Mint a call-scoped grant here only after signature validation, and
             # bind it to CallSid (kept off TwiML so a stolen grant cannot be
@@ -2148,11 +2343,13 @@ class VoiceServer:
                     # Inject caller context into instructions (phone + name lookup)
                     custom_params = start.get("customParameters", {})
                     from_number = custom_params.get("from_number", "")
+                    remote_party = custom_params.get("remote_party") or from_number
                     handoff_id = custom_params.get("handoff_id") or None
                     standup_brief = custom_params.get("standup_brief") or None
-                    caller_id = from_number or call_sid or stream_sid
+                    caller_id = remote_party or call_sid or stream_sid
                     metadata = {
                         "from_number": from_number,
+                        "remote_party": remote_party,
                         "call_sid": call_sid,
                         "stream_sid": stream_sid,
                         "provider": self.provider,

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -850,7 +850,12 @@ class VoiceServer:
         self._connections: dict[str, tuple] = {}
         self._pending_post_calls: dict[str, str] = {}
         self._pending_archive_records: dict[str, list[Path]] = {}
+        # One open group per remote party. Resume/redial inside the hold window
+        # reuses that group even when CallSids differ. Overlapping teardowns
+        # from the same number are serialized via `_call_end_locks` so a
+        # last-writer cannot drop a sibling archive path.
         self._pending_call_groups: dict[str, str] = {}
+        self._call_end_locks: dict[str, asyncio.Lock] = {}
         # Pre-warmed realtime connections: from_number -> (client, created_at)
         # Keyed by from_number, claimed and discarded when the Twilio stream starts.
         self._prewarm_sessions: dict[str, tuple[OpenAIRealtimeClient, float]] = {}
@@ -1238,6 +1243,9 @@ class VoiceServer:
     def _dedupe_record_paths(self, record_paths: list[Path]) -> list[Path]:
         return list(dict.fromkeys(record_paths))
 
+    def _call_end_lock_for(self, caller_id: str) -> asyncio.Lock:
+        return self._call_end_locks.setdefault(caller_id, asyncio.Lock())
+
     def _restore_archive_record_paths(self, raw_paths: list[str]) -> list[Path]:
         restored_paths: list[Path] = []
         for raw_path in raw_paths:
@@ -1315,6 +1323,15 @@ class VoiceServer:
                     else now
                 )
         existing_remote = existing.get("remote_party")
+        existing_paths = existing.get("archive_record_paths") or []
+        merged_paths = self._dedupe_record_paths(
+            [
+                Path(str(item))
+                for item in existing_paths
+                if isinstance(item, str) and item.strip()
+            ]
+            + list(record_paths)
+        )
         payload: dict[str, object] = {
             "schema_version": 1,
             "call_group_id": call_group_id,
@@ -1326,7 +1343,7 @@ class VoiceServer:
                 if isinstance(existing_remote, str) and existing_remote
                 else caller_id
             ),
-            "archive_record_paths": [str(path) for path in record_paths],
+            "archive_record_paths": [str(path) for path in merged_paths],
             "closes_at": closes_at,
             "updated_at": now,
         }
@@ -1949,7 +1966,9 @@ class VoiceServer:
                 None, self._cancel_post_call_schedule, existing_unit
             )
 
-        deduped_record_paths = self._dedupe_record_paths(record_paths)
+        deduped_record_paths = self._dedupe_record_paths(
+            list(self._pending_archive_records.get(caller_id, [])) + list(record_paths)
+        )
         if not deduped_record_paths:
             self._pending_archive_records.pop(caller_id, None)
             self._pending_call_groups.pop(caller_id, None)
@@ -2135,6 +2154,23 @@ class VoiceServer:
         if not caller_id:
             return
 
+        async with self._call_end_lock_for(caller_id):
+            await self._on_call_end_locked(
+                caller_id,
+                source,
+                transcript,
+                metadata,
+                tool_bridge=tool_bridge,
+            )
+
+    async def _on_call_end_locked(
+        self,
+        caller_id: str,
+        source: str,
+        transcript: list[TranscriptTurn],
+        metadata: dict[str, str],
+        tool_bridge: GptmeToolBridge | None = None,
+    ) -> None:
         subagent_timings: list[dict[str, object]] = []
         if tool_bridge is not None:
             try:
@@ -2143,8 +2179,7 @@ class VoiceServer:
                 logger.warning("Failed to collect subagent timings: %s", exc)
 
         cleaned_metadata = {k: v for k, v in metadata.items() if v}
-        if caller_id:
-            cleaned_metadata.setdefault("remote_party", caller_id)
+        cleaned_metadata.setdefault("remote_party", caller_id)
 
         pending_record_paths = list(self._pending_archive_records.get(caller_id, []))
         record = RecentCallRecord(

--- a/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
@@ -88,6 +88,22 @@ def build_stream_url(
     return urlunsplit((scheme, parsed.netloc, path, "", ""))
 
 
+def outbound_identity_params(
+    to_number: str, extra: dict[str, str] | None = None
+) -> dict[str, str]:
+    """TwiML params that preserve the remote party on outbound Twilio legs.
+
+    Outbound Media Streams otherwise arrive with no From number, so the server
+    would archive the Call SID as ``caller_id`` and lose the dialed party.
+    ``from_number`` stays the key the WebSocket handler already uses for resume
+    and identity lookup; ``remote_party`` is the explicit durable identity.
+    """
+    params = dict(extra or {})
+    params["from_number"] = to_number
+    params["remote_party"] = to_number
+    return params
+
+
 def build_connect_stream_twiml(
     stream_url: str, custom_params: dict[str, str] | None = None
 ) -> str:
@@ -149,9 +165,10 @@ def create_outbound_call(
             ) from exc
 
     client = client_cls(settings.account_sid, settings.auth_token)
+    custom_params = outbound_identity_params(to_number, settings.custom_params)
     call = client.calls.create(
         to=to_number,
         from_=settings.from_number,
-        twiml=build_connect_stream_twiml(settings.stream_url, settings.custom_params),
+        twiml=build_connect_stream_twiml(settings.stream_url, custom_params),
     )
     return call.sid

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1826,9 +1826,11 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
             )
             first_path = server._save_call_record(first)
             await server._schedule_post_call(first.caller_id, [first_path])
+            first_group_id = server._pending_call_groups[first.caller_id]
             first_unit = server._pending_post_calls[first.caller_id]
             first.archive_record_paths = [str(first_path)]
             first.pending_post_call_unit = first_unit
+            first.call_group_id = first_group_id
             server._save_recent_call(first)
 
             with pytest.MonkeyPatch.context() as mp:
@@ -1838,6 +1840,7 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
             assert resumed is not None
             assert cancelled_units == [first_unit]
             assert server._pending_archive_records[first.caller_id] == [first_path]
+            assert server._pending_call_groups[first.caller_id] == first_group_id
 
             second = RecentCallRecord(
                 caller_id=first.caller_id,
@@ -1853,6 +1856,21 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
                 first_path,
                 second_path,
             ]
+            assert server._pending_call_groups[first.caller_id] == first_group_id
+            manifest = json.loads(
+                server._call_group_manifest_path(first_group_id).read_text()
+            )
+            assert manifest["status"] == "open"
+            assert manifest["schema_version"] == 1
+            assert manifest["remote_party"] == first.caller_id
+            assert manifest["archive_record_paths"] == [
+                str(first_path),
+                str(second_path),
+            ]
+            assert server._call_group_is_closed(manifest, now=1_100.0) is False
+            assert server._call_group_is_closed(
+                manifest, now=float(manifest["closes_at"])
+            )
             assert server._pending_post_calls[first.caller_id] != first_unit
 
     asyncio.run(_exercise())
@@ -1891,6 +1909,32 @@ def test_save_call_record_uses_unique_archive_path_per_call() -> None:
             json.loads(second_path.read_text())["transcript"][0]["text"]
             == "Second call"
         )
+
+
+def test_call_record_payload_preserves_remote_party_identity() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        server = VoiceServer()
+        server.state_dir = Path(tmpdir)
+        record = RecentCallRecord(
+            caller_id="+46700000001",
+            source="twilio",
+            ended_at=1_000.0,
+            transcript=[TranscriptTurn(role="user", text="hello")],
+            metadata={
+                "call_sid": "CAoutbound",
+                "from_number": "+15551234567",
+                "remote_party": "+46700000001",
+            },
+            call_group_id="group-outbound-1",
+        )
+
+        path = server._save_call_record(record)
+        payload = json.loads(path.read_text())
+
+        assert payload["caller_id"] == "+46700000001"
+        assert payload["call_group_id"] == "group-outbound-1"
+        assert payload["metadata"]["remote_party"] == "+46700000001"
+        assert payload["metadata"]["from_number"] == "+15551234567"
 
 
 def test_schedule_post_call_replaces_existing_timer_unit() -> None:
@@ -1966,6 +2010,9 @@ def test_consume_recent_call_restores_pending_schedule_after_restart() -> None:
         record_path = first_server._save_call_record(record)
         record.archive_record_paths = [str(record_path)]
         record.pending_post_call_unit = "gptme-voice-post-call-restart"
+        record.call_group_id = first_server._build_call_group_id(
+            record.caller_id, record_path
+        )
         first_server._save_recent_call(record)
 
         second_server = VoiceServer()
@@ -1980,6 +2027,9 @@ def test_consume_recent_call_restores_pending_schedule_after_restart() -> None:
         assert resumed is not None
         assert cancelled_units == ["gptme-voice-post-call-restart"]
         assert second_server._pending_archive_records[record.caller_id] == [record_path]
+        assert (
+            second_server._pending_call_groups[record.caller_id] == record.call_group_id
+        )
 
 
 def test_on_call_end_persists_pending_post_call_state() -> None:
@@ -2010,12 +2060,164 @@ def test_on_call_end_persists_pending_post_call_state() -> None:
 
             recent = server._load_recent_call("+46700000013")
             assert recent is not None
+            assert recent.call_group_id == server._pending_call_groups["+46700000013"]
             assert len(recent.archive_record_paths) == 1
             assert (
                 recent.pending_post_call_unit
                 == server._pending_post_calls["+46700000013"]
             )
             assert Path(recent.archive_record_paths[0]).exists()
+            archive = json.loads(Path(recent.archive_record_paths[0]).read_text())
+            assert recent.call_group_id is not None
+            assert archive["call_group_id"] == recent.call_group_id
+            assert archive["metadata"]["remote_party"] == "+46700000013"
+            manifest = json.loads(
+                server._call_group_manifest_path(recent.call_group_id).read_text()
+            )
+            assert manifest["status"] == "open"
+            assert manifest["remote_party"] == "+46700000013"
+            assert manifest["archive_record_paths"] == recent.archive_record_paths
+
+    asyncio.run(_exercise())
+
+
+def test_call_group_hold_covers_resume_window() -> None:
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            server.resume_window_seconds = 300
+            server.post_call_delay_seconds = 60
+            server.post_call_command = "run-post-call"
+            seen_delays: list[int] = []
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                seen_delays.append(delay_seconds)
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+
+            record = RecentCallRecord(
+                caller_id="+46700000020",
+                source="twilio",
+                ended_at=1_000.0,
+                transcript=[],
+                metadata={"call_sid": "CAhold"},
+            )
+            path = server._save_call_record(record)
+            await server._schedule_post_call(record.caller_id, [path])
+
+            assert seen_delays == [60]
+            group_id = server._pending_call_groups[record.caller_id]
+            manifest = json.loads(
+                server._call_group_manifest_path(group_id).read_text()
+            )
+            assert manifest["status"] == "open"
+            assert float(manifest["closes_at"]) >= time.time() + 299
+            assert server._call_group_is_closed(manifest, now=time.time() + 60) is False
+            assert server._call_group_is_closed(manifest, now=time.time() + 300)
+
+    asyncio.run(_exercise())
+
+
+def test_zero_hold_closes_call_group_immediately() -> None:
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            server.resume_window_seconds = 0
+            server.post_call_delay_seconds = 0
+            server.post_call_command = "run-post-call"
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                return None
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+
+            await server._on_call_end(
+                caller_id="+46700000021",
+                source="twilio",
+                transcript=[TranscriptTurn(role="user", text="no hold")],
+                metadata={"call_sid": "CAzero", "remote_party": "+46700000021"},
+            )
+
+            archive_paths = list((Path(tmpdir) / "archive").glob("*.json"))
+            assert len(archive_paths) == 1
+            archive = json.loads(archive_paths[0].read_text())
+            group_id = archive["call_group_id"]
+            manifest = json.loads(
+                server._call_group_manifest_path(group_id).read_text()
+            )
+            assert manifest["status"] == "closed"
+            assert "closed_at" in manifest
+            assert server._call_group_is_closed(manifest)
+            assert "+46700000021" not in server._pending_call_groups
+
+    asyncio.run(_exercise())
+
+
+def test_closed_call_group_does_not_reuse_id_for_next_call() -> None:
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            server.resume_window_seconds = 300
+            server.post_call_delay_seconds = 300
+            server.post_call_command = "run-post-call"
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                return None
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+
+            await server._on_call_end(
+                caller_id="+46700000022",
+                source="twilio",
+                transcript=[TranscriptTurn(role="user", text="first call")],
+                metadata={"call_sid": "CAone"},
+            )
+            first_group = server._pending_call_groups["+46700000022"]
+            closed = server._close_call_group("+46700000022")
+            assert closed == first_group
+            assert "+46700000022" not in server._pending_call_groups
+
+            await server._on_call_end(
+                caller_id="+46700000022",
+                source="twilio",
+                transcript=[TranscriptTurn(role="user", text="second call")],
+                metadata={"call_sid": "CAtwo"},
+            )
+            second_group = server._pending_call_groups["+46700000022"]
+            assert second_group != first_group
+            first_manifest = json.loads(
+                server._call_group_manifest_path(first_group).read_text()
+            )
+            second_manifest = json.loads(
+                server._call_group_manifest_path(second_group).read_text()
+            )
+            assert first_manifest["status"] == "closed"
+            assert second_manifest["status"] == "open"
+            assert (
+                first_manifest["archive_record_paths"]
+                != second_manifest["archive_record_paths"]
+            )
 
     asyncio.run(_exercise())
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2222,6 +2222,86 @@ def test_closed_call_group_does_not_reuse_id_for_next_call() -> None:
     asyncio.run(_exercise())
 
 
+def test_call_group_manifest_unions_archive_paths() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        server = VoiceServer()
+        server.state_dir = Path(tmpdir)
+        first = Path(tmpdir) / "archive" / "first.json"
+        second = Path(tmpdir) / "archive" / "second.json"
+        first.parent.mkdir(parents=True)
+        first.write_text("{}")
+        second.write_text("{}")
+
+        server._write_call_group_manifest(
+            caller_id="+46700000030",
+            call_group_id="group-union",
+            record_paths=[first],
+        )
+        server._write_call_group_manifest(
+            caller_id="+46700000030",
+            call_group_id="group-union",
+            record_paths=[second],
+        )
+
+        manifest = json.loads(
+            server._call_group_manifest_path("group-union").read_text()
+        )
+        assert manifest["archive_record_paths"] == [str(first), str(second)]
+
+
+def test_concurrent_same_caller_teardowns_share_one_group() -> None:
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            server.resume_window_seconds = 300
+            server.post_call_delay_seconds = 300
+            server.post_call_command = "run-post-call"
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                return None
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+
+            await asyncio.gather(
+                server._on_call_end(
+                    caller_id="+46700000031",
+                    source="twilio",
+                    transcript=[TranscriptTurn(role="user", text="leg one")],
+                    metadata={"call_sid": "CAoverlap1"},
+                ),
+                server._on_call_end(
+                    caller_id="+46700000031",
+                    source="twilio",
+                    transcript=[TranscriptTurn(role="user", text="leg two")],
+                    metadata={"call_sid": "CAoverlap2"},
+                ),
+            )
+
+            group_id = server._pending_call_groups["+46700000031"]
+            manifest = json.loads(
+                server._call_group_manifest_path(group_id).read_text()
+            )
+            archive_paths = list((Path(tmpdir) / "archive").glob("*.json"))
+            assert len(archive_paths) == 2
+            assert set(manifest["archive_record_paths"]) == {
+                str(path) for path in archive_paths
+            }
+            assert manifest["status"] == "open"
+            assert manifest["remote_party"] == "+46700000031"
+            assert set(server._pending_archive_records["+46700000031"]) == {
+                Path(p) for p in manifest["archive_record_paths"]
+            }
+
+    asyncio.run(_exercise())
+
+
 def test_post_call_schedule_survives_scheduler_process_exit(tmp_path: Path) -> None:
     marker_file = tmp_path / "post-call-fired.txt"
     launcher_done_file = tmp_path / "launcher-done.txt"

--- a/packages/gptme-voice/tests/test_twilio_integration.py
+++ b/packages/gptme-voice/tests/test_twilio_integration.py
@@ -5,6 +5,7 @@ from gptme_voice.realtime.twilio_integration import (
     build_connect_stream_twiml,
     build_stream_url,
     create_outbound_call,
+    outbound_identity_params,
     resolve_outbound_call_settings,
 )
 
@@ -102,7 +103,20 @@ def test_create_outbound_call_uses_twilio_client():
         "auth_token": "secret",
         "to": "+46701234567",
         "from_": "+15551234567",
-        "twiml": build_connect_stream_twiml("wss://voice.example/twilio"),
+        "twiml": build_connect_stream_twiml(
+            "wss://voice.example/twilio",
+            outbound_identity_params("+46701234567"),
+        ),
+    }
+
+
+def test_outbound_identity_params_preserve_dialed_remote_party():
+    params = outbound_identity_params("+46701234567", {"handoff_id": "abc"})
+
+    assert params == {
+        "handoff_id": "abc",
+        "from_number": "+46701234567",
+        "remote_party": "+46701234567",
     }
 
 
@@ -124,3 +138,5 @@ def test_call_cli_dry_run_prints_twiml(monkeypatch):
 
     assert result.exit_code == 0
     assert 'url="wss://voice.example/twilio"' in result.output
+    assert 'name="from_number" value="+46701234567"' in result.output
+    assert 'name="remote_party" value="+46701234567"' in result.output


### PR DESCRIPTION
## Summary

Outbound Twilio legs were archived under the Call SID, so post-call follow-up lost the dialed number. Resumed calls also had no durable grouping record, so a first leg could dispatch while a later leg was still live.

This is the producer half of Bob's post-call completion contract (`voice-post-call-pm-completion-contract-followups`). PM consumption of closed groups is a follow-up and is **not** in this PR.

## Changes

- Embed the dialed number as TwiML `from_number` **and** `remote_party` on outbound calls.
- Stamp `remote_party` plus a stable `call_group_id` on archive records.
- Write an open/closed manifest at `state/voice-calls/call-groups/<id>.json` that survives resume: same group id, appended archive paths, `closes_at = now + max(delay, resume window)`.
- Explicit close (or elapsed `closes_at`) starts a new group on the next call from that number.
- The existing post-call dispatcher delay is unchanged (`delay=0` stays the recovery/backfill "run now" signal).

## Tests

- `packages/gptme-voice/tests/test_server.py` — resume grouping, remote-party archive payload, hold window vs dispatcher delay, immediate close, no id reuse after close.
- `packages/gptme-voice/tests/test_twilio_integration.py` — outbound TwiML identity params.

`uv run --extra test pytest tests/test_server.py tests/test_twilio_integration.py` — 136 passed.

## Follow-up

PM should emit **one** item per closed group, age-gated by `closes_at`, with a title that does not include the phone number. Design: Bob `knowledge/technical-designs/2026-08-30-voice-call-group-pm-integration.md`.