### PR TITLE
feat(lesson_matcher): add match.repos repository gate

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -130,6 +130,19 @@ def normalize_repo_slug(value: str) -> str | None:
     return None
 
 
+def _repo_gate(raw: object) -> tuple[list[str], bool]:
+    """Return ``(normalized slugs, is_restricted)`` for a ``match.repos`` value.
+
+    ``is_restricted`` is True when the author supplied any repo entries.
+    If every entry is malformed, slugs is empty but the gate stays restricted
+    so :func:`filter_by_repo` fail-closes instead of treating the lesson as
+    unrestricted.
+    """
+    raw_list = _string_list(raw)
+    slugs = [s for s in (normalize_repo_slug(r) for r in raw_list) if s]
+    return slugs, bool(raw_list)
+
+
 def _dedupe_strings(values: Sequence[object]) -> list[str]:
     """Strip and deduplicate strings while preserving first-seen order."""
     deduped: list[str] = []
@@ -480,12 +493,12 @@ def extract_frontmatter(content: str) -> tuple[dict[str, Any], str]:
         match_dict["session_categories"] = session_categories
 
     # ``match.repos`` — optional repository gate; nested form only (same rule
-    # as session_categories).  Each entry is normalised to lowercase owner/repo;
-    # invalid entries are silently dropped.
+    # as session_categories).  Preserve raw entries so ``_parse_lesson_file``
+    # can fail-close when every entry is invalid instead of collapsing the
+    # gate to unrestricted.
     _raw_repos = _extract_list_frontmatter_field(match_block, "repos")
-    repos = [s for s in (normalize_repo_slug(r) for r in _raw_repos) if s]
-    if repos:
-        match_dict["repos"] = repos
+    if _raw_repos:
+        match_dict["repos"] = _raw_repos
 
     top_level_patterns = _extract_list_frontmatter_field(
         top_level_without_match, "patterns", allow_indented=False
@@ -741,7 +754,7 @@ def _score_skill_descriptor(lesson: dict[str, Any], prompt_lower: str) -> tuple[
 # ---------------------------------------------------------------------------
 
 #: On-disk cache schema. Bump when the lesson dict shape changes.
-_CACHE_VERSION = 1
+_CACHE_VERSION = 2
 
 # resolved path -> (mtime_ns, size, lesson_or_None). None means parsed-but-skipped.
 _parse_cache: dict[str, tuple[int, int, dict[str, Any] | None]] = {}
@@ -798,6 +811,7 @@ _LESSON_LIST_FIELDS = (
     "tags",
     "harness_restrict",
     "session_categories",
+    "repos",
 )
 _LESSON_STRING_FIELDS = ("path", "title", "description", "when_to_use", "body")
 
@@ -811,6 +825,7 @@ def _valid_cached_lesson(lesson: object) -> bool:
         and (lesson.get("id") is None or isinstance(lesson.get("id"), str))
         and (lesson.get("skill_name") is None or isinstance(lesson.get("skill_name"), str))
         and isinstance(lesson.get("is_skill"), bool)
+        and isinstance(lesson.get("repos_restricted"), bool)
         and isinstance(lesson.get("n_keywords"), int)
     )
 
@@ -938,7 +953,7 @@ def _parse_lesson_file(path: Path) -> dict[str, Any] | None:
     session_categories = _dedupe_strings(_string_list(_raw_sc))
 
     _raw_repos = match_data.get("repos") or [] if isinstance(match_data, dict) else []
-    repos = [s for s in (normalize_repo_slug(r) for r in _string_list(_raw_repos)) if s]
+    repos, repos_restricted = _repo_gate(_raw_repos)
 
     if not keywords and not patterns and not skill_name:
         return None
@@ -959,6 +974,7 @@ def _parse_lesson_file(path: Path) -> dict[str, Any] | None:
         "harness_restrict": harness_restrict,
         "session_categories": session_categories,
         "repos": repos,
+        "repos_restricted": repos_restricted,
         "is_skill": path.name == "SKILL.md" or skill_name is not None,
         "body": body,
         "n_keywords": len(keywords),
@@ -1172,15 +1188,20 @@ def filter_by_session_category(
 def filter_by_repo(lessons: list[dict[str, Any]], current_repo: str | None) -> list[dict[str, Any]]:
     """Return lessons that are unrestricted or match *current_repo*.
 
-    Lessons with a non-empty ``match.repos`` list are excluded unless a
+    Lessons with a configured ``match.repos`` gate are excluded unless a
     normalised form of *current_repo* appears in that list.  The contract
     mirrors ``filter_by_session_category`` with one difference: unknown context
     is **fail-closed** (restricted lessons are excluded when *current_repo* is
     ``None``).
 
+    A lesson is restricted when ``repos_restricted`` is True or ``repos`` is
+    non-empty.  That distinction matters when every configured entry is
+    invalid: normalisation yields an empty list, but the author still wrote a
+    gate, so the lesson stays excluded instead of becoming unrestricted.
+
     Rationale: the purpose of the field is to prevent bleed.  If an unknown
-    context failed open, repo-scoped lessons would inject into all sessions
-    until every runtime is wired — eliminating the benefit.
+    context — or a typo'd gate — failed open, repo-scoped lessons would inject
+    into unrelated sessions.
 
     *current_repo* is normalised through :func:`normalize_repo_slug`; pass a
     raw ``GPTME_CURRENT_REPO`` value or an already-normalised slug.
@@ -1191,6 +1212,7 @@ def filter_by_repo(lessons: list[dict[str, Any]], current_repo: str | None) -> l
     | ``[gptme/gptme]``      | ``gptme/gptme``| pass     |
     | ``[gptme/gptme]``      | ``erikbjare/bob``| exclude |
     | ``[gptme/gptme]``      | ``None``       | exclude  |
+    | all entries invalid    | anything       | exclude  |
 
     Examples::
 
@@ -1202,12 +1224,13 @@ def filter_by_repo(lessons: list[dict[str, Any]], current_repo: str | None) -> l
     filtered = []
     for lesson in lessons:
         repos = lesson.get("repos") or []
-        if not repos:
+        restricted = bool(lesson.get("repos_restricted")) or bool(repos)
+        if not restricted:
             # unrestricted — always pass
             filtered.append(lesson)
         elif normalised and normalised in repos:
             filtered.append(lesson)
-        # else: restricted and context unknown or non-matching → exclude
+        # else: restricted and context unknown, non-matching, or invalid gate → exclude
     return filtered
 
 

--- a/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
+++ b/packages/gptme-rag/src/gptme_rag/lesson_matcher.py
@@ -22,10 +22,12 @@ belongs in the agent harnesses that accumulate per-lesson reward signal.
 Public API::
 
     from gptme_rag.lesson_matcher import scan_lessons, score_lessons
-    from gptme_rag.lesson_matcher import filter_by_session_category
+    from gptme_rag.lesson_matcher import filter_by_session_category, filter_by_repo
+    from gptme_rag.lesson_matcher import normalize_repo_slug
 
     lessons = scan_lessons([Path("lessons")])
     lessons = filter_by_session_category(lessons, "code")
+    lessons = filter_by_repo(lessons, os.environ.get("GPTME_CURRENT_REPO"))
     results = score_lessons(lessons, user_prompt, max_results=5)
 """
 
@@ -77,6 +79,55 @@ PATTERN_TIMEOUT_SECONDS: float = 0.01
 _SKIP_DIR_PARTS: frozenset[str] = frozenset(
     {"__pycache__", ".git", "node_modules", ".venv", "venv", "env"}
 )
+
+#: Pattern for a valid two-segment GitHub slug (owner/repo).
+_REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+#: SSH remote form: git@github.com:owner/repo.git
+_REPO_SSH_RE = re.compile(r"git@[^:]+:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?$")
+#: HTTPS remote form: https://github.com/owner/repo(.git)
+_REPO_HTTPS_RE = re.compile(r"https?://[^/]+/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?(?:/.*)?$")
+
+
+def normalize_repo_slug(value: str) -> str | None:
+    """Normalise *value* to a lowercase ``owner/repo`` slug or return ``None``.
+
+    Accepts bare slugs (``gptme/gptme``), HTTPS GitHub URLs, and SSH remote
+    strings.  Anything that does not resolve to exactly two non-empty path
+    segments is returned as ``None`` — callers treat ``None`` as *unknown*.
+
+    Examples::
+
+        normalize_repo_slug("gptme/gptme")              -> "gptme/gptme"
+        normalize_repo_slug("ErikBjare/bob")             -> "erikbjare/bob"
+        normalize_repo_slug("gptme/gptme.git")           -> "gptme/gptme"
+        normalize_repo_slug("https://github.com/A/B")   -> "a/b"
+        normalize_repo_slug("git@github.com:A/B.git")   -> "a/b"
+        normalize_repo_slug("./local")                   -> None
+        normalize_repo_slug("gptme")                     -> None  (one segment)
+    """
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+
+    # SSH form
+    m = _REPO_SSH_RE.match(value)
+    if m:
+        return m.group(1).lower()
+
+    # HTTPS form
+    m = _REPO_HTTPS_RE.match(value)
+    if m:
+        return m.group(1).rstrip("/").lower()
+
+    # Bare slug — reject anything that looks like a local path first
+    if value.startswith((".", "/")):
+        return None
+    # Strip optional .git suffix then validate two segments
+    bare = value.removesuffix(".git")
+    if _REPO_SLUG_RE.match(bare):
+        return bare.lower()
+
+    return None
 
 
 def _dedupe_strings(values: Sequence[object]) -> list[str]:
@@ -427,6 +478,14 @@ def extract_frontmatter(content: str) -> tuple[dict[str, Any], str]:
                 session_categories = [s.strip() for s in val.split(",") if s.strip()]
     if session_categories:
         match_dict["session_categories"] = session_categories
+
+    # ``match.repos`` — optional repository gate; nested form only (same rule
+    # as session_categories).  Each entry is normalised to lowercase owner/repo;
+    # invalid entries are silently dropped.
+    _raw_repos = _extract_list_frontmatter_field(match_block, "repos")
+    repos = [s for s in (normalize_repo_slug(r) for r in _raw_repos) if s]
+    if repos:
+        match_dict["repos"] = repos
 
     top_level_patterns = _extract_list_frontmatter_field(
         top_level_without_match, "patterns", allow_indented=False
@@ -878,6 +937,9 @@ def _parse_lesson_file(path: Path) -> dict[str, Any] | None:
     _raw_sc = match_data.get("session_categories") or [] if isinstance(match_data, dict) else []
     session_categories = _dedupe_strings(_string_list(_raw_sc))
 
+    _raw_repos = match_data.get("repos") or [] if isinstance(match_data, dict) else []
+    repos = [s for s in (normalize_repo_slug(r) for r in _string_list(_raw_repos)) if s]
+
     if not keywords and not patterns and not skill_name:
         return None
 
@@ -896,6 +958,7 @@ def _parse_lesson_file(path: Path) -> dict[str, Any] | None:
         "tags": tags,
         "harness_restrict": harness_restrict,
         "session_categories": session_categories,
+        "repos": repos,
         "is_skill": path.name == "SKILL.md" or skill_name is not None,
         "body": body,
         "n_keywords": len(keywords),
@@ -1103,6 +1166,48 @@ def filter_by_session_category(
         cats = lesson.get("session_categories") or []
         if not cats or (cat_lower is not None and cat_lower in {c.lower() for c in cats}):
             filtered.append(lesson)
+    return filtered
+
+
+def filter_by_repo(lessons: list[dict[str, Any]], current_repo: str | None) -> list[dict[str, Any]]:
+    """Return lessons that are unrestricted or match *current_repo*.
+
+    Lessons with a non-empty ``match.repos`` list are excluded unless a
+    normalised form of *current_repo* appears in that list.  The contract
+    mirrors ``filter_by_session_category`` with one difference: unknown context
+    is **fail-closed** (restricted lessons are excluded when *current_repo* is
+    ``None``).
+
+    Rationale: the purpose of the field is to prevent bleed.  If an unknown
+    context failed open, repo-scoped lessons would inject into all sessions
+    until every runtime is wired — eliminating the benefit.
+
+    *current_repo* is normalised through :func:`normalize_repo_slug`; pass a
+    raw ``GPTME_CURRENT_REPO`` value or an already-normalised slug.
+
+    | ``match.repos``        | *current_repo* | Result   |
+    |------------------------|----------------|----------|
+    | absent / empty         | anything       | pass     |
+    | ``[gptme/gptme]``      | ``gptme/gptme``| pass     |
+    | ``[gptme/gptme]``      | ``erikbjare/bob``| exclude |
+    | ``[gptme/gptme]``      | ``None``       | exclude  |
+
+    Examples::
+
+        filter_by_repo(lessons, "gptme/gptme")   # exact slug (lowercase)
+        filter_by_repo(lessons, "ErikBjare/bob")  # normalised before compare
+        filter_by_repo(lessons, None)             # unknown — restricted lessons excluded
+    """
+    normalised = normalize_repo_slug(current_repo) if current_repo else None
+    filtered = []
+    for lesson in lessons:
+        repos = lesson.get("repos") or []
+        if not repos:
+            # unrestricted — always pass
+            filtered.append(lesson)
+        elif normalised and normalised in repos:
+            filtered.append(lesson)
+        # else: restricted and context unknown or non-matching → exclude
     return filtered
 
 

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -19,11 +19,13 @@ from gptme_rag.lesson_matcher import (
     effective_status,
     extract_frontmatter,
     filter_by_harness,
+    filter_by_repo,
     filter_by_session_category,
     filter_held_out,
     is_held_out,
     keyword_to_regex,
     match_keyword,
+    normalize_repo_slug,
     parse_holdout_set,
     scan_lessons,
     score_lessons,
@@ -1753,3 +1755,197 @@ class TestEffectiveStatus:
         fm, _ = extract_frontmatter(content)
 
         assert effective_status(fm) == "active"
+
+
+# ---------------------------------------------------------------------------
+# normalize_repo_slug
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRepoSlug:
+    def test_bare_slug_lowercased(self):
+        assert normalize_repo_slug("gptme/gptme") == "gptme/gptme"
+
+    def test_mixed_case_lowercased(self):
+        assert normalize_repo_slug("ErikBjare/bob") == "erikbjare/bob"
+
+    def test_strips_git_suffix(self):
+        assert normalize_repo_slug("gptme/gptme.git") == "gptme/gptme"
+
+    def test_https_url(self):
+        assert normalize_repo_slug("https://github.com/gptme/gptme") == "gptme/gptme"
+
+    def test_https_url_with_git_suffix(self):
+        assert normalize_repo_slug("https://github.com/gptme/gptme.git") == "gptme/gptme"
+
+    def test_https_url_mixed_case(self):
+        assert normalize_repo_slug("https://github.com/ErikBjare/bob") == "erikbjare/bob"
+
+    def test_ssh_remote(self):
+        assert normalize_repo_slug("git@github.com:gptme/gptme.git") == "gptme/gptme"
+
+    def test_ssh_remote_no_git_suffix(self):
+        assert normalize_repo_slug("git@github.com:gptme/gptme") == "gptme/gptme"
+
+    def test_single_segment_is_none(self):
+        assert normalize_repo_slug("gptme") is None
+
+    def test_local_path_is_none(self):
+        assert normalize_repo_slug("./gptme") is None
+        assert normalize_repo_slug("/home/bob/bob") is None
+
+    def test_empty_is_none(self):
+        assert normalize_repo_slug("") is None
+
+    def test_none_input_is_none(self):
+        assert normalize_repo_slug(None) is None  # type: ignore[arg-type]
+
+    def test_activitywatch_slug(self):
+        assert normalize_repo_slug("ActivityWatch/aw-server-rust") == "activitywatch/aw-server-rust"
+
+
+# ---------------------------------------------------------------------------
+# filter_by_repo
+# ---------------------------------------------------------------------------
+
+
+def _make_lesson(repos: list[str] | None) -> dict:
+    """Minimal lesson dict for filter_by_repo tests."""
+    lesson: dict = {"keywords": ["x"], "path": "lessons/x.md", "session_categories": []}
+    if repos is not None:
+        lesson["repos"] = [r for r in (normalize_repo_slug(s) for s in repos) if r]
+    else:
+        lesson["repos"] = []
+    return lesson
+
+
+class TestFilterByRepo:
+    def test_unrestricted_lesson_always_passes(self):
+        lesson = _make_lesson(None)
+        assert filter_by_repo([lesson], "gptme/gptme") == [lesson]
+
+    def test_unrestricted_lesson_passes_when_repo_unknown(self):
+        lesson = _make_lesson(None)
+        assert filter_by_repo([lesson], None) == [lesson]
+
+    def test_restricted_lesson_passes_for_matching_repo(self):
+        lesson = _make_lesson(["gptme/gptme"])
+        assert filter_by_repo([lesson], "gptme/gptme") == [lesson]
+
+    def test_restricted_lesson_excluded_for_wrong_repo(self):
+        lesson = _make_lesson(["gptme/gptme"])
+        assert filter_by_repo([lesson], "erikbjare/bob") == []
+
+    def test_restricted_lesson_excluded_when_repo_unknown(self):
+        lesson = _make_lesson(["gptme/gptme"])
+        assert filter_by_repo([lesson], None) == []
+
+    def test_normalizes_current_repo_slug(self):
+        lesson = _make_lesson(["gptme/gptme"])
+        # Pass mixed-case; filter should normalise
+        assert filter_by_repo([lesson], "Gptme/Gptme") == [lesson]
+
+    def test_normalizes_current_repo_url(self):
+        lesson = _make_lesson(["gptme/gptme"])
+        assert filter_by_repo([lesson], "https://github.com/gptme/gptme") == [lesson]
+
+    def test_empty_repos_field_treated_as_unrestricted(self):
+        lesson = _make_lesson([])
+        assert filter_by_repo([lesson], None) == [lesson]
+
+    def test_mixed_restricted_and_unrestricted(self):
+        free = _make_lesson(None)
+        scoped = _make_lesson(["gptme/gptme"])
+        result = filter_by_repo([free, scoped], "erikbjare/bob")
+        assert result == [free]
+
+    def test_multiple_repos_in_match(self):
+        lesson = _make_lesson(["gptme/gptme", "activitywatch/aw-server-rust"])
+        assert filter_by_repo([lesson], "gptme/gptme") == [lesson]
+        assert filter_by_repo([lesson], "activitywatch/aw-server-rust") == [lesson]
+        assert filter_by_repo([lesson], "erikbjare/bob") == []
+
+
+# ---------------------------------------------------------------------------
+# match.repos frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+class TestReposFrontmatterParsing:
+    def test_yaml_repos_field_parsed(self):
+        """With PyYAML, match.repos is parsed into the lesson dict."""
+        content = (
+            "---\n"
+            "match:\n"
+            "  keywords: [datastore merge]\n"
+            "  repos: [gptme/gptme, activitywatch/aw-server-rust]\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        fm, _ = extract_frontmatter(content)
+        assert fm.get("match", {}).get("repos") == ["gptme/gptme", "activitywatch/aw-server-rust"]
+
+    def test_regex_fallback_repos_field(self, monkeypatch):
+        """Without PyYAML, match.repos must be parsed by the regex fallback."""
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        content = (
+            "---\n"
+            "match:\n"
+            "  keywords:\n"
+            "    - datastore merge\n"
+            "  repos:\n"
+            "    - gptme/gptme\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        fm, _ = extract_frontmatter(content)
+        assert fm.get("match", {}).get("repos") == ["gptme/gptme"]
+
+    def test_top_level_repos_ignored(self, monkeypatch):
+        """A top-level repos: key must not act as a match gate (same rule as session_categories)."""
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        content = (
+            "---\n"
+            "repos: [gptme/gptme]\n"
+            "match:\n"
+            "  keywords: [datastore merge]\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        fm, _ = extract_frontmatter(content)
+        assert "repos" not in fm.get("match", {})
+
+    def test_scan_lessons_includes_repos(self, tmp_path):
+        """scan_lessons returns the normalised repos list inside lesson dicts."""
+        (tmp_path / "lesson.md").write_text(
+            "---\n"
+            "match:\n"
+            "  keywords: [datastore merge]\n"
+            "  repos: [gptme/gptme]\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        lessons = scan_lessons([tmp_path])
+        assert len(lessons) == 1
+        assert lessons[0]["repos"] == ["gptme/gptme"]
+
+    def test_scan_lessons_no_repos_field_defaults_empty(self, tmp_path):
+        (tmp_path / "lesson.md").write_text(
+            "---\nmatch:\n  keywords: [datastore merge]\n---\n# Title\nBody.\n"
+        )
+        lessons = scan_lessons([tmp_path])
+        assert len(lessons) == 1
+        assert lessons[0]["repos"] == []
+
+    def test_scan_lessons_invalid_repo_entry_dropped(self, tmp_path):
+        """An invalid entry (e.g. single-segment or path) is silently dropped."""
+        (tmp_path / "lesson.md").write_text(
+            "---\n"
+            "match:\n"
+            "  keywords: [datastore merge]\n"
+            "  repos: [gptme/gptme, ./local, gptme]\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        lessons = scan_lessons([tmp_path])
+        assert lessons[0]["repos"] == ["gptme/gptme"]

--- a/packages/gptme-rag/tests/test_lesson_matcher.py
+++ b/packages/gptme-rag/tests/test_lesson_matcher.py
@@ -1813,9 +1813,12 @@ def _make_lesson(repos: list[str] | None) -> dict:
     """Minimal lesson dict for filter_by_repo tests."""
     lesson: dict = {"keywords": ["x"], "path": "lessons/x.md", "session_categories": []}
     if repos is not None:
-        lesson["repos"] = [r for r in (normalize_repo_slug(s) for s in repos) if r]
+        slugs = [r for r in (normalize_repo_slug(s) for s in repos) if r]
+        lesson["repos"] = slugs
+        lesson["repos_restricted"] = bool(repos)
     else:
         lesson["repos"] = []
+        lesson["repos_restricted"] = False
     return lesson
 
 
@@ -1864,6 +1867,14 @@ class TestFilterByRepo:
         assert filter_by_repo([lesson], "gptme/gptme") == [lesson]
         assert filter_by_repo([lesson], "activitywatch/aw-server-rust") == [lesson]
         assert filter_by_repo([lesson], "erikbjare/bob") == []
+
+    def test_all_invalid_repos_fail_closed(self):
+        """A configured gate whose every entry is invalid must not become unrestricted."""
+        lesson = _make_lesson(["./local", "gptme"])
+        assert lesson["repos"] == []
+        assert lesson["repos_restricted"] is True
+        assert filter_by_repo([lesson], "gptme/gptme") == []
+        assert filter_by_repo([lesson], None) == []
 
 
 # ---------------------------------------------------------------------------
@@ -1928,6 +1939,7 @@ class TestReposFrontmatterParsing:
         lessons = scan_lessons([tmp_path])
         assert len(lessons) == 1
         assert lessons[0]["repos"] == ["gptme/gptme"]
+        assert lessons[0]["repos_restricted"] is True
 
     def test_scan_lessons_no_repos_field_defaults_empty(self, tmp_path):
         (tmp_path / "lesson.md").write_text(
@@ -1936,6 +1948,7 @@ class TestReposFrontmatterParsing:
         lessons = scan_lessons([tmp_path])
         assert len(lessons) == 1
         assert lessons[0]["repos"] == []
+        assert lessons[0]["repos_restricted"] is False
 
     def test_scan_lessons_invalid_repo_entry_dropped(self, tmp_path):
         """An invalid entry (e.g. single-segment or path) is silently dropped."""
@@ -1949,3 +1962,41 @@ class TestReposFrontmatterParsing:
         )
         lessons = scan_lessons([tmp_path])
         assert lessons[0]["repos"] == ["gptme/gptme"]
+        assert lessons[0]["repos_restricted"] is True
+
+    def test_scan_lessons_all_invalid_repos_fail_closed(self, tmp_path):
+        """All-invalid match.repos stays restricted so filter_by_repo excludes it."""
+        (tmp_path / "lesson.md").write_text(
+            "---\n"
+            "match:\n"
+            "  keywords: [datastore merge]\n"
+            "  repos: [./local, gptme]\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        lessons = scan_lessons([tmp_path])
+        assert len(lessons) == 1
+        assert lessons[0]["repos"] == []
+        assert lessons[0]["repos_restricted"] is True
+        assert filter_by_repo(lessons, "gptme/gptme") == []
+        assert filter_by_repo(lessons, None) == []
+
+    def test_regex_fallback_all_invalid_repos_fail_closed(self, tmp_path, monkeypatch):
+        """Regex fallback must not drop an all-invalid gate into unrestricted."""
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        (tmp_path / "lesson.md").write_text(
+            "---\n"
+            "match:\n"
+            "  keywords:\n"
+            "    - datastore merge\n"
+            "  repos:\n"
+            "    - ./local\n"
+            "    - gptme\n"
+            "---\n"
+            "# Title\nBody.\n"
+        )
+        lessons = scan_lessons([tmp_path])
+        assert len(lessons) == 1
+        assert lessons[0]["repos"] == []
+        assert lessons[0]["repos_restricted"] is True
+        assert filter_by_repo(lessons, "erikbjare/bob") == []


### PR DESCRIPTION
## Summary

New optional field `match.repos` under `match:` in lesson frontmatter filters lessons by target repository. Stops repo-specific guidance bleeding into unrelated sessions.

## Changes

- `normalize_repo_slug()`: normalises bare slugs, HTTPS URLs, SSH remotes → lowercase `owner/repo` or `None`
- `filter_by_repo()`: fail-closed gate (unknown context excludes restricted lessons), mirrors `filter_by_session_category` contract
- Parser: `match.repos` parsed in both PyYAML and regex-fallback paths; invalid entries silently dropped
- lesson dict gains `repos: []` field (empty = unrestricted, no behaviour change for existing lessons)
- 29 new tests covering normalizer, filter, and frontmatter parsing edge cases

## Semantics

| `match.repos` | `current_repo` | Result |
|---|---|---|
| absent / empty | anything | pass (fail-open) |
| `[gptme/gptme]` | `gptme/gptme` | pass |
| `[gptme/gptme]` | `erikbjare/bob` | exclude |
| `[gptme/gptme]` | `None` (unknown) | **exclude** (fail-closed) |

Callers supply `GPTME_CURRENT_REPO` env var. The autonomous launcher exports it from `CASCADE_UPSTREAM_COORDINATION_ID` (cross-repo sessions) or defaults to `ErikBjare/bob` (brain sessions).