### PR TITLE
fix(vision-node): join capture thread before camera release

### DIFF
--- a/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
@@ -146,14 +146,26 @@ class VisionBridge:
         self._send_message = send_message
         self.pipeline.start()
 
-    async def stop(self) -> None:
-        """Stop capture, release the source, and drain pending event sends."""
-        self.pipeline.stop()
-        release = getattr(self.pipeline.source, "release", None)
-        if release is not None:
-            release()
+    async def stop(self, *, timeout: float = 5.0) -> None:
+        """Stop capture, release the source, and drain pending event sends.
+
+        The emission path is cleared first so a late pipeline callback cannot
+        schedule work after teardown. ``source.release()`` runs only after the
+        capture thread has actually exited — concurrent OpenCV ``read()`` /
+        ``release()`` is not documented thread-safe.
+        """
         self._send_message = None
         self._loop = None
+        await asyncio.to_thread(self.pipeline.stop, timeout)
+        if self.pipeline.is_running():
+            logger.warning(
+                "vision pipeline worker still alive after %.1fs; skipping source.release()",
+                timeout,
+            )
+        else:
+            release = getattr(self.pipeline.source, "release", None)
+            if release is not None:
+                release()
         pending = list(self._pending_sends)
         for task in pending:
             task.cancel()

--- a/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/bridge.py
@@ -14,6 +14,7 @@ import base64
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from typing import TypeVar
 
 import cv2
 
@@ -26,10 +27,29 @@ logger = logging.getLogger(__name__)
 _MAX_PENDING_EVENT_SENDS = 4
 
 SendMessage = Callable[[str], Awaitable[None]]
+_T = TypeVar("_T")
 
 
 async def _send_event(send_message: SendMessage, message: str) -> None:
     await send_message(message)
+
+
+async def _await_even_if_cancelled(aw: asyncio.Future[_T]) -> _T:
+    """Await *aw* even if the current task is cancelled.
+
+    Capture-thread join must finish before ``source.release()``: concurrent
+    OpenCV ``read()`` / ``release()`` is not documented thread-safe. The
+    original cancellation is re-raised after *aw* completes.
+    """
+    cancelled_exc: BaseException | None = None
+    while not aw.done():
+        try:
+            await asyncio.shield(aw)
+        except asyncio.CancelledError as exc:
+            cancelled_exc = exc
+    if cancelled_exc is not None:
+        raise cancelled_exc
+    return aw.result()
 
 
 class VisionBridge:
@@ -153,22 +173,33 @@ class VisionBridge:
         schedule work after teardown. ``source.release()`` runs only after the
         capture thread has actually exited — concurrent OpenCV ``read()`` /
         ``release()`` is not documented thread-safe.
+
+        Cancellation during the off-loop join still runs this cleanup: the
+        worker join is shielded so we never ``release()`` against a live
+        ``read()``, and pending event-send tasks are cancelled regardless.
         """
         self._send_message = None
         self._loop = None
-        await asyncio.to_thread(self.pipeline.stop, timeout)
-        if self.pipeline.is_running():
-            logger.warning(
-                "vision pipeline worker still alive after %.1fs; skipping source.release()",
-                timeout,
-            )
-        else:
-            release = getattr(self.pipeline.source, "release", None)
-            if release is not None:
-                release()
-        pending = list(self._pending_sends)
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
-        self._pending_sends.clear()
+        join = asyncio.create_task(asyncio.to_thread(self.pipeline.stop, timeout))
+        try:
+            await _await_even_if_cancelled(join)
+        finally:
+            if self.pipeline.is_running():
+                logger.warning(
+                    "vision pipeline worker still alive after %.1fs; skipping source.release()",
+                    timeout,
+                )
+            else:
+                release = getattr(self.pipeline.source, "release", None)
+                if release is not None:
+                    release()
+            pending = list(self._pending_sends)
+            for pending_task in pending:
+                pending_task.cancel()
+            self._pending_sends.clear()
+            if pending:
+                await _await_even_if_cancelled(
+                    asyncio.ensure_future(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+                )

--- a/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/pipeline.py
@@ -87,7 +87,8 @@ class VisionPipeline:
     def _process_frame(self, frame: np.ndarray) -> list[VisionEvent]:
         """Run detectors and emit events for one captured frame."""
         with self._latest_frame_lock:
-            self.latest_frame = frame
+            # Copy: OpenCV VideoCapture.read() can reuse the same buffer.
+            self.latest_frame = frame.copy()
 
         detections: list[Detection] = []
         for detector in self.detectors:
@@ -153,6 +154,10 @@ class VisionPipeline:
             target=self._run, name="vision-pipeline", daemon=True
         )
         self._thread.start()
+
+    def is_running(self) -> bool:
+        thread = self._thread
+        return thread is not None and thread.is_alive()
 
     def stop(self, timeout: float = 5.0) -> None:
         self._stop.set()

--- a/packages/gptme-vision-node/tests/test_bridge.py
+++ b/packages/gptme-vision-node/tests/test_bridge.py
@@ -174,6 +174,54 @@ async def test_stop_skips_release_while_capture_thread_is_blocked() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_cleans_up_when_cancelled_during_join() -> None:
+    """A cancelled stop() must still drain pending sends and skip unsafe release."""
+    unblock = threading.Event()
+    entered = threading.Event()
+
+    class BlockingSource:
+        def __init__(self) -> None:
+            self.released = False
+
+        def get_frame(self):
+            entered.set()
+            unblock.wait()
+            return None
+
+        def release(self) -> None:
+            self.released = True
+
+    source = BlockingSource()
+    bridge = VisionBridge(source, [])
+    hold_send = asyncio.Event()
+
+    async def blocked_send(_message: str) -> None:
+        await hold_send.wait()
+
+    bridge.start(asyncio.get_running_loop(), blocked_send)
+    assert entered.wait(timeout=1)
+    bridge._schedule_event(VisionEvent(PERSON_APPEARED))
+    assert bridge._pending_sends
+
+    stop_task = asyncio.create_task(bridge.stop(timeout=0.2))
+    await asyncio.sleep(0)
+    stop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    assert not bridge._pending_sends
+    assert not source.released
+    assert bridge.pipeline.is_running()
+
+    unblock.set()
+    thread = bridge.pipeline._thread
+    if thread is not None:
+        thread.join(timeout=1)
+    await bridge.stop()
+    assert source.released
+
+
+@pytest.mark.asyncio
 async def test_unrelated_server_message_is_not_consumed() -> None:
     bridge = VisionBridge(_Source(), [])
 

--- a/packages/gptme-vision-node/tests/test_bridge.py
+++ b/packages/gptme-vision-node/tests/test_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import threading
 
 import numpy as np
 import pytest
@@ -124,6 +125,52 @@ async def test_stop_cancels_blocked_event_sends() -> None:
 
     await asyncio.wait_for(bridge.stop(), timeout=0.1)
     assert not bridge._pending_sends
+
+
+@pytest.mark.asyncio
+async def test_stop_releases_source_after_pipeline_exits() -> None:
+    source = _Source()
+    bridge = VisionBridge(source, [])
+    await bridge.stop()
+    assert source.released
+
+
+@pytest.mark.asyncio
+async def test_stop_skips_release_while_capture_thread_is_blocked() -> None:
+    unblock = threading.Event()
+    entered = threading.Event()
+
+    class BlockingSource:
+        def __init__(self) -> None:
+            self.released = False
+
+        def get_frame(self):
+            entered.set()
+            unblock.wait()
+            return None
+
+        def release(self) -> None:
+            self.released = True
+
+    source = BlockingSource()
+    bridge = VisionBridge(source, [])
+
+    async def send(_message: str) -> None:
+        return None
+
+    bridge.start(asyncio.get_running_loop(), send)
+    assert entered.wait(timeout=1)
+    try:
+        await asyncio.wait_for(bridge.stop(timeout=0.05), timeout=1)
+        assert not source.released
+        assert bridge.pipeline.is_running()
+    finally:
+        unblock.set()
+        thread = bridge.pipeline._thread
+        if thread is not None:
+            thread.join(timeout=1)
+        await bridge.stop()
+    assert source.released
 
 
 @pytest.mark.asyncio

--- a/packages/gptme-vision-node/tests/test_pipeline.py
+++ b/packages/gptme-vision-node/tests/test_pipeline.py
@@ -88,6 +88,18 @@ def test_latest_frame_copy_is_an_independent_snapshot():
     assert np.any(pipeline.latest_frame != 0)
 
 
+def test_process_frame_stores_an_independent_copy():
+    """OpenCV can reuse the capture buffer; stored latest_frame must not alias it."""
+    frame = solid_frame((60, 60, 60))
+    pipeline = VisionPipeline(ListSource([frame]), [])
+
+    pipeline.step()
+    frame[:] = 0
+
+    assert pipeline.latest_frame is not None
+    assert np.any(pipeline.latest_frame != 0)
+
+
 def test_motion_events_and_latest_frame():
     still = solid_frame((60, 60, 60))
     moved = still.copy()


### PR DESCRIPTION
## Summary

Follow-up to gptme/gptme-contrib#1556. The AI review P1 landed five minutes after that PR merged.

- `VisionBridge.stop()` now clears the event-emission path first, joins the capture thread off the asyncio loop, and calls `source.release()` only after the worker has actually exited. Concurrent OpenCV `read()` / `release()` is not documented thread-safe; a hung camera previously timed out the join and released anyway.
- `_process_frame` stores `frame.copy()` so OpenCV buffer reuse cannot alias `latest_frame`.

## Tests

- `test_stop_releases_source_after_pipeline_exits`
- `test_stop_skips_release_while_capture_thread_is_blocked`
- `test_process_frame_stores_an_independent_copy`

`uv run pytest packages/gptme-vision-node/tests/test_bridge.py packages/gptme-vision-node/tests/test_pipeline.py -q` — 22 passed.

## Deliberate limits

- Did not change OpenCV's blocking `read()`. A hung camera still skips `release()` after the join timeout (logged) rather than racing the backend.
