### PR TITLE
fix(rag): handle large collection indexing failures

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -474,6 +474,7 @@ def index(
         console.print(f"❌ Error indexing directory: {e}", style="red")
         if logger.isEnabledFor(logging.DEBUG):
             console.print_exception()
+        raise SystemExit(1) from e
 
 
 @cli.command()

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -1461,11 +1461,25 @@ class Indexer:
         Returns:
             List of documents
         """
-        # Get all documents from collection
-        results = self.collection.get()
-        result_ids = results["ids"] or []
-        result_docs = results["documents"] or []
-        result_metas = results["metadatas"] or []
+        # Chroma's unbounded get() can exceed SQLite's variable limit on large
+        # collections. Read bounded pages instead; callers still receive the
+        # complete list.
+        page_size = 1000
+        result_ids: list[str] = []
+        result_docs: list[str] = []
+        result_metas: list[dict] = []
+        offset = 0
+        while True:
+            results = self.collection.get(limit=page_size, offset=offset)
+            page_ids = results["ids"] or []
+            page_docs = results["documents"] or []
+            page_metas = results["metadatas"] or []
+            result_ids.extend(page_ids)
+            result_docs.extend(page_docs)
+            result_metas.extend(page_metas)  # type: ignore[arg-type]
+            if len(page_ids) < page_size:
+                break
+            offset += len(page_ids)
         logger.debug("ChromaDB returned %d documents", len(result_ids))
         if result_ids:
             logger.debug("First document metadata: %s", result_metas[0])

--- a/packages/gptme-rag/tests/test_content_hash_changedetection.py
+++ b/packages/gptme-rag/tests/test_content_hash_changedetection.py
@@ -149,7 +149,7 @@ def test_index_preserves_old_chunks_when_replacement_add_fails(tmp_path, monkeyp
 
     monkeypatch.setattr(chromadb.Collection, "add", fail_replacement_add)
     second = _run_index(runner, index_dir, [src])
-    assert second.exit_code == 0, second.output
+    assert second.exit_code == 1, second.output
     assert "simulated embedding failure" in second.output
 
     chromadb.api.shared_system_client.SharedSystemClient._identifier_to_system.clear()

--- a/packages/gptme-rag/tests/test_large_collection.py
+++ b/packages/gptme-rag/tests/test_large_collection.py
@@ -1,0 +1,45 @@
+"""Regression tests for indexing large persistent collections."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gptme_rag.cli import cli
+from gptme_rag.indexing.indexer import Indexer
+
+
+@pytest.mark.parametrize("total", [1000, 1001])
+def test_list_documents_reads_collection_in_pages(total):
+    ids = [f"doc-{i}" for i in range(total)]
+    documents = [f"content-{i}" for i in range(total)]
+    metadatas = [{"source": f"source-{i}"} for i in range(total)]
+
+    indexer = Indexer.__new__(Indexer)
+    indexer.collection = MagicMock()
+
+    def get_page(*, limit: int, offset: int):
+        end = offset + limit
+        return {
+            "ids": ids[offset:end],
+            "documents": documents[offset:end],
+            "metadatas": metadatas[offset:end],
+        }
+
+    indexer.collection.get.side_effect = get_page
+
+    result = indexer.list_documents(group_by_source=False)
+
+    assert len(result) == total
+    assert [doc.doc_id for doc in result] == ids
+    assert indexer.collection.get.call_count == 2
+    indexer.collection.get.assert_any_call(limit=1000, offset=0)
+    indexer.collection.get.assert_any_call(limit=1000, offset=1000)
+
+
+def test_index_command_exits_nonzero_when_indexing_fails(tmp_path):
+    with patch("gptme_rag.cli.Indexer", side_effect=RuntimeError("database failure")):
+        result = CliRunner().invoke(cli, ["index", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Error indexing directory: database failure" in result.output


### PR DESCRIPTION
## Problem

Large persistent collections can make an unbounded Chroma `collection.get()` exceed SQLite variable limits. The index command also printed the exception but returned exit code 0, so service supervisors treated a failed rebuild as success.

## Fix

- read collection contents in bounded 1,000-record pages
- return exit code 1 when indexing raises
- cover multi-page and exact-page-boundary reads
- update the replacement-failure regression to require a nonzero exit while preserving old chunks

## Verification

- 17 content-hash/large-collection tests passed
- 3 pagination/exit-contract tests passed after the boundary addition
- package mypy passed
- scoped prek hooks passed
- PR quality gate: 100/100