### PR TITLE
fix(gptme-sessions): close step_types LOO attribution gaps

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -495,22 +495,32 @@ class SessionRecord:
         """
         sa = self.span_aggregates or {}
         raw_counts: dict[str, int] = sa.get("tool_counts") or {}
-        total_spans = max(sa.get("total_spans") or 1, 1)
+        # 0 is a real observation (no completed tool spans). Do not coerce it
+        # to 1 — that would stamp shallow_session on absent evidence.
+        total_spans = sa.get("total_spans") or 0
         error_spans = sa.get("error_spans") or 0
         retry_depth = sa.get("retry_depth") or 0
 
-        # Normalize harness-specific tool names
+        # Normalize harness-specific tool names onto CC-canonical labels.
+        # Keys are lowercased; lookup uses tool.lower().
+        # Task (CC) is the subagent tool → Agent, not TaskOp. TodoWrite is TaskOp.
         _aliases = {
             "shell": "Bash",
             "ipython": "Bash",
+            "exec_command": "Bash",
+            "write_stdin": "Bash",
+            "exec": "Bash",
             "save": "Write",
             "patch": "Edit",
             "append": "Edit",
+            "apply_patch": "Edit",
             "read": "Read",
             "todo": "TaskOp",
             "complete": "TaskOp",
+            "todowrite": "TaskOp",
             "agent": "Agent",
             "subagent": "Agent",
+            "task": "Agent",
         }
         tc: dict[str, int] = {}
         for tool, count in raw_counts.items():
@@ -523,11 +533,14 @@ class SessionRecord:
         agent_count = tc.get("Agent", 0)
         task_op_count = tc.get("TaskOp", 0)
 
-        bash_ratio = bash_count / total_spans
-        read_ratio = read_count / total_spans
-        edit_ratio = edit_count / total_spans
+        if total_spans > 0:
+            bash_ratio = bash_count / total_spans
+            read_ratio = read_count / total_spans
+            edit_ratio = edit_count / total_spans
+            error_rate = error_spans / total_spans
+        else:
+            bash_ratio = read_ratio = edit_ratio = error_rate = 0.0
         tool_diversity = len([v for v in tc.values() if v > 0])
-        error_rate = error_spans / total_spans
 
         step_types: list[str] = []
 
@@ -548,7 +561,7 @@ class SessionRecord:
             step_types.append("high_tool_diversity")
         if total_spans >= 40:
             step_types.append("deep_session")
-        elif total_spans <= 10:
+        elif 0 < total_spans <= 10:
             step_types.append("shallow_session")
 
         # Quality / reliability
@@ -559,9 +572,13 @@ class SessionRecord:
         if error_rate > 0.10:
             step_types.append("error_prone")
 
-        # Delivery patterns (from deliverable_details)
+        # Delivery patterns (from deliverable_details). Producers emit
+        # commit/git_commit/merge_commit/pull_request for commit-bearing work;
+        # counting only the literal "commit" kind stamps completed sessions
+        # as no_commit.
         dd = self.deliverable_details or []
-        commit_count = sum(1 for d in dd if d.get("kind") == "commit")
+        _commit_kinds = {"commit", "git_commit", "merge_commit", "pull_request"}
+        commit_count = sum(1 for d in dd if d.get("kind") in _commit_kinds)
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 
         # Partition on commit cardinality: 0 / 1 / 2+. Two-commit sessions

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -511,8 +511,10 @@ class SessionRecord:
             "write_stdin": "Bash",
             "exec": "Bash",
             "save": "Write",
+            "write": "Write",
             "patch": "Edit",
             "append": "Edit",
+            "edit": "Edit",
             "apply_patch": "Edit",
             "read": "Read",
             "todo": "TaskOp",
@@ -579,6 +581,11 @@ class SessionRecord:
         dd = self.deliverable_details or []
         _commit_kinds = {"commit", "git_commit", "merge_commit", "pull_request"}
         commit_count = sum(1 for d in dd if d.get("kind") in _commit_kinds)
+        # A single `gh pr merge` emits both pull_request and merge_commit
+        # for one delivery. Pair them so one merge is not stamped multi_commit.
+        pr_n = sum(1 for d in dd if d.get("kind") == "pull_request")
+        merge_n = sum(1 for d in dd if d.get("kind") == "merge_commit")
+        commit_count -= min(pr_n, merge_n)
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 
         # Partition on commit cardinality: 0 / 1 / 2+. Two-commit sessions

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -581,10 +581,22 @@ class SessionRecord:
         dd = self.deliverable_details or []
         _commit_kinds = {"commit", "git_commit", "merge_commit", "pull_request"}
         commit_count = sum(1 for d in dd if d.get("kind") in _commit_kinds)
+
         # A single `gh pr merge` emits both pull_request and merge_commit
-        # for one delivery. Pair them so one merge is not stamped multi_commit.
-        pr_n = sum(1 for d in dd if d.get("kind") == "pull_request")
-        merge_n = sum(1 for d in dd if d.get("kind") == "merge_commit")
+        # with evidence.action == "gh_pr_merge". Pair only those — a bare
+        # pull_request (PR URL) plus an unrelated merge_commit must stay two
+        # deliveries, or LOO undercounts distinct work.
+        def _action(d: dict[str, Any]) -> str | None:
+            evidence = d.get("evidence")
+            if isinstance(evidence, dict):
+                action = evidence.get("action")
+                return action if isinstance(action, str) else None
+            return None
+
+        pr_n = sum(1 for d in dd if d.get("kind") == "pull_request" and _action(d) == "gh_pr_merge")
+        merge_n = sum(
+            1 for d in dd if d.get("kind") == "merge_commit" and _action(d) == "gh_pr_merge"
+        )
         commit_count -= min(pr_n, merge_n)
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -707,6 +707,8 @@ def test_populate_span_aggregates_also_populates_step_types(tmp_path: Path):
         ({"TodoWrite": 3, "Bash": 7}, "task_op_heavy"),
         ({"Task": 1, "Bash": 9}, "agent_spawner"),
         ({"write_stdin": 10}, "bash_dominant"),
+        ({"write": 5, "Bash": 5}, "edit_focused"),
+        ({"edit": 5, "Bash": 5}, "edit_focused"),
     ],
 )
 def test_step_types_cross_harness_aliases(tool_counts: dict, expected: str):
@@ -741,6 +743,54 @@ def test_step_types_commit_bearing_kinds(kind: str):
     labels = r.step_types or []
     assert "no_commit" not in labels
     assert "single_commit" in labels
+
+
+def test_step_types_pr_merge_pair_is_single_commit():
+    """A paired pull_request + merge_commit is one logical delivery.
+
+    Regression for gptme/gptme-contrib#1564 Greptile P1: `gh pr merge`
+    records both kinds, so entry-based counting stamped multi_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "pull_request", "value": "merge PR #42"},
+            {"kind": "merge_commit", "value": "merge-commit (abc1234)"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels
+    assert "multi_commit" not in labels
+    assert "no_commit" not in labels
+
+
+def test_step_types_pr_merge_pair_plus_commit_is_multi():
+    """A PR-merge pair plus a separate commit is still multi_commit."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "commit", "value": "sha0"},
+            {"kind": "pull_request", "value": "merge PR #42"},
+            {"kind": "merge_commit", "value": "merge-commit (abc1234)"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
 
 
 def test_step_types_zero_spans_not_shallow():

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -760,8 +760,16 @@ def test_step_types_pr_merge_pair_is_single_commit():
             "retry_depth": 0,
         },
         deliverable_details=[
-            {"kind": "pull_request", "value": "merge PR #42"},
-            {"kind": "merge_commit", "value": "merge-commit (abc1234)"},
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
         ],
     )
     r.populate_step_types()
@@ -783,7 +791,40 @@ def test_step_types_pr_merge_pair_plus_commit_is_multi():
         },
         deliverable_details=[
             {"kind": "commit", "value": "sha0"},
-            {"kind": "pull_request", "value": "merge PR #42"},
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
+
+
+def test_step_types_unrelated_pr_and_merge_commit_not_paired():
+    """Independently sourced pull_request + merge_commit stay two deliveries.
+
+    Regression for gptme/gptme-contrib#1564 Greptile P1: count-only pairing
+    collapsed a PR URL and an unrelated merge_commit into single_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "pull_request", "value": "https://github.com/org/repo/pull/99"},
             {"kind": "merge_commit", "value": "merge-commit (abc1234)"},
         ],
     )

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -699,6 +699,70 @@ def test_populate_span_aggregates_also_populates_step_types(tmp_path: Path):
     assert "shallow_session" in r.step_types
 
 
+@pytest.mark.parametrize(
+    "tool_counts,expected",
+    [
+        ({"exec_command": 10}, "bash_dominant"),
+        ({"apply_patch": 5, "Bash": 5}, "edit_focused"),
+        ({"TodoWrite": 3, "Bash": 7}, "task_op_heavy"),
+        ({"Task": 1, "Bash": 9}, "agent_spawner"),
+        ({"write_stdin": 10}, "bash_dominant"),
+    ],
+)
+def test_step_types_cross_harness_aliases(tool_counts: dict, expected: str):
+    """Codex/CC tool names normalize onto Bash/Edit/TaskOp/Agent labels.
+
+    Regression for gptme/gptme-contrib#1564 Greptile P1: aliases only covered
+    gptme names, so exec_command/apply_patch/TodoWrite/Task never contributed.
+    CC Task is the subagent tool → Agent, not TaskOp.
+    """
+    labels = _record_with_spans(total_spans=10, tool_counts=tool_counts).step_types or []
+    assert expected in labels
+
+
+@pytest.mark.parametrize("kind", ["git_commit", "merge_commit", "pull_request"])
+def test_step_types_commit_bearing_kinds(kind: str):
+    """git_commit/merge_commit/pull_request count as commit-bearing delivery.
+
+    Regression for gptme/gptme-contrib#1564 Greptile P1: only the literal
+    ``commit`` kind was counted, so those producers stamped no_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[{"kind": kind, "value": "x"}],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "no_commit" not in labels
+    assert "single_commit" in labels
+
+
+def test_step_types_zero_spans_not_shallow():
+    """Zero completed spans must not be coerced into an observed shallow_session.
+
+    Regression for gptme/gptme-contrib#1564 Greptile P1: ``max(total or 1, 1)``
+    turned absent tool evidence into total_spans=1 and stamped shallow_session.
+    """
+    labels = _record_with_spans(total_spans=0, tool_counts={}).step_types or []
+    assert "shallow_session" not in labels
+    assert "deep_session" not in labels
+
+
+def test_populate_span_aggregates_codex_normalizes_exec_command(tmp_path: Path):
+    """Codex exec_command spans classify as bash_dominant after aliasing."""
+    p = _write_codex_trajectory(tmp_path)
+    r = SessionRecord(harness="codex", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is True
+    assert r.step_types is not None
+    assert "bash_dominant" in r.step_types
+
+
 # --- harm_category tests ---
 
 


### PR DESCRIPTION
## Summary

Follow-up to gptme/gptme-contrib#1562. The `step_types` field already landed; this PR closes the three Greptile P1s that would have corrupted LOO attribution.

## Changes

- **Cross-harness aliases** — Codex `exec_command`/`write_stdin`/`exec` → Bash, `apply_patch` → Edit; Claude Code `TodoWrite` → TaskOp, `Task` → Agent (subagent tool, not TaskOp).
- **Commit-bearing kinds** — count `git_commit` / `merge_commit` / `pull_request`, not just literal `commit`.
- **Zero spans** — do not coerce `total_spans` 0→1; depth labels require `0 < total_spans`. Empty trajectories are no longer stamped `shallow_session`.

## Tests

91 tests pass in `test_record.py`, including regressions for each P1.

## Rebase note

Rebased onto current `master` after #1562 merged. Duplicate feat commits dropped; remaining commit is `23a8060f`.