### PR TITLE
fix(gptme-sessions): deduplicate logical commit deliveries

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -188,24 +188,25 @@ _PR_NUMBER_RE = re.compile(r"PR\s+#(\d+)", re.IGNORECASE)
 def _commit_identity(value: object) -> str | None:
     """Extract a SHA identity from a commit deliverable value.
 
-    Prefer the trailing parenthetical SHA used by trajectory producers
-    (``message (sha)``, ``merge-commit (sha)``) so hexadecimal tokens in the
-    commit message cannot override the actual identity. Fall back to a bare
-    SHA, then a leading SHA (Grok: ``sha message``).
+    Prefer a bare SHA, then a leading SHA (Grok: ``sha message``), then the
+    trailing parenthetical SHA used by trajectory producers (``message (sha)``,
+    ``merge-commit (sha)``). Leading SHA beats a parenthetical hex token in the
+    commit message so Grok identity is not overridden; hexadecimal tokens in
+    the message still cannot override identity when no leading SHA is present.
     """
     if not isinstance(value, str):
         return None
     stripped = value.strip()
     if not stripped:
         return None
-    trailing = _TRAILING_PAREN_SHA_RE.search(stripped)
-    if trailing:
-        return trailing.group(1).lower()
     if looks_like_sha(stripped):
         return stripped.lower()
     leading = _LEADING_SHA_RE.match(stripped)
     if leading:
         return leading.group(1).lower()
+    trailing = _TRAILING_PAREN_SHA_RE.search(stripped)
+    if trailing:
+        return trailing.group(1).lower()
     return None
 
 
@@ -229,6 +230,36 @@ def _pr_identity(value: object) -> str:
     if number:
         return f"#{number.group(1)}"
     return stripped.lower()
+
+
+def _remember_pr_id(pr_ids: list[str], pr_id: str) -> None:
+    """Record a PR identity, merging ``#N`` with ``owner/repo#N``.
+
+    Caller URLs normalize to ``owner/repo#N``; trajectory text like
+    ``merge PR #N`` normalizes to ``#N``. Those are the same delivery when
+    merge-SHA resolution failed and both producers recorded the PR.
+    Distinct qualified identities with the same number stay distinct.
+    """
+    if "#" not in pr_id:
+        if pr_id not in pr_ids:
+            pr_ids.append(pr_id)
+        return
+    number = pr_id.rsplit("#", 1)[-1]
+    qualified = not pr_id.startswith("#")
+    for i, known in enumerate(pr_ids):
+        if "#" not in known:
+            continue
+        if known.rsplit("#", 1)[-1] != number:
+            continue
+        known_qualified = not known.startswith("#")
+        if known == pr_id:
+            return
+        if not qualified and known_qualified:
+            return
+        if qualified and not known_qualified:
+            pr_ids[i] = pr_id
+            return
+    pr_ids.append(pr_id)
 
 
 @dataclass
@@ -651,9 +682,7 @@ class SessionRecord:
             for detail in dd:
                 if detail.get("kind") != "pull_request":
                     continue
-                pr_id = _pr_identity(detail.get("value"))
-                if pr_id not in pr_ids:
-                    pr_ids.append(pr_id)
+                _remember_pr_id(pr_ids, _pr_identity(detail.get("value")))
             commit_count = len(pr_ids)
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -574,30 +574,32 @@ class SessionRecord:
         if error_rate > 0.10:
             step_types.append("error_prone")
 
-        # Delivery patterns (from deliverable_details). Producers emit
-        # commit/git_commit/merge_commit/pull_request for commit-bearing work;
-        # counting only the literal "commit" kind stamps completed sessions
-        # as no_commit.
+        # Delivery patterns (from deliverable_details). Commit details can be
+        # duplicated across trajectory and caller producers. Prefer unique SHA
+        # identities; identical identity-less values also count once. PRs are
+        # commit-bearing fallback evidence only when no commit detail exists.
         dd = self.deliverable_details or []
-        _commit_kinds = {"commit", "git_commit", "merge_commit", "pull_request"}
-        commit_count = sum(1 for d in dd if d.get("kind") in _commit_kinds)
+        _sha_re = re.compile(r"(?<![0-9a-f])([0-9a-f]{7,40})(?![0-9a-f])", re.IGNORECASE)
+        commit_ids: list[str] = []
+        anonymous_commit_values: set[str] = set()
+        for detail in dd:
+            if detail.get("kind") not in {"commit", "git_commit", "merge_commit"}:
+                continue
+            value = detail.get("value")
+            match = _sha_re.search(value) if isinstance(value, str) else None
+            if match is None:
+                anonymous_commit_values.add(str(value))
+                continue
+            commit_id = match.group(1).lower()
+            for known_id in commit_ids:
+                if commit_id.startswith(known_id) or known_id.startswith(commit_id):
+                    break
+            else:
+                commit_ids.append(commit_id)
 
-        # A single `gh pr merge` emits both pull_request and merge_commit
-        # with evidence.action == "gh_pr_merge". Pair only those — a bare
-        # pull_request (PR URL) plus an unrelated merge_commit must stay two
-        # deliveries, or LOO undercounts distinct work.
-        def _action(d: dict[str, Any]) -> str | None:
-            evidence = d.get("evidence")
-            if isinstance(evidence, dict):
-                action = evidence.get("action")
-                return action if isinstance(action, str) else None
-            return None
-
-        pr_n = sum(1 for d in dd if d.get("kind") == "pull_request" and _action(d) == "gh_pr_merge")
-        merge_n = sum(
-            1 for d in dd if d.get("kind") == "merge_commit" and _action(d) == "gh_pr_merge"
-        )
-        commit_count -= min(pr_n, merge_n)
+        commit_count = len(commit_ids) + len(anonymous_commit_values)
+        if commit_count == 0 and any(d.get("kind") == "pull_request" for d in dd):
+            commit_count = 1
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 
         # Partition on commit cardinality: 0 / 1 / 2+. Two-commit sessions

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -185,14 +185,17 @@ _PR_URL_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)", re.IGNORECASE
 _PR_NUMBER_RE = re.compile(r"PR\s+#(\d+)", re.IGNORECASE)
 
 
-def _commit_identity(value: object) -> str | None:
+def _commit_identity(value: object, kind: str | None = None) -> str | None:
     """Extract a SHA identity from a commit deliverable value.
 
-    Prefer a bare SHA, then a leading SHA (Grok: ``sha message``), then the
-    trailing parenthetical SHA used by trajectory producers (``message (sha)``,
-    ``merge-commit (sha)``). Leading SHA beats a parenthetical hex token in the
-    commit message so Grok identity is not overridden; hexadecimal tokens in
-    the message still cannot override identity when no leading SHA is present.
+    Producers encode identity in different slots of the same string:
+
+    - Grok ``git_commit``: ``sha message``. The leading SHA is identity; a
+      parenthetical hex token in the message is not.
+    - Trajectory ``commit`` / ``merge_commit``: ``message (sha)``. The trailing
+      parenthetical SHA is identity; a leading hex token in the message is not.
+    - Caller / unknown: a bare SHA, else the producer-encoded slot when
+      present (trailing paren, then leading SHA).
     """
     if not isinstance(value, str):
         return None
@@ -202,11 +205,21 @@ def _commit_identity(value: object) -> str | None:
     if looks_like_sha(stripped):
         return stripped.lower()
     leading = _LEADING_SHA_RE.match(stripped)
-    if leading:
-        return leading.group(1).lower()
     trailing = _TRAILING_PAREN_SHA_RE.search(stripped)
+    # Grok writes ``sha message``; prefer the leading token even when the
+    # commit message itself ends in ``(hex)``.
+    if kind == "git_commit":
+        if leading:
+            return leading.group(1).lower()
+        if trailing:
+            return trailing.group(1).lower()
+        return None
+    # Trajectory and merge-commit values put the real SHA in trailing parens.
+    # A message that happens to start with a hex token must not win.
     if trailing:
         return trailing.group(1).lower()
+    if leading:
+        return leading.group(1).lower()
     return None
 
 
@@ -670,7 +683,7 @@ class SessionRecord:
             if detail.get("kind") not in {"commit", "git_commit", "merge_commit"}:
                 continue
             value = detail.get("value")
-            commit_id = _commit_identity(value)
+            commit_id = _commit_identity(value, kind=detail.get("kind"))
             if commit_id is None:
                 anonymous_commit_values.add(str(value))
                 continue

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .deliverables import looks_like_sha
+
 # Harm category taxonomy (idea #191 — ESRRSim-inspired, 7×~3 subcategories).
 # See knowledge/technical-designs/dual-rubric-harm-category-taxonomy.md.
 HARM_CATEGORY_TAXONOMY: dict[str, str] = {
@@ -175,6 +177,58 @@ def compute_trajectory_grade(
     if denominator == 0.0:
         return None
     return numerator / denominator
+
+
+_TRAILING_PAREN_SHA_RE = re.compile(r"\(([0-9a-f]{7,40})\)\s*$", re.IGNORECASE)
+_LEADING_SHA_RE = re.compile(r"^([0-9a-f]{7,40})(?![0-9a-f])", re.IGNORECASE)
+_PR_URL_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)", re.IGNORECASE)
+_PR_NUMBER_RE = re.compile(r"PR\s+#(\d+)", re.IGNORECASE)
+
+
+def _commit_identity(value: object) -> str | None:
+    """Extract a SHA identity from a commit deliverable value.
+
+    Prefer the trailing parenthetical SHA used by trajectory producers
+    (``message (sha)``, ``merge-commit (sha)``) so hexadecimal tokens in the
+    commit message cannot override the actual identity. Fall back to a bare
+    SHA, then a leading SHA (Grok: ``sha message``).
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    trailing = _TRAILING_PAREN_SHA_RE.search(stripped)
+    if trailing:
+        return trailing.group(1).lower()
+    if looks_like_sha(stripped):
+        return stripped.lower()
+    leading = _LEADING_SHA_RE.match(stripped)
+    if leading:
+        return leading.group(1).lower()
+    return None
+
+
+def _remember_commit_id(commit_ids: list[str], commit_id: str) -> None:
+    """Record a SHA, merging short/full forms of the same hash."""
+    for known_id in commit_ids:
+        if commit_id.startswith(known_id) or known_id.startswith(commit_id):
+            return
+    commit_ids.append(commit_id)
+
+
+def _pr_identity(value: object) -> str:
+    """Stable identity for a pull-request deliverable."""
+    if not isinstance(value, str):
+        return str(value)
+    stripped = value.strip()
+    url = _PR_URL_RE.search(stripped)
+    if url:
+        return f"{url.group(1).lower()}/{url.group(2).lower()}#{url.group(3)}"
+    number = _PR_NUMBER_RE.search(stripped)
+    if number:
+        return f"#{number.group(1)}"
+    return stripped.lower()
 
 
 @dataclass
@@ -579,27 +633,28 @@ class SessionRecord:
         # identities; identical identity-less values also count once. PRs are
         # commit-bearing fallback evidence only when no commit detail exists.
         dd = self.deliverable_details or []
-        _sha_re = re.compile(r"(?<![0-9a-f])([0-9a-f]{7,40})(?![0-9a-f])", re.IGNORECASE)
         commit_ids: list[str] = []
         anonymous_commit_values: set[str] = set()
         for detail in dd:
             if detail.get("kind") not in {"commit", "git_commit", "merge_commit"}:
                 continue
             value = detail.get("value")
-            match = _sha_re.search(value) if isinstance(value, str) else None
-            if match is None:
+            commit_id = _commit_identity(value)
+            if commit_id is None:
                 anonymous_commit_values.add(str(value))
                 continue
-            commit_id = match.group(1).lower()
-            for known_id in commit_ids:
-                if commit_id.startswith(known_id) or known_id.startswith(commit_id):
-                    break
-            else:
-                commit_ids.append(commit_id)
+            _remember_commit_id(commit_ids, commit_id)
 
         commit_count = len(commit_ids) + len(anonymous_commit_values)
-        if commit_count == 0 and any(d.get("kind") == "pull_request" for d in dd):
-            commit_count = 1
+        if commit_count == 0:
+            pr_ids: list[str] = []
+            for detail in dd:
+                if detail.get("kind") != "pull_request":
+                    continue
+                pr_id = _pr_identity(detail.get("value"))
+                if pr_id not in pr_ids:
+                    pr_ids.append(pr_id)
+            commit_count = len(pr_ids)
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 
         # Partition on commit cardinality: 0 / 1 / 2+. Two-commit sessions

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -824,6 +824,64 @@ def test_step_types_two_distinct_commits_plus_pr_is_multi():
     assert "single_commit" not in labels
 
 
+def test_step_types_commit_message_hex_does_not_override_sha():
+    """Hex tokens in the commit message must not become the identity.
+
+    Regression for gptme/gptme-contrib#1565 Greptile P1: unanchored
+    ``search()`` picked the first 7+ hex token, collapsing two distinct
+    SHAs that shared a message token into single_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "commit", "value": "fix: revert deadbeef123 (aaa1111)"},
+            {"kind": "commit", "value": "fix: revert deadbeef123 (bbb2222)"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
+
+
+def test_step_types_two_pr_only_is_multi():
+    """Distinct PR-only deliveries keep their cardinality.
+
+    Regression for gptme/gptme-contrib#1565 Greptile P1: the no-commit
+    fallback hardcoded commit_count=1, collapsing two PRs into
+    single_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/3646",
+            },
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme-contrib/pull/1565",
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
+
+
 def test_step_types_pr_merge_pair_is_single_commit():
     """A PR and its merge commit are one logical delivery.
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -745,8 +745,87 @@ def test_step_types_commit_bearing_kinds(kind: str):
     assert "single_commit" in labels
 
 
+def test_step_types_deduplicates_same_commit_across_producers():
+    """Short/full SHA variants for one commit count as one logical delivery."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "git_commit",
+                "value": "48225d823 fix(cli): pass model alias",
+            },
+            {
+                "kind": "commit",
+                "value": "48225d823eba894164b90290cb7a6d2ecfaf3508",
+            },
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/3646",
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels
+    assert "multi_commit" not in labels
+
+
+def test_step_types_pr_only_is_single_commit():
+    """A PR without commit details still represents one commit-bearing delivery."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/3646",
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels
+    assert "no_commit" not in labels
+
+
+def test_step_types_two_distinct_commits_plus_pr_is_multi():
+    """PR metadata must not collapse two distinct commit identities."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "commit", "value": "1111111 first"},
+            {"kind": "git_commit", "value": "2222222 second"},
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/3646",
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
+
+
 def test_step_types_pr_merge_pair_is_single_commit():
-    """A paired pull_request + merge_commit is one logical delivery.
+    """A PR and its merge commit are one logical delivery.
 
     Regression for gptme/gptme-contrib#1564 Greptile P1: `gh pr merge`
     records both kinds, so entry-based counting stamped multi_commit.
@@ -780,7 +859,7 @@ def test_step_types_pr_merge_pair_is_single_commit():
 
 
 def test_step_types_pr_merge_pair_plus_commit_is_multi():
-    """A PR-merge pair plus a separate commit is still multi_commit."""
+    """A PR merge plus a separate commit is still multi_commit."""
     r = SessionRecord(
         session_id="step-types",
         span_aggregates={
@@ -809,12 +888,8 @@ def test_step_types_pr_merge_pair_plus_commit_is_multi():
     assert "single_commit" not in labels
 
 
-def test_step_types_unrelated_pr_and_merge_commit_not_paired():
-    """Independently sourced pull_request + merge_commit stay two deliveries.
-
-    Regression for gptme/gptme-contrib#1564 Greptile P1: count-only pairing
-    collapsed a PR URL and an unrelated merge_commit into single_commit.
-    """
+def test_step_types_pr_metadata_does_not_inflate_merge_commit():
+    """PR metadata beside one merge commit remains one logical delivery."""
     r = SessionRecord(
         session_id="step-types",
         span_aggregates={
@@ -830,8 +905,8 @@ def test_step_types_unrelated_pr_and_merge_commit_not_paired():
     )
     r.populate_step_types()
     labels = r.step_types or []
-    assert "multi_commit" in labels
-    assert "single_commit" not in labels
+    assert "single_commit" in labels
+    assert "multi_commit" not in labels
 
 
 def test_step_types_zero_spans_not_shallow():

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -850,6 +850,64 @@ def test_step_types_commit_message_hex_does_not_override_sha():
     assert "single_commit" not in labels
 
 
+def test_step_types_grok_leading_sha_not_overridden_by_message_paren():
+    """Grok ``sha message (hex)`` must keep the leading SHA as identity.
+
+    Regression for gptme/gptme-contrib#1565 Greptile P1 (round 2): preferring
+    trailing parenthetical SHA made ``abc1234 fix: revert change (deadbeef)``
+    disagree with caller evidence ``abc1234``, stamping multi_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "git_commit",
+                "value": "abc1234 fix: revert change (deadbeef)",
+            },
+            {"kind": "commit", "value": "abc1234"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels
+    assert "multi_commit" not in labels
+
+
+def test_step_types_pr_url_and_text_same_pr_is_single():
+    """URL and ``PR #N`` forms of the same PR are one delivery.
+
+    Regression for gptme/gptme-contrib#1565 Greptile P1 (round 2): when
+    merge-SHA resolution fails, ``owner/repo#N`` and ``#N`` were counted
+    as two deliveries.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/42",
+            },
+            {"kind": "pull_request", "value": "merge PR #42"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels
+    assert "multi_commit" not in labels
+
+
 def test_step_types_two_pr_only_is_multi():
     """Distinct PR-only deliveries keep their cardinality.
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -850,6 +850,60 @@ def test_step_types_commit_message_hex_does_not_override_sha():
     assert "single_commit" not in labels
 
 
+def test_step_types_trailing_sha_not_overridden_by_leading_message_token():
+    """Trajectory ``hex-token message (sha)`` must keep the trailing SHA.
+
+    Regression for gptme/gptme-contrib#1565 Greptile P1 (round 3): leading-SHA
+    precedence treated a hex token at the start of a trajectory commit message
+    as identity, collapsing two distinct trailing SHAs into single_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "commit", "value": "deadbeef123 fix: revert (aaa1111)"},
+            {"kind": "commit", "value": "deadbeef123 fix: revert (bbb2222)"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
+
+
+def test_step_types_grok_and_trajectory_same_sha_is_single():
+    """Grok leading SHA and trajectory trailing SHA for one hash are one delivery.
+
+    Kind-aware parsing is load-bearing: a global leading-SHA or trailing-SHA
+    rule would disagree across producers and stamp multi_commit.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "git_commit",
+                "value": "aaa1111 fix: revert change (deadbeef)",
+            },
+            {"kind": "commit", "value": "deadbeef123 fix: revert change (aaa1111)"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels
+    assert "multi_commit" not in labels
+
+
 def test_step_types_grok_leading_sha_not_overridden_by_message_paren():
     """Grok ``sha message (hex)`` must keep the leading SHA as identity.
 


### PR DESCRIPTION
## Summary

- deduplicate short/full SHA variants emitted for the same commit by trajectory and caller producers
- treat pull-request details as metadata when commit evidence already exists, while retaining PR-only sessions as commit-bearing
- preserve distinct SHA cardinality so genuinely multi-commit sessions remain `multi_commit`

## Evidence

The live SessionRecord ledger has 227 sessions carrying both commit details and PR metadata. Of those, 158 currently have two or more commit-detail entries but only one unique SHA, so entry counting labels them `multi_commit` even though they produced one commit. A representative record carries `48225d823 ...`, full SHA `48225d823eba...`, and PR #3646 for the same logical delivery.

## Tests

- `uv run --package gptme-sessions pytest -q packages/gptme-sessions/tests/test_record.py` (105 passed)
- `uv run ruff check packages/gptme-sessions/src/gptme_sessions/record.py packages/gptme-sessions/tests/test_record.py`
- `uv run ruff format --check packages/gptme-sessions/src/gptme_sessions/record.py packages/gptme-sessions/tests/test_record.py`

