### PR TITLE
feat(autonomous): upstream template runner scripts

### DIFF
--- a/scripts/runs/autonomous/autonomous-run-cc.sh
+++ b/scripts/runs/autonomous/autonomous-run-cc.sh
@@ -49,25 +49,38 @@ log() {
 }
 
 # --- Lock management ---
-LOCKFILE="/tmp/${AGENT_NAME,,}-autonomous.lock"
+LOCKFILE="${TMPDIR:-/tmp}/${AGENT_NAME,,}-autonomous.lock"
+LOCK_HELD=false
 
 acquire_lock() {
-    if [ -f "$LOCKFILE" ]; then
-        local pid
-        pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            log "ERROR: Another autonomous run is active (PID $pid)"
-            exit 1
-        fi
-        log "WARN: Stale lock from PID $pid, removing"
-        rm -f "$LOCKFILE"
+    if ! command -v flock >/dev/null 2>&1; then
+        log "ERROR: flock is required for exclusive autonomous runs"
+        exit 1
     fi
-    echo $$ > "$LOCKFILE"
+
+    exec 9>>"$LOCKFILE"
+    if ! flock -n 9; then
+        local pid
+        pid=$(cat "$LOCKFILE" 2>/dev/null || true)
+        exec 9>&-
+        log "ERROR: Another autonomous run is active (PID ${pid:-unknown})"
+        exit 1
+    fi
+
+    : > "$LOCKFILE"
+    printf '%s\n' "$$" >&9
+    LOCK_HELD=true
 }
 
 release_lock() {
     # shellcheck disable=SC2317  # Called by trap, not directly
-    rm -f "$LOCKFILE"
+    if [ "$LOCK_HELD" = true ]; then
+        # Keep the inode in place: unlinking a flock file can split later lockers
+        # across the old and newly-created inodes.
+        flock -u 9 2>/dev/null || true
+        exec 9>&-
+        LOCK_HELD=false
+    fi
 }
 
 trap release_lock EXIT INT TERM HUP
@@ -172,13 +185,14 @@ unset CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
 
 # Run Claude Code
 # IMPORTANT: </dev/null prevents SIGSTOP in non-interactive contexts (tmux, systemd)
+set +e
 timeout "$SCRIPT_TIMEOUT" claude -p \
     --dangerously-skip-permissions \
     --model "$MODEL" \
     --append-system-prompt-file "$SYSPROMPT_FILE" \
     "$PROMPT" </dev/null
-
 EXIT_CODE=$?
+set -e
 
 if [ $EXIT_CODE -eq 124 ]; then
     log "Session timed out after ${SCRIPT_TIMEOUT}s"

--- a/scripts/runs/autonomous/autonomous-run-cc.sh
+++ b/scripts/runs/autonomous/autonomous-run-cc.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Autonomous operation runner for Claude Code backend
+#
+# This script runs Claude Code in autonomous mode with the agent's system prompt
+# built from gptme.toml identity files + dynamic context.
+#
+# SETUP REQUIRED:
+# 1. Install Claude Code: npm install -g @anthropic-ai/claude-code
+# 2. Authenticate: claude /login (requires browser for OAuth)
+# 3. Customize AGENT_NAME and WORKSPACE below
+# 4. Set up systemd timer (see dotfiles/.config/systemd/user/)
+#
+# Usage:
+#   ./scripts/runs/autonomous/autonomous-run-cc.sh
+#   ./scripts/runs/autonomous/autonomous-run-cc.sh --model opus
+
+set -euo pipefail
+
+# === CONFIGURATION (CUSTOMIZE THESE) ===
+AGENT_NAME="YourAgent"
+WORKSPACE="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT_TIMEOUT=3000  # 50 minutes
+MODEL="sonnet"       # Default model (sonnet/opus/haiku)
+# ========================================
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model) MODEL="$2"; shift 2 ;;
+        --timeout) SCRIPT_TIMEOUT="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+# Load environment (nvm, pyenv, etc.)
+# Use || true because version managers may return non-zero in non-interactive shells
+if [ -f ~/.profile ]; then
+    # shellcheck source=/dev/null
+    source ~/.profile 2>/dev/null || true
+fi
+
+# Ensure bin/ is on PATH after profile sourcing so it survives any profile PATH reset
+export PATH="$WORKSPACE/bin:$PATH"
+
+cd "$WORKSPACE"
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# --- Lock management ---
+LOCKFILE="/tmp/${AGENT_NAME,,}-autonomous.lock"
+
+acquire_lock() {
+    if [ -f "$LOCKFILE" ]; then
+        local pid
+        pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            log "ERROR: Another autonomous run is active (PID $pid)"
+            exit 1
+        fi
+        log "WARN: Stale lock from PID $pid, removing"
+        rm -f "$LOCKFILE"
+    fi
+    echo $$ > "$LOCKFILE"
+}
+
+release_lock() {
+    # shellcheck disable=SC2317  # Called by trap, not directly
+    rm -f "$LOCKFILE"
+}
+
+trap release_lock EXIT INT TERM HUP
+acquire_lock
+
+log "=== $AGENT_NAME autonomous run starting (backend: claude-code, model: $MODEL) ==="
+
+# --- Git pull ---
+log "Pulling latest changes..."
+git pull --rebase --autostash 2>&1 || {
+    log "WARN: git pull failed, continuing with local state"
+}
+
+# --- Optional trigger gate ---
+run_session_gate() {
+    if [ "${SESSION_GATE_ENABLED:-false}" != "true" ]; then
+        return 0
+    fi
+
+    local gate_script="$WORKSPACE/scripts/runs/autonomous/session-gate.py"
+    if [ ! -f "$gate_script" ]; then
+        log "ERROR: SESSION_GATE_ENABLED=true but $gate_script is missing"
+        exit 2
+    fi
+
+    set +e
+    python3 "$gate_script" --workspace "$WORKSPACE" --verbose
+    local gate_status=$?
+    set -e
+
+    case "$gate_status" in
+        0)
+            log "Session gate found no triggers; skipping this scheduled run"
+            exit 0
+            ;;
+        1)
+            log "Session gate found triggers; continuing"
+            ;;
+        *)
+            log "ERROR: Session gate failed with exit code $gate_status"
+            exit "$gate_status"
+            ;;
+    esac
+}
+
+run_session_gate
+
+# --- Build system prompt ---
+SYSPROMPT_FILE=$(mktemp "/tmp/${AGENT_NAME,,}-sysprompt-XXXXXX")
+trap 'release_lock; rm -f "$SYSPROMPT_FILE"' EXIT INT TERM HUP
+
+log "Building system prompt from gptme.toml..."
+"$WORKSPACE/scripts/build-system-prompt.sh" > "$SYSPROMPT_FILE"
+
+SYSPROMPT_SIZE=$(wc -c < "$SYSPROMPT_FILE")
+log "System prompt: $SYSPROMPT_SIZE bytes"
+
+# --- Build user prompt ---
+PROMPT="You are $AGENT_NAME, starting an autonomous work session. Your identity files have been injected as system context — you don't need to re-read ABOUT.md, ARCHITECTURE.md, etc.
+
+## Workflow
+
+### Step 1: Assess loose ends
+Review the dynamic context (injected as system prompt) for:
+- Open PR comments or review requests needing response
+- Recently failed CI checks
+- Tasks marked as waiting or blocked that may be unblocked
+- Unfinished work from recent journal entries
+
+If there are loose ends that can be resolved quickly (< 5 min), handle them first.
+
+### Step 2: Select work
+Check task status for active, unblocked tasks. Prefer tasks already in progress.
+If all active tasks are blocked, look for self-improvement work:
+- GitHub issue triage
+- Cross-repo contributions
+- Code quality (run tests, fix regressions)
+- Task hygiene (close stale tasks, update metadata)
+- Documentation updates
+
+### Step 3: Execute
+Work on the selected task:
+- Make real, meaningful progress (commits, PRs, code changes)
+- Follow the git workflow: conventional commits, explicit file paths, \`git-safe-commit\` (in \`bin/\`) when committing
+- Update task state when done
+- Log progress in the journal (append-only)
+
+## Rules
+- You have ~50 minutes. Focus on shipping, not perfecting.
+- Commit early and often. Small, well-described commits.
+- Commit with explicit paths via \`git-safe-commit file1 file2 -m \"...\"\` — never \`git add .\` or \`git commit -a\`
+- Push commits to origin before ending the session.
+- If stuck on something for more than 10 minutes, move on.
+- Don't ask questions — make reasonable decisions and document them.
+- Use absolute paths for all file operations."
+
+log "Starting Claude Code session..."
+
+# Unset nested-session protection vars
+unset CLAUDECODE 2>/dev/null || true
+unset CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
+
+# Run Claude Code
+# IMPORTANT: </dev/null prevents SIGSTOP in non-interactive contexts (tmux, systemd)
+timeout "$SCRIPT_TIMEOUT" claude -p \
+    --dangerously-skip-permissions \
+    --model "$MODEL" \
+    --append-system-prompt-file "$SYSPROMPT_FILE" \
+    "$PROMPT" </dev/null
+
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 124 ]; then
+    log "Session timed out after ${SCRIPT_TIMEOUT}s"
+fi
+
+# Safety net: push any uncommitted work
+git push origin master 2>/dev/null || true
+
+log "=== $AGENT_NAME autonomous run finished (exit: $EXIT_CODE) ==="
+exit $EXIT_CODE

--- a/scripts/runs/autonomous/autonomous-run.sh
+++ b/scripts/runs/autonomous/autonomous-run.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Autonomous operation runner template for gptme agents
+# This script runs gptme in autonomous mode with conversation history and safety guidelines
+#
+# CUSTOMIZATION REQUIRED:
+# 1. Update AGENT_NAME with your agent's name
+# 2. Update WORKSPACE with your workspace path
+# 3. Update REPO_OWNER/REPO_NAME if using GitHub integration
+# 4. Customize the prompt template in the "Create autonomous operation prompt" section
+# 5. Adjust SCRIPT_TIMEOUT based on your scheduling needs
+#
+# CONCURRENT EXECUTION:
+# This script does NOT support concurrent execution.
+# Multiple simultaneous runs can cause git conflicts and file operation race conditions.
+# Implement a lock mechanism if scheduling frequent runs.
+
+set -e  # Exit on error
+
+# === CONFIGURATION (CUSTOMIZE THESE) ===
+AGENT_NAME="YourAgent"  # Replace with your agent's name
+WORKSPACE="/path/to/your/workspace"  # Replace with your workspace path
+# shellcheck disable=SC2034  # These are template placeholders for users to customize
+REPO_OWNER="your-github-username"  # Replace with your GitHub username
+# shellcheck disable=SC2034  # These are template placeholders for users to customize
+REPO_NAME="your-agent-workspace"  # Replace with your workspace repo name
+SCRIPT_TIMEOUT=3000  # 50 minutes in seconds (allows hourly scheduling with buffer)
+# ========================================
+
+# Function to log with timestamp
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# Cleanup function
+cleanup() {
+    # shellcheck disable=SC2317  # Called by trap, not directly
+    log "Cleaning up..."
+    # Kill any gptme child processes
+    # shellcheck disable=SC2317  # Called by trap, not directly
+    pkill -P $$ gptme 2>/dev/null || true
+    # shellcheck disable=SC2317  # Called by trap, not directly
+    sleep 1
+    # Clean up temporary prompt file
+    # shellcheck disable=SC2317  # Called by trap, not directly
+    [ -f "$PROMPT_FILE" ] && rm -f "$PROMPT_FILE"
+}
+
+# Ensure cleanup on exit
+trap cleanup EXIT
+trap 'log "ERROR: Script failed at line $LINENO"' ERR
+
+# Pull latest changes from remote
+log "Pulling latest changes from git..."
+cd "$WORKSPACE"
+# Compute REPO_DIR after cd so bin/ always resolves to the workspace repo
+REPO_DIR="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="$REPO_DIR/scripts"
+export PATH="$REPO_DIR/bin:$PATH"
+if ! git pull; then
+    log "WARNING: Git pull failed, continuing with current state"
+fi
+
+# Generate work queue from task files (if script exists)
+if [ -f "$SCRIPT_DIR/generate-work-queue.py" ]; then
+    log "Generating work queue from task files..."
+    "$SCRIPT_DIR/generate-work-queue.py" 2>&1 || log "⚠️  Work queue generation encountered issues"
+fi
+
+run_session_gate() {
+    if [ "${SESSION_GATE_ENABLED:-false}" != "true" ]; then
+        return 0
+    fi
+
+    local gate_script="$WORKSPACE/scripts/runs/autonomous/session-gate.py"
+    if [ ! -f "$gate_script" ]; then
+        log "ERROR: SESSION_GATE_ENABLED=true but $gate_script is missing"
+        exit 2
+    fi
+
+    set +e
+    python3 "$gate_script" --workspace "$WORKSPACE" --verbose
+    local gate_status=$?
+    set -e
+
+    case "$gate_status" in
+        0)
+            log "Session gate found no triggers; skipping this scheduled run"
+            exit 0
+            ;;
+        1)
+            log "Session gate found triggers; continuing"
+            ;;
+        *)
+            log "ERROR: Session gate failed with exit code $gate_status"
+            exit "$gate_status"
+            ;;
+    esac
+}
+
+run_session_gate
+
+# Enable chat history for context continuity
+export GPTME_CHAT_HISTORY=true
+
+log "Starting autonomous run (timeout: ${SCRIPT_TIMEOUT}s / 50 minutes)..."
+log "Workspace: $WORKSPACE"
+
+# Detect if this is a scheduled run or manual trigger
+if [ -n "$INVOCATION_ID" ]; then
+    RUN_TYPE="Scheduled (systemd)"
+else
+    RUN_TYPE="Manual"
+fi
+
+# Queue file paths (customize queue system as needed)
+# shellcheck disable=SC2034  # Template placeholders for agent customization
+MANUAL_QUEUE="$WORKSPACE/state/queue-manual.md"
+# shellcheck disable=SC2034  # Template placeholders for agent customization
+GENERATED_QUEUE="$WORKSPACE/state/queue-generated.md"
+
+PROMPT_FILE=/tmp/autonomous-prompt-$$.txt
+
+# Create autonomous operation prompt
+# CUSTOMIZE THIS SECTION with your agent's specific workflow and guidelines
+cat > "$PROMPT_FILE" <<EOF
+You are $AGENT_NAME, running autonomously.
+
+**Current Time**: $(date --iso=minutes)
+**Run Type**: $RUN_TYPE
+**Context Budget**: 200k tokens (use ~160k for work, save ~40k margin for completion)
+
+**Recent Activity**: You have summaries of recent conversations via GPTME_CHAT_HISTORY.
+
+## Required Workflow
+
+Focus on EXECUTION over planning. Three-step workflow optimized for doing work:
+
+**Step 1**: Quick Loose Ends Check (2-5 min max)
+- Check git status, critical notifications only
+- Fix only immediate blockers
+
+**Step 2**: Task Selection via CASCADE (5-10 min max)
+1. **PRIMARY**: Read state/queue-manual.md "Planned Next" section
+   - If empty or missing: Fall back to state/queue-generated.md
+2. **SECONDARY**: Check notifications for direct assignments
+3. **TERTIARY**: Check workspace tasks if PRIMARY/SECONDARY blocked
+4. **COMMIT to task** before completing Step 2
+
+**Step 3**: EXECUTION (20-30 min - the main focus!)
+- This is where the real work happens
+- Don't stop early - keep working until real blocker or token hint
+- Make substantial progress on the selected task
+- Verify your work (tests, CI checks, etc.)
+
+**Real Blocker Criteria** (STRICT - all three sources must be blocked):
+- Checked PRIMARY → All blocked
+- Checked SECONDARY → Nothing actionable
+- Checked TERTIARY → All blocked
+
+## Key Principles
+
+- **Verifiable Tasks**: Prioritize tasks with tests/CI/verification
+- **Efficient Selection**: <10 tool calls OR 20k tokens for Step 2
+- **Token Efficiency**:
+  - Read full files when <1000 lines (not partial with head/tail)
+  - Filter shell output with grep when expecting large dumps
+  - Concise session summaries (5-10 lines) without repeating work queue
+- **Absolute Paths**: Always use $WORKSPACE for workspace files
+
+## Git Workflow
+
+**For External Repos**:
+- MUST use worktrees for PRs
+- MUST read/create/update/comment on PRs
+- Never commit directly to master/main on external repos
+
+**For Workspace Repo**:
+- Can commit directly to master
+- Follow Conventional Commits format
+
+## Critical File Operations
+
+**Always use ABSOLUTE PATHS** for workspace files:
+- Correct: \`$WORKSPACE/journal/2025-10-19-topic.md\`
+- Wrong: \`journal/2025-10-19-topic.md\` (breaks when cwd changes)
+
+**Journal Location**:
+- Create in workspace: \`$WORKSPACE/journal/YYYY-MM-DD-topic.md\`
+- NEW topics = NEW files with descriptive names
+- NEVER create journal/ in external repos
+
+## Session Completion
+
+Keep documentation BRIEF (2-5 min max):
+1. Return to workspace: \`cd $WORKSPACE\`
+2. **Update work queue**: \`state/queue-manual.md\`
+   - One-line "Current Run" status
+   - Refresh "Planned Next" (3 tasks)
+   - Update timestamp
+3. Commit: \`git-safe-commit journal/<today>/*.md state/queue-manual.md -m "docs: session updates" && git push\`
+4. Use \`complete\` tool when finished
+
+Begin your autonomous work session now.
+EOF
+
+# Run gptme with the autonomous prompt (with timeout)
+log "Starting gptme session..."
+timeout "$SCRIPT_TIMEOUT" gptme --non-interactive "$PROMPT_FILE" 2>&1 || EXIT_CODE=$?
+EXIT_CODE=${EXIT_CODE:-0}
+
+# Check exit status
+if [ "$EXIT_CODE" -eq 0 ]; then
+    log "Autonomous run completed successfully"
+    exit 0
+elif [ "$EXIT_CODE" -eq 124 ]; then
+    log "WARNING: Autonomous run timed out after ${SCRIPT_TIMEOUT}s"
+    exit 124
+else
+    log "ERROR: Autonomous run failed with exit code $EXIT_CODE"
+    exit "$EXIT_CODE"
+fi

--- a/scripts/runs/autonomous/autonomous-run.sh
+++ b/scripts/runs/autonomous/autonomous-run.sh
@@ -106,7 +106,7 @@ log "Starting autonomous run (timeout: ${SCRIPT_TIMEOUT}s / 50 minutes)..."
 log "Workspace: $WORKSPACE"
 
 # Detect if this is a scheduled run or manual trigger
-if [ -n "$INVOCATION_ID" ]; then
+if [ -n "${INVOCATION_ID:-}" ]; then
     RUN_TYPE="Scheduled (systemd)"
 else
     RUN_TYPE="Manual"

--- a/tests/test_autonomous_runners.py
+++ b/tests/test_autonomous_runners.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNERS = ROOT / "scripts" / "runs" / "autonomous"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def _copy_runner(
+    name: str, workspace: Path, replacements: dict[str, str] | None = None
+) -> Path:
+    runner = workspace / "scripts" / "runs" / "autonomous" / name
+    runner.parent.mkdir(parents=True, exist_ok=True)
+    content = (RUNNERS / name).read_text()
+    for old, new in (replacements or {}).items():
+        assert old in content
+        content = content.replace(old, new)
+    runner.write_text(content)
+    runner.chmod(0o755)
+    return runner
+
+
+def _clean_environment(tmp_path: Path) -> dict[str, str]:
+    home = tmp_path / "home"
+    temp_dir = tmp_path / "tmp"
+    home.mkdir()
+    temp_dir.mkdir()
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "TMPDIR": str(temp_dir)})
+    env.pop("INVOCATION_ID", None)
+    return env
+
+
+def test_gptme_manual_run_allows_unset_invocation_id_under_nounset(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+    runner = _copy_runner(
+        "autonomous-run.sh",
+        workspace,
+        {
+            'AGENT_NAME="YourAgent"': 'AGENT_NAME="TestAgent"',
+            'WORKSPACE="/path/to/your/workspace"': f'WORKSPACE="{workspace}"',
+        },
+    )
+    call_log = tmp_path / "gptme-call.log"
+    _write_executable(
+        workspace / "bin" / "gptme",
+        '#!/bin/sh\ncat "$2" > "$GPTME_CALL_LOG"\n',
+    )
+    env = _clean_environment(tmp_path)
+    env["GPTME_CALL_LOG"] = str(call_log)
+
+    result = subprocess.run(
+        ["bash", "-u", str(runner)],
+        cwd=workspace,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "**Run Type**: Manual" in call_log.read_text()
+    assert "Autonomous run completed successfully" in result.stdout
+
+
+def _prepare_cc_runner(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runner = _copy_runner(
+        "autonomous-run-cc.sh",
+        workspace,
+        {'AGENT_NAME="YourAgent"': 'AGENT_NAME="TestAgent"'},
+    )
+    _write_executable(
+        workspace / "scripts" / "build-system-prompt.sh",
+        '#!/bin/sh\nprintf "test system prompt\\n"\n',
+    )
+    _write_executable(
+        workspace / "bin" / "git",
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$GIT_CALL_LOG"\n',
+    )
+    _write_executable(
+        workspace / "bin" / "claude",
+        """#!/bin/sh
+if [ "${CLAUDE_MODE:-exit}" = "hold" ]; then
+    : > "$CLAUDE_STARTED_FILE"
+    while [ ! -f "$CLAUDE_RELEASE_FILE" ]; do
+        sleep 0.02
+    done
+elif [ "${CLAUDE_MODE:-exit}" = "spin" ]; then
+    while :; do :; done
+fi
+exit "${CLAUDE_EXIT_CODE:-0}"
+""",
+    )
+    env = _clean_environment(tmp_path)
+    git_log = tmp_path / "git-call.log"
+    env["GIT_CALL_LOG"] = str(git_log)
+    return runner, git_log, env
+
+
+@pytest.mark.parametrize(
+    ("mode", "claude_exit", "runner_args", "expected_exit", "expected_log"),
+    [
+        ("exit", "17", [], 17, "finished (exit: 17)"),
+        ("spin", "0", ["--timeout", "0.05"], 124, "timed out after 0.05s"),
+    ],
+)
+def test_cc_failure_paths_still_push_and_log_completion(
+    tmp_path: Path,
+    mode: str,
+    claude_exit: str,
+    runner_args: list[str],
+    expected_exit: int,
+    expected_log: str,
+) -> None:
+    runner, git_log, env = _prepare_cc_runner(tmp_path)
+    env.update({"CLAUDE_MODE": mode, "CLAUDE_EXIT_CODE": claude_exit})
+
+    result = subprocess.run(
+        [str(runner), *runner_args],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=10,
+    )
+
+    assert result.returncode == expected_exit, result.stdout
+    assert "push origin master" in git_log.read_text().splitlines()
+    assert expected_log in result.stdout
+    assert f"finished (exit: {expected_exit})" in result.stdout
+
+
+def test_cc_runner_lock_excludes_overlapping_processes(tmp_path: Path) -> None:
+    runner, _, env = _prepare_cc_runner(tmp_path)
+    started = tmp_path / "claude-started"
+    release = tmp_path / "claude-release"
+    env.update(
+        {
+            "CLAUDE_MODE": "hold",
+            "CLAUDE_STARTED_FILE": str(started),
+            "CLAUDE_RELEASE_FILE": str(release),
+        }
+    )
+
+    first = subprocess.Popen(
+        [str(runner)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not started.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert started.exists(), "first runner did not reach Claude"
+
+        second = subprocess.run(
+            [str(runner)],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=5,
+        )
+
+        assert second.returncode == 1
+        assert "Another autonomous run is active" in second.stdout
+    finally:
+        release.touch()
+        first_stdout, _ = first.communicate(timeout=5)
+
+    assert first.returncode == 0, first_stdout
+
+    third = subprocess.run(
+        [str(runner)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=5,
+    )
+    assert third.returncode == 0, third.stdout


### PR DESCRIPTION
## What changed

- add the generic gptme and Claude Code autonomous runner templates under `scripts/runs/autonomous/`
- make gptme-contrib the canonical implementation source for agent templates

## Why

Companion gptme/gptme-agent-template#80 added session-gate wiring by carrying custom copies of both runners in the template repo. That violates the template fork invariant: reusable scripts belong here, while the template should expose symlinks into its contrib submodule.

After this lands, gptme/gptme-agent-template#80 can point both runner paths here and retain only template-specific tests/docs.

## Validation

- `ruff check scripts/runs/autonomous/session-gate.py tests/test_session_gate.py`
- `ruff format --check scripts/runs/autonomous/session-gate.py tests/test_session_gate.py`
- `shellcheck scripts/runs/autonomous/autonomous-run.sh scripts/runs/autonomous/autonomous-run-cc.sh`
- `uv run --with pytest python3 -m pytest tests/test_session_gate.py -q`
- scoped `prek` hooks via commit
- PR quality gate: 100/100