### PR TITLE
feat(gptme-sessions): persist Pi route metadata

### DIFF
--- a/packages/gptme-sessions/README.md
+++ b/packages/gptme-sessions/README.md
@@ -3,7 +3,9 @@
 Session tracking and analytics for agents. Supports trajectories from gptme,
 Claude Code, Codex, Copilot, Grok Build, and Pi native v3 sessions.
 
-Provides an append-only JSONL-based session record system that any agent can use to track operational metadata across sessions: which harness ran, what model was used, what type of work was done, and the outcome.
+Provides an append-only JSONL-based session record system that any agent can use
+to track operational metadata across sessions: which harness and inference
+provider ran, what model was used, what type of work was done, and the outcome.
 
 ## Installation
 
@@ -24,11 +26,14 @@ store = SessionStore(sessions_dir=Path("state/sessions"))
 
 # Append a session record
 store.append(SessionRecord(
-    harness="claude-code",
-    model="opus",
+    harness="pi",
+    provider="openai-codex",
+    model="gpt-5.6-luna",
     run_type="autonomous",
     category="code",
     outcome="productive",
+    stop_reason="stop",
+    cost_usd=0.0004264,
     duration_seconds=2400,
     deliverables=["abc123"],
 ))
@@ -114,8 +119,13 @@ Model names are automatically normalized to short canonical forms:
 Records are stored as append-only JSONL (one JSON object per line):
 
 ```jsonl
-{"session_id":"a1b2c3d4","timestamp":"2026-03-04T12:00:00+00:00","harness":"claude-code","model":"opus","run_type":"autonomous","category":"code","outcome":"productive","duration_seconds":2400,"deliverables":["abc123"]}
+{"session_id":"a1b2c3d4","timestamp":"2026-08-31T12:00:00+00:00","harness":"pi","provider":"openai-codex","model":"gpt-5.6-luna","run_type":"autonomous","category":"code","outcome":"productive","stop_reason":"stop","cost_usd":0.0004264,"duration_seconds":2400,"deliverables":["abc123"]}
 ```
+
+`cost_usd` is the USD-equivalent cost reported by the harness. With OAuth or
+subscription access it can be a nominal API-equivalent value rather than an
+incremental charge on the subscription invoice. Missing cost is `null`; a
+reported `0.0` is retained as a real observation.
 
 ## Extending
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -46,10 +46,16 @@ from .store import (
 logger = logging.getLogger(__name__)
 
 HARNESS_CHOICES = ["gptme", "claude-code", "codex", "copilot-cli"]
+# Pi can already be recorded from an explicitly supplied native trajectory.
+# Automatic Pi discovery remains a separate retention slice.
+POST_SESSION_HARNESS_CHOICES = [*HARNESS_CHOICES, "pi"]
 
 # Maps usage dict keys (from extract_from_path) to SessionRecord field names.
 _USAGE_FIELD_MAP: dict[str, str] = {
     "model": "model",
+    "provider": "provider",
+    "cost": "cost_usd",
+    "stop_reason": "stop_reason",
     "total_tokens": "token_count",
     "input_tokens": "input_tokens",
     "output_tokens": "output_tokens",
@@ -70,6 +76,10 @@ def _assign_if_missing(record: SessionRecord, field: str, value: object) -> bool
     if value is None:
         return False
     current = getattr(record, field)
+    # Zero is an observed cost, especially for local/subscription providers.
+    # It must not be treated as an empty value and replaced during a later sync.
+    if field == "cost_usd" and current is not None:
+        return False
     if isinstance(current, list):
         if current:
             return False
@@ -2314,8 +2324,8 @@ def repair_grades(ctx: click.Context, dry_run: bool) -> None:
 @click.option(
     "--harness",
     required=True,
-    type=click.Choice(HARNESS_CHOICES),
-    help="Harness name (claude-code, gptme, codex, copilot)",
+    type=click.Choice(POST_SESSION_HARNESS_CHOICES),
+    help="Harness name (claude-code, gptme, codex, copilot, pi)",
 )
 @click.option("--model", default="unknown", help="Model name")
 @click.option("--run-type", default="unknown", help="Run type (autonomous, etc.)")
@@ -2422,6 +2432,10 @@ def post_session_cmd(
                     "session_id": ps.record.session_id,
                     "outcome": ps.record.outcome,
                     "grade": ps.grade,
+                    "provider": ps.provider,
+                    "model": ps.record.model,
+                    "stop_reason": ps.stop_reason,
+                    "cost_usd": ps.cost_usd,
                     "token_count": ps.token_count,
                 }
             )

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -70,6 +70,50 @@ _USAGE_FIELD_MAP: dict[str, str] = {
     "session_total_bytes": "session_total_bytes",
 }
 
+# Fields whose absence should trigger ``sync --signals`` re-extraction.
+# Missing fields that a harness never emits must not keep backfill true forever.
+_COPILOT_BACKFILL_FIELDS: tuple[str, ...] = (
+    "model",
+    "sys_prompt_bytes",
+    "first_turn_bytes",
+    "context_peak_bytes",
+    "session_total_bytes",
+)
+_DEFAULT_BACKFILL_FIELDS: tuple[str, ...] = (
+    "token_count",
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_tokens",
+    "cache_read_tokens",
+    "sys_prompt_tokens",
+    "context_peak_tokens",
+    "context_window",
+    "sys_prompt_bytes",
+    "first_turn_bytes",
+    "context_peak_bytes",
+    "session_total_bytes",
+)
+_PI_ROUTE_BACKFILL_FIELDS: tuple[str, ...] = (
+    "provider",
+    "stop_reason",
+    "cost_usd",
+)
+
+
+def _usage_backfill_fields(harness: str | None) -> tuple[str, ...]:
+    """Record fields that ``sync --signals`` should backfill for ``harness``.
+
+    Copilot trajectories never contain token-count fields — only byte metrics
+    and model name are extractable. Pi extractors populate provider, stop
+    reason, and reported cost; skipping those on an otherwise complete record
+    leaves route metadata absent from the durable store and JSON/CSV exports.
+    """
+    if harness == "copilot-cli":
+        return _COPILOT_BACKFILL_FIELDS
+    if harness == "pi":
+        return _DEFAULT_BACKFILL_FIELDS + _PI_ROUTE_BACKFILL_FIELDS
+    return _DEFAULT_BACKFILL_FIELDS
+
 
 def _assign_if_missing(record: SessionRecord, field: str, value: object) -> bool:
     """Set ``record.field`` when it is empty/unknown and ``value`` is usable."""
@@ -2127,34 +2171,9 @@ def sync(
                 existing.project = entry["project"]
                 needs_update = True
 
-            # Copilot trajectories never contain token-count fields — only byte
-            # metrics and model name are extractable. Checking token fields for
-            # copilot-cli sessions would keep usage_backfill_needed=True forever.
-            if existing.harness == "copilot-cli":
-                _backfill_fields: tuple[str, ...] = (
-                    "model",
-                    "sys_prompt_bytes",
-                    "first_turn_bytes",
-                    "context_peak_bytes",
-                    "session_total_bytes",
-                )
-            else:
-                _backfill_fields = (
-                    "token_count",
-                    "input_tokens",
-                    "output_tokens",
-                    "cache_creation_tokens",
-                    "cache_read_tokens",
-                    "sys_prompt_tokens",
-                    "context_peak_tokens",
-                    "context_window",
-                    "sys_prompt_bytes",
-                    "first_turn_bytes",
-                    "context_peak_bytes",
-                    "session_total_bytes",
-                )
             usage_backfill_needed = any(
-                getattr(existing, field) is None for field in _backfill_fields
+                getattr(existing, field) is None
+                for field in _usage_backfill_fields(existing.harness)
             )
 
             if (

--- a/packages/gptme-sessions/src/gptme_sessions/cost.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cost.py
@@ -62,11 +62,15 @@ _PRICING_CONFIG: object = _UNSET
 
 
 def estimate_record_cost(record: "SessionRecord") -> float | None:
-    """Estimate USD cost for a single session record.
+    """Return reported USD cost, or estimate it from usage when absent.
 
-    Returns None if gptme-usage is not installed, pricing is unknown,
+    A harness-reported ``cost_usd`` is authoritative, including a real zero.
+    Otherwise returns None if gptme-usage is not installed, pricing is unknown,
     or the record lacks token data.
     """
+    if record.cost_usd is not None:
+        return float(record.cost_usd)
+
     try:
         from gptme_usage.harness_models import estimate_session_cost
     except ImportError:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -228,8 +228,8 @@ class PostSessionResult:
                                ``None`` if no trajectory was available.
         signals:               Raw signal dict from :func:`~gptme_sessions.signals.extract_from_path`,
                                or ``None`` if no trajectory was available.
-        token_count:           Total token count from the trajectory (CC format only),
-                               or ``None`` if not available.
+        token_count:           Total token count from the trajectory, or ``None`` if
+                               not available.
         input_tokens:          Input tokens from usage breakdown, or ``None`` if not present.
         output_tokens:         Output tokens from usage breakdown, or ``None`` if not present.
         cache_creation_tokens: Cache-write tokens, or ``None`` if not present.
@@ -241,6 +241,10 @@ class PostSessionResult:
         first_turn_bytes:      All messages before first assistant message (UTF-8 bytes).
         context_peak_bytes:    Max per-turn context bytes before assistant.
         session_total_bytes:   Total bytes of all message content.
+        provider:              Raw inference provider reported by the trajectory.
+        stop_reason:           Harness-native final assistant stop reason.
+        cost_usd:              Harness-reported USD-equivalent cost. For subscription
+                               providers this may be nominal rather than billed spend.
     """
 
     record: SessionRecord
@@ -258,6 +262,10 @@ class PostSessionResult:
     first_turn_bytes: int | None = None
     context_peak_bytes: int | None = None
     session_total_bytes: int | None = None
+    # Keep additive result metadata at the tail for positional compatibility.
+    provider: str | None = None
+    stop_reason: str | None = None
+    cost_usd: float | None = None
 
 
 def post_session(
@@ -410,6 +418,9 @@ def post_session(
 
     grade: float | None = None
     signals: dict[str, Any] | None = None
+    provider: str | None = None
+    stop_reason: str | None = None
+    cost_usd: float | None = None
     token_count: int | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
@@ -445,6 +456,15 @@ def post_session(
                 gen_ms_total = _traj_timings.get("gen_ms_total")
                 tool_ms_total = _traj_timings.get("tool_ms_total")
             if usage:
+                _provider = usage.get("provider")
+                _stop_reason = usage.get("stop_reason")
+                _cost = usage.get("cost")
+                if isinstance(_provider, str) and _provider:
+                    provider = _provider
+                if isinstance(_stop_reason, str) and _stop_reason:
+                    stop_reason = _stop_reason
+                if not isinstance(_cost, bool) and isinstance(_cost, (int, float)):
+                    cost_usd = float(_cost)
                 _in = usage.get("input_tokens")
                 _out = usage.get("output_tokens")
                 _cc = usage.get("cache_creation_tokens")
@@ -702,8 +722,7 @@ def post_session(
             len(caller_deliverables),
         )
         outcome_flip_reason = (
-            f"no_trajectory_caller_deliverables:{outcome}"
-            f"->productive:n={len(caller_deliverables)}"
+            f"no_trajectory_caller_deliverables:{outcome}->productive:n={len(caller_deliverables)}"
         )
         outcome = "productive"
 
@@ -739,6 +758,12 @@ def post_session(
         "deliverables": deliverables,
         "deliverable_details": deliverable_details,
     }
+    if provider is not None:
+        record_kwargs["provider"] = provider
+    if stop_reason is not None:
+        record_kwargs["stop_reason"] = stop_reason
+    if cost_usd is not None:
+        record_kwargs["cost_usd"] = cost_usd
     if outcome_flip_reason is not None:
         record_kwargs["outcome_flip_reason"] = outcome_flip_reason
     if context_tier is not None:
@@ -880,6 +905,9 @@ def post_session(
         record=record,
         grade=grade,
         signals=signals,
+        provider=provider,
+        stop_reason=stop_reason,
+        cost_usd=cost_usd,
         token_count=token_count,
         input_tokens=input_tokens,
         output_tokens=output_tokens,

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -200,7 +200,7 @@ class SessionRecord:
     project: str | None = None  # workspace/project path
 
     # Operational context
-    harness: str | None = "unknown"  # claude-code, gptme, codex
+    harness: str | None = "unknown"  # claude-code, gptme, codex, pi
     model: str | None = "unknown"  # raw model string (e.g. claude-opus-4-6)
     context_tier: str | None = None  # standard, extended, large, massive
     ab_group: str | None = None  # A/B group assignment ("treatment" or "control")
@@ -318,6 +318,14 @@ class SessionRecord:
     # post_session() from the hook's per-session events file. Empty for
     # harnesses that don't run the hook.
     lesson_events: list[dict[str, Any]] = field(default_factory=list)
+
+    # Additive route metadata. Keep new public fields at the dataclass tail so
+    # existing positional SessionRecord constructors retain their old mapping.
+    provider: str | None = None  # raw inference provider (e.g. openai-codex, xai)
+    stop_reason: str | None = None  # harness-native final assistant stop reason
+    # Harness-reported USD-equivalent cost. For subscription/OAuth providers
+    # this may be nominal API-equivalent cost, not incremental billed spend.
+    cost_usd: float | None = None
 
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1637,3 +1637,98 @@ class TestFmtSince:
         from gptme_sessions.cli import _fmt_since
 
         assert _fmt_since(since_days) == expected
+
+
+class TestSyncRouteBackfill:
+    """sync --signals must backfill Pi route metadata on complete legacy records."""
+
+    def test_usage_backfill_fields_include_pi_route_metadata(self) -> None:
+        from gptme_sessions.cli import _usage_backfill_fields
+
+        pi_fields = _usage_backfill_fields("pi")
+        assert "provider" in pi_fields
+        assert "stop_reason" in pi_fields
+        assert "cost_usd" in pi_fields
+        assert "token_count" in pi_fields
+
+        copilot_fields = _usage_backfill_fields("copilot-cli")
+        assert "provider" not in copilot_fields
+        assert "stop_reason" not in copilot_fields
+        assert "cost_usd" not in copilot_fields
+        assert "token_count" not in copilot_fields
+
+        gptme_fields = _usage_backfill_fields("gptme")
+        assert "provider" not in gptme_fields
+        assert "cost_usd" not in gptme_fields
+        assert "token_count" in gptme_fields
+
+    def test_sync_signals_backfills_pi_route_metadata_for_existing_known_record(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        from gptme_sessions.cli import main
+
+        fake_file = tmp_path / "session.jsonl"
+        fake_file.touch()
+
+        monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [])
+        monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [fake_file])
+        monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [])
+        monkeypatch.setattr("gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [])
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda p: {
+                "productive": True,
+                "session_duration_s": 90,
+                "deliverables": [],
+                "inferred_category": "code",
+                "usage": {
+                    "provider": "xai",
+                    "model": "grok-4.6",
+                    "cost": 0.0,
+                    "stop_reason": "stop",
+                },
+            },
+        )
+
+        sessions_dir = tmp_path / "sessions"
+        store = SessionStore(sessions_dir=sessions_dir)
+        store.append(
+            SessionRecord(
+                harness="pi",
+                trajectory_path=str(fake_file),
+                outcome="productive",
+                duration_seconds=90,
+                token_count=1200,
+                input_tokens=800,
+                output_tokens=400,
+                cache_creation_tokens=10,
+                cache_read_tokens=20,
+                sys_prompt_tokens=100,
+                context_peak_tokens=900,
+                context_window=128000,
+                sys_prompt_bytes=400,
+                first_turn_bytes=800,
+                context_peak_bytes=800,
+                session_total_bytes=1600,
+            )
+        )
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["gptme-sessions", "--sessions-dir", str(sessions_dir), "sync", "--signals"],
+        )
+        rc = main()
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "updated 1" in captured.out
+
+        records = store.load_all()
+        assert len(records) == 1
+        assert records[0].outcome == "productive"
+        assert records[0].provider == "xai"
+        assert records[0].model == "grok-4.6"
+        assert records[0].cost_usd == 0.0
+        assert records[0].stop_reason == "stop"

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -178,6 +178,34 @@ class TestExportCommand:
         assert len(data) == 5
         assert {row["session_id"] for row in data}
 
+    def test_export_preserves_pi_route_metadata(self, tmp_path: Path):
+        """Both structured export formats retain exact Pi route metadata."""
+        SessionStore(sessions_dir=tmp_path).append(
+            SessionRecord(
+                harness="pi",
+                provider="xai",
+                model="grok-4.6",
+                stop_reason="stop",
+                cost_usd=0.000824,
+            )
+        )
+
+        json_rc, json_out = _invoke(["export", "--format", "json"], tmp_path)
+        assert json_rc == 0
+        json_row = json.loads(json_out)[0]
+        assert json_row["provider"] == "xai"
+        assert json_row["model"] == "grok-4.6"
+        assert json_row["stop_reason"] == "stop"
+        assert json_row["cost_usd"] == pytest.approx(0.000824)
+
+        csv_rc, csv_out = _invoke(["export", "--format", "csv"], tmp_path)
+        assert csv_rc == 0
+        csv_row = next(csv.DictReader(StringIO(csv_out)))
+        assert csv_row["provider"] == "xai"
+        assert csv_row["model"] == "grok-4.6"
+        assert csv_row["stop_reason"] == "stop"
+        assert float(csv_row["cost_usd"]) == pytest.approx(0.000824)
+
     def test_export_json_since_7d(self, tmp_path: Path):
         """export --format json --since 7d drops records older than the window."""
         store = _seed_store(tmp_path)

--- a/packages/gptme-sessions/tests/test_cost.py
+++ b/packages/gptme-sessions/tests/test_cost.py
@@ -38,6 +38,18 @@ def _make_record(
 
 
 class TestEstimateRecordCost:
+    def test_prefers_harness_reported_cost(self):
+        """A reported cost bypasses model pricing, including unknown models."""
+        record = _make_record(model="completely-unknown-model", input_tokens=None)
+        record.cost_usd = 0.0123
+        assert estimate_record_cost(record) == 0.0123
+
+    def test_reported_zero_is_authoritative(self):
+        """A real zero must not fall through to a nonzero token estimate."""
+        record = _make_record(input_tokens=1_000_000, output_tokens=1_000_000)
+        record.cost_usd = 0.0
+        assert estimate_record_cost(record) == 0.0
+
     def test_no_crash_with_real_gptme_usage(self):
         """estimate_record_cost doesn't raise — returns float or None."""
         record = _make_record()

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from gptme_sessions.post_session import post_session
+from gptme_sessions.post_session import PostSessionResult, post_session
+from gptme_sessions.record import SessionRecord
 from gptme_sessions.store import SessionStore
 
 # gptme_sessions/__init__.py re-exports 'post_session' (function), shadowing the
@@ -15,6 +16,16 @@ from gptme_sessions.store import SessionStore
 # from gptme_sessions.post_session import post_session ensures the module is in
 # sys.modules, so we can retrieve it directly for patch.object calls.
 _post_session_mod = sys.modules["gptme_sessions.post_session"]
+
+
+def test_post_session_result_route_metadata_does_not_shift_positional_fields():
+    """Additive result fields preserve the established constructor prefix."""
+    result = PostSessionResult(SessionRecord(), None, None, 123, 45, 67)
+
+    assert result.token_count == 123
+    assert result.input_tokens == 45
+    assert result.output_tokens == 67
+    assert result.provider is None
 
 
 def test_post_session_context_tier(tmp_path: Path):
@@ -233,6 +244,66 @@ def test_post_session_model_fallback_from_signals(tmp_path: Path):
             trajectory_path=fake_traj,
         )
     assert result.record.model == "claude-sonnet-4-6"
+
+
+def test_post_session_persists_pi_route_metadata(tmp_path: Path):
+    """Pi provider/model/cost/stop metadata reaches the canonical store."""
+    store = SessionStore(sessions_dir=tmp_path)
+    trajectory = Path(__file__).parent / "fixtures" / "pi" / "productive-codex.jsonl"
+
+    result = post_session(
+        store=store,
+        harness="pi",
+        model="unknown",
+        trajectory_path=trajectory,
+    )
+
+    assert result.provider == "openai-codex"
+    assert result.record.provider == "openai-codex"
+    assert result.record.model == "gpt-5.6-luna"
+    assert result.stop_reason == "stop"
+    assert result.record.stop_reason == "stop"
+    assert result.cost_usd == pytest.approx(0.0004264)
+    assert result.record.cost_usd == pytest.approx(0.0004264)
+
+    persisted = SessionStore(sessions_dir=tmp_path).load_all()
+    assert len(persisted) == 1
+    assert persisted[0].provider == "openai-codex"
+    assert persisted[0].model == "gpt-5.6-luna"
+    assert persisted[0].stop_reason == "stop"
+    assert persisted[0].cost_usd == pytest.approx(0.0004264)
+
+
+@pytest.mark.parametrize(
+    ("reported_cost", "expected_cost"),
+    [(0.0, 0.0), (None, None)],
+)
+def test_post_session_preserves_zero_vs_missing_cost(
+    tmp_path: Path, reported_cost: float | None, expected_cost: float | None
+):
+    """A reported zero remains distinct from unavailable cost data."""
+    store = SessionStore(sessions_dir=tmp_path)
+    trajectory = tmp_path / "trajectory.jsonl"
+    trajectory.touch()
+    usage = {"model": "grok-4.6"}
+    if reported_cost is not None:
+        usage["cost"] = reported_cost
+
+    with patch.object(
+        _post_session_mod,
+        "extract_from_path",
+        return_value={"productive": True, "usage": usage},
+    ):
+        result = post_session(
+            store=store,
+            harness="pi",
+            model="unknown",
+            trajectory_path=trajectory,
+        )
+
+    assert result.cost_usd == expected_cost
+    assert result.record.cost_usd == expected_cost
+    assert SessionStore(sessions_dir=tmp_path).load_all()[0].cost_usd == expected_cost
 
 
 def test_post_session_populates_productivity_grade(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -33,6 +33,48 @@ def test_context_tier_roundtrip():
     assert r2.context_tier == "massive"
 
 
+def test_provider_cost_and_stop_reason_roundtrip():
+    """Observed route metadata survives dict and JSONL serialization."""
+    record = SessionRecord(
+        harness="pi",
+        provider="openai-codex",
+        model="gpt-5.6-luna",
+        stop_reason="stop",
+        cost_usd=0.0,
+    )
+
+    as_dict = record.to_dict()
+    assert as_dict["provider"] == "openai-codex"
+    assert as_dict["stop_reason"] == "stop"
+    assert as_dict["cost_usd"] == 0.0
+
+    restored = SessionRecord.from_dict(json.loads(record.to_json()))
+    assert restored.provider == "openai-codex"
+    assert restored.model == "gpt-5.6-luna"
+    assert restored.stop_reason == "stop"
+    assert restored.cost_usd == 0.0
+
+
+def test_route_metadata_does_not_shift_existing_positional_fields():
+    """Additive fields must not change the established constructor prefix."""
+    record = SessionRecord(
+        "session-id",
+        "2026-08-31T12:00:00+00:00",
+        None,
+        None,
+        "session-name",
+        "/workspace",
+        "codex",
+        "gpt-5.4",
+        "large",
+    )
+
+    assert record.harness == "codex"
+    assert record.model == "gpt-5.4"
+    assert record.context_tier == "large"
+    assert record.provider is None
+
+
 def test_deliverable_details_roundtrip():
     """deliverable_details survives to_dict/from_dict round-trip."""
     r = SessionRecord(

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3572,6 +3572,46 @@ def test_post_session_cli_basic(tmp_path: Path, capsys, monkeypatch):
     assert records[0].outcome == "unknown"
 
 
+def test_post_session_cli_accepts_pi_with_explicit_trajectory(tmp_path: Path, capsys, monkeypatch):
+    """Pi recording works before automatic Pi discovery is implemented."""
+    import sys
+
+    from gptme_sessions.cli import main
+
+    trajectory = Path(__file__).parent / "fixtures" / "pi" / "productive-codex.jsonl"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "gptme-sessions",
+            "--sessions-dir",
+            str(tmp_path),
+            "post-session",
+            "--harness",
+            "pi",
+            "--trajectory",
+            str(trajectory),
+            "--json",
+        ],
+    )
+
+    assert main() == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["outcome"] == "productive"
+    assert output["provider"] == "openai-codex"
+    assert output["model"] == "gpt-5.6-luna"
+    assert output["stop_reason"] == "stop"
+    assert output["cost_usd"] == pytest.approx(0.0004264)
+
+    records = SessionStore(sessions_dir=tmp_path).load_all()
+    assert len(records) == 1
+    assert records[0].harness == "pi"
+    assert records[0].provider == "openai-codex"
+    assert records[0].model == "gpt-5.6-luna"
+    assert records[0].stop_reason == "stop"
+    assert records[0].cost_usd == pytest.approx(0.0004264)
+
+
 def test_post_session_cli_timeout_exit_code(tmp_path: Path, capsys, monkeypatch):
     """CLI post-session: exit code 124 with no evidence → unknown."""
     import sys
@@ -3596,6 +3636,8 @@ def test_post_session_cli_timeout_exit_code(tmp_path: Path, capsys, monkeypatch)
     assert rc == 0
     captured = capsys.readouterr()
     assert "outcome=unknown" in captured.out
+    records = SessionStore(sessions_dir=tmp_path).load_all()
+    assert records[0].stop_reason is None
 
 
 def test_post_session_cli_json_output(tmp_path: Path, capsys, monkeypatch):
@@ -6404,6 +6446,61 @@ def test_assign_if_missing_no_false_positive_on_zero():
     changed = _assign_if_missing(record, "duration_seconds", 42)
     assert changed
     assert record.duration_seconds == 42
+
+
+def test_extract_result_populates_pi_route_metadata_for_new_record():
+    """sync maps Pi route metadata onto a newly discovered session record."""
+    from gptme_sessions.cli import _apply_extract_result_to_kwargs
+
+    record_kwargs: dict = {}
+    _apply_extract_result_to_kwargs(
+        record_kwargs,
+        {
+            "productive": True,
+            "usage": {
+                "provider": "xai",
+                "model": "grok-4.6",
+                "cost": 0.0,
+                "stop_reason": "stop",
+            },
+        },
+    )
+
+    assert record_kwargs["provider"] == "xai"
+    assert record_kwargs["model"] == "grok-4.6"
+    assert record_kwargs["cost_usd"] == 0.0
+    assert record_kwargs["stop_reason"] == "stop"
+
+
+def test_extract_result_does_not_replace_observed_zero_cost():
+    """sync backfill treats zero as observed cost, not a missing sentinel."""
+    from gptme_sessions.cli import _apply_extract_result_to_record
+
+    record = SessionRecord(
+        harness="pi",
+        provider=None,
+        model="unknown",
+        cost_usd=0.0,
+        stop_reason=None,
+    )
+    changed = _apply_extract_result_to_record(
+        record,
+        {
+            "productive": False,
+            "usage": {
+                "provider": "openai-codex",
+                "model": "gpt-5.6-luna",
+                "cost": 1.25,
+                "stop_reason": "stop",
+            },
+        },
+    )
+
+    assert changed
+    assert record.provider == "openai-codex"
+    assert record.model == "gpt-5.6-luna"
+    assert record.cost_usd == 0.0
+    assert record.stop_reason == "stop"
 
 
 def test_sync_signals_backfills_existing_records(tmp_path: Path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary

- persist Pi provider, model, final stop reason, and harness-reported USD-equivalent cost in `SessionRecord`
- preserve missing cost versus a real `0.0`, and prefer reported cost over optional token-price estimation
- accept `post-session --harness pi` for explicit native trajectories and retain the fields in JSON/CSV exports
- document that OAuth/subscription cost can be nominal API-equivalent cost rather than incremental billed spend

This is an independent follow-up to #1568. Native discovery/sync remains a separate review slice so each change stays auditable.

## Compatibility

- new dataclass/result fields are appended to preserve the established positional constructor prefix
- existing records deserialize with `None` for the new fields
- timeout exit codes do not synthesize a Pi stop reason

## Tests

- `uv run --project packages/gptme-sessions --with gptme pytest packages/gptme-sessions/tests -q` (1,243 passed)
- `uv run mypy packages/gptme-sessions/src/gptme_sessions` (23 files clean)
- Ruff, diff-check, and scoped pre-commit hooks passed
- PR quality gate: 94/100 (only deduction is expected line overlap with unrelated #1565)
