### PR TITLE
fix(gptme-sessions): preserve missing reported cost

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/session_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/session_data.py
@@ -198,7 +198,7 @@ def fetch_session_stats_range(
                 info.model = info.model or usage.get("model") or ""
                 info.input_tokens = usage["input_tokens"]
                 info.output_tokens = usage["output_tokens"]
-                info.cost = usage["cost"]
+                info.cost = usage.get("cost", 0.0)
 
         # Fallback: extract model from eval dirname
         if not info.model and "evals" in session_dir.name:

--- a/packages/gptme-activity-summary/tests/test_session_data.py
+++ b/packages/gptme-activity-summary/tests/test_session_data.py
@@ -103,6 +103,25 @@ def test_fetch_session_stats_with_logs(tmp_path):
     assert stats.total_duration_seconds == 300.0  # 5 minutes
 
 
+def test_fetch_session_stats_without_reported_cost(tmp_path):
+    """Token usage without a reported cost remains valid session data."""
+    session_dir = tmp_path / "2025-01-15-test-session"
+    session_dir.mkdir()
+    (session_dir / "config.toml").write_text('model = "claude-3-opus"\n')
+    message = {
+        "role": "assistant",
+        "content": "Hi there",
+        "metadata": {"input_tokens": 200, "output_tokens": 100},
+    }
+    (session_dir / "conversation.jsonl").write_text(json.dumps(message))
+
+    stats = fetch_session_stats(date(2025, 1, 15), logs_dir=tmp_path)
+
+    assert stats.total_input_tokens == 200
+    assert stats.total_output_tokens == 100
+    assert stats.total_cost == 0.0
+
+
 def test_fetch_session_stats_range(tmp_path):
     """Test fetching stats across a date range."""
     # Create sessions on different days

--- a/packages/gptme-sessions/README.md
+++ b/packages/gptme-sessions/README.md
@@ -39,7 +39,7 @@ store.append(SessionRecord(
 ))
 
 # Query records
-recent = store.query(model="opus", since_days=7)
+recent = store.query(model="gpt-5.6-luna", since_days=7)
 
 # Get stats
 stats = store.stats()

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -3083,20 +3083,12 @@ def cost(
     last_7d: bool,
     as_json: bool,
 ) -> None:
-    """Show session cost breakdown.
+    """Show reported and estimated session costs.
 
-    Requires gptme-usage to be installed for pricing data.
-    Install with: pip install gptme-sessions[cost]
+    Harness-reported costs work without optional dependencies. Install
+    ``gptme-sessions[cost]`` to estimate records that only contain token usage.
     """
     from .cost import analyze_costs, format_cost_summary
-
-    try:
-        from gptme_usage.harness_models import estimate_session_cost as _  # noqa: F401
-    except ImportError:
-        raise click.ClickException(
-            "gptme-usage is required for cost estimation.\n"
-            "Install with: pip install gptme-sessions[cost]"
-        )
 
     if last_7d:
         days = 7

--- a/packages/gptme-sessions/src/gptme_sessions/cost.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cost.py
@@ -1,6 +1,6 @@
-"""Session cost estimation and analysis.
+"""Session cost reporting, estimation, and analysis.
 
-Requires ``gptme-usage`` (optional dependency):
+Token-based estimates require ``gptme-usage`` (optional dependency):
     pip install gptme-sessions[cost]
 """
 

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1206,6 +1206,7 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     cache_read_tokens = 0
     cache_creation_tokens = 0
     cost = 0.0
+    cost_found = False
     model: str | None = None
     sys_prompt_tokens: int | None = None
     context_peak_tokens: int | None = None
@@ -1285,22 +1286,24 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         context_peak_tokens = (
             turn_context if context_peak_tokens is None else max(context_peak_tokens, turn_context)
         )
-        cost += metadata.get("cost", 0.0)
+        reported_cost = metadata.get("cost")
+        if not isinstance(reported_cost, bool) and isinstance(reported_cost, (int, float)):
+            cost += float(reported_cost)
+            cost_found = True
 
     total_tokens = input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens
     has_byte_metrics = any(
         v is not None
         for v in (sys_prompt_bytes, first_turn_bytes, context_peak_bytes, session_total_bytes)
     )
-    if total_tokens == 0 and cost == 0.0 and not has_byte_metrics:
+    if total_tokens == 0 and not cost_found and not has_byte_metrics:
         return {}
-    return {
+    result: dict[str, object] = {
         "model": model,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "cache_read_tokens": cache_read_tokens,
         "cache_creation_tokens": cache_creation_tokens,
-        "cost": cost,
         "total_tokens": total_tokens,
         "sys_prompt_tokens": sys_prompt_tokens,
         "context_peak_tokens": context_peak_tokens,
@@ -1309,6 +1312,9 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         "context_peak_bytes": context_peak_bytes,
         "session_total_bytes": session_total_bytes,
     }
+    if cost_found:
+        result["cost"] = cost
+    return result
 
 
 def extract_timings_gptme(msgs: list[dict]) -> dict:
@@ -2368,9 +2374,9 @@ def extract_signals_pi(msgs: list[dict]) -> dict:
     }
 
 
-def _pi_cost_number(value: object) -> float:
+def _pi_cost_number(value: object) -> float | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return 0.0
+        return None
     return float(value)
 
 
@@ -2402,6 +2408,7 @@ def extract_usage_pi(msgs: list[dict]) -> dict:
         "cache_creation": 0.0,
         "total": 0.0,
     }
+    cost_found = False
 
     for entry in active_records:
         entry_type = entry.get("type")
@@ -2481,13 +2488,17 @@ def extract_usage_pi(msgs: list[dict]) -> dict:
                 "cache_creation": _pi_cost_number(cost.get("cacheWrite")),
             }
             for key, value in turn_cost.items():
-                cost_breakdown[key] += value
-            reported_cost = cost.get("total")
-            cost_breakdown["total"] += (
-                _pi_cost_number(reported_cost)
-                if reported_cost is not None
-                else sum(turn_cost.values())
-            )
+                if value is not None:
+                    cost_breakdown[key] += value
+            reported_cost = _pi_cost_number(cost.get("total"))
+            if reported_cost is not None:
+                cost_breakdown["total"] += reported_cost
+                cost_found = True
+            elif any(value is not None for value in turn_cost.values()):
+                cost_breakdown["total"] += sum(
+                    value for value in turn_cost.values() if value is not None
+                )
+                cost_found = True
 
     if not usage_found and provider is None and model is None and stop_reason is None:
         return {}
@@ -2497,9 +2508,10 @@ def extract_usage_pi(msgs: list[dict]) -> dict:
         "cache_read_tokens": cache_read_tokens,
         "cache_creation_tokens": cache_creation_tokens,
         "total_tokens": input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens,
-        "cost": cost_breakdown["total"],
-        "cost_breakdown": cost_breakdown,
     }
+    if cost_found:
+        result["cost"] = cost_breakdown["total"]
+        result["cost_breakdown"] = cost_breakdown
     if provider is not None:
         result["provider"] = provider
     if model is not None:

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -345,6 +345,29 @@ class TestExportCommand:
         assert "invalid choice" in out.lower() or "xml" in out.lower()
 
 
+# -- cost --------------------------------------------------------------------
+
+
+class TestCostCommand:
+    def test_reported_costs_work_without_optional_estimator(self, tmp_path: Path):
+        """Reported costs, including zero, do not require gptme-usage."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(model="gpt-5.6-luna", cost_usd=0.0123))
+        store.append(SessionRecord(model="local/model", cost_usd=0.0))
+
+        with patch.dict(
+            "sys.modules",
+            {"gptme_usage": None, "gptme_usage.harness_models": None},
+        ):
+            rc, out = _invoke(["cost", "--json"], tmp_path)
+
+        assert rc == 0, out
+        result = json.loads(out)
+        assert result["session_count"] == 2
+        assert result["priced_count"] == 2
+        assert result["total_cost"] == pytest.approx(0.0123)
+
+
 # -- show --------------------------------------------------------------------
 
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -2562,7 +2562,7 @@ def test_extract_usage_gptme_no_metadata():
     # Byte metrics are returned even without token metadata (the primary gptme use case)
     assert result["session_total_bytes"] == len("test".encode())
     assert result["total_tokens"] == 0
-    assert result["cost"] == 0.0
+    assert "cost" not in result
 
 
 def test_extract_usage_gptme_truly_empty():
@@ -2599,6 +2599,20 @@ def test_extract_usage_gptme_byte_metrics_without_token_data():
     assert result["context_peak_bytes"] == len(sys_content.encode()) + len(user_content.encode())
     # Token fields are zero since no metadata
     assert result["total_tokens"] == 0
+    assert "cost" not in result
+
+
+def test_extract_usage_gptme_explicit_zero_cost_is_reported():
+    """An explicit zero remains distinct from unavailable cost data."""
+    result = extract_usage_gptme(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "metadata": {"model": "local/model", "cost": 0.0},
+            }
+        ]
+    )
     assert result["cost"] == 0.0
 
 

--- a/packages/gptme-sessions/tests/test_signals_pi.py
+++ b/packages/gptme-sessions/tests/test_signals_pi.py
@@ -248,6 +248,41 @@ def test_compaction_retained_tail_usage_is_not_double_counted() -> None:
     assert extract_signals_pi(records)["compaction_count"] == 1
 
 
+def test_missing_pi_cost_is_distinct_from_explicit_zero() -> None:
+    usage_without_cost = _usage(7)
+    usage_without_cost.pop("cost")
+    records = [
+        _header(),
+        {
+            "type": "message",
+            "id": "root",
+            "parentId": None,
+            "timestamp": "2026-08-31T12:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": "done",
+                "usage": usage_without_cost,
+                "stopReason": "stop",
+            },
+        },
+    ]
+
+    missing = extract_usage_pi(records)
+    assert "cost" not in missing
+    assert "cost_breakdown" not in missing
+
+    records[1]["message"]["usage"]["cost"] = {
+        "input": 0.0,
+        "output": 0.0,
+        "cacheRead": 0.0,
+        "cacheWrite": 0.0,
+        "total": 0.0,
+    }
+    explicit_zero = extract_usage_pi(records)
+    assert explicit_zero["cost"] == 0.0
+    assert explicit_zero["cost_breakdown"]["total"] == 0.0
+
+
 def test_pi_print_stream_is_detected_then_rejected() -> None:
     records = [_header(), {"type": "agent_start"}]
     with pytest.raises(PiSessionFormatError, match="entry type 'agent_start'"):


### PR DESCRIPTION
## Summary

- omit cost and cost_breakdown when gptme or Pi trajectories did not report cost
- retain an explicit reported 0.0 as an authoritative observation
- let the cost command aggregate reported per-record costs without the optional gptme-usage estimator
- keep the README Pi example model consistent

Follow-up to gptme/gptme-contrib#1570 and gptme/gptme-contrib#1571.

## Verification

- uv run pytest packages/gptme-sessions/tests -q (1271 passed)
- make -C packages/gptme-sessions typecheck
- uv run ruff check on all changed Python files
- prek run --files on all changed files