### PR TITLE
fix(gptme-sessions): harden Pi discovery and resumed sync

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -243,33 +243,39 @@ def _refresh_pi_extract_result(record: SessionRecord, result: dict) -> bool:
     return changed
 
 
-def _merge_concurrent_annotations(
-    records: list[SessionRecord], latest_records: list[SessionRecord]
+def _merge_concurrent_record_updates(
+    records: list[SessionRecord],
+    latest_records: list[SessionRecord],
+    original_records: dict[str, dict[str, object]],
 ) -> None:
-    """Merge operator annotations that landed after sync's initial store read.
+    """Three-way merge updates that landed after sync's initial store read.
 
     Sync intentionally extracts outside the store lock because trajectory
-    parsing can be slow. Before rewriting, it re-reads under the lock and uses
-    this helper so a concurrent ``annotate`` cannot be clobbered by the stale
-    same-session object. Deliverables retain additive semantics.
+    parsing can be slow. Before rewriting, compare the final locked re-read
+    with the original snapshot: fields changed by another writer win, while
+    fields untouched on disk retain sync's extracted values.
     """
     latest_by_id = {record.session_id: record for record in latest_records}
     for record in records:
         latest = latest_by_id.get(record.session_id)
-        if latest is None:
+        original = original_records.get(record.session_id)
+        if latest is None or original is None:
             continue
 
-        annotated_fields = list(dict.fromkeys([*record.annotated_fields, *latest.annotated_fields]))
-        for field in latest.annotated_fields:
-            if field in ANNOTATABLE_FIELDS:
-                setattr(record, field, getattr(latest, field))
-        record.annotated_fields = annotated_fields
-
-        merged_deliverables = list(record.deliverables)
-        for deliverable in latest.deliverables:
-            if deliverable not in merged_deliverables:
-                merged_deliverables.append(deliverable)
-        record.deliverables = merged_deliverables
+        latest_values = latest.to_dict()
+        original_annotations = original.get("annotated_fields")
+        if not isinstance(original_annotations, list):
+            original_annotations = []
+        concurrently_annotated = set(latest.annotated_fields) - set(original_annotations)
+        for field, latest_value in latest_values.items():
+            if field == "session_id":
+                continue
+            if original.get(field) == latest_value and field not in concurrently_annotated:
+                continue
+            if hasattr(record, field):
+                setattr(record, field, latest_value)
+            else:
+                record._legacy_fields[field] = latest_value
 
 
 def _apply_extract_result_to_kwargs(record_kwargs: dict, result: dict) -> None:
@@ -2321,6 +2327,7 @@ def sync(
 
     # Build lookup structures for deduplication and in-place updates.
     existing_records = store.load_all()
+    original_records = {record.session_id: record.to_dict() for record in existing_records}
     existing_by_path: dict[str, SessionRecord] = {}
     for record in existing_records:
         # ``journal_path`` held trajectories in records written before the
@@ -2510,10 +2517,12 @@ def sync(
     if not dry_run:
         if updated_paths:
             # Rewrite the store to persist in-place mutations on existing_records.
-            # Extraction happens outside the lock; merge annotations from a
-            # final locked re-read so an operator correction cannot be lost.
+            # Extraction happens outside the lock; three-way merge a final
+            # locked re-read so no concurrent record mutation is lost.
             with store.lock():
-                _merge_concurrent_annotations(existing_records, store.load_all())
+                _merge_concurrent_record_updates(
+                    existing_records, store.load_all(), original_records
+                )
                 store.rewrite(existing_records + new_records)
         else:
             for rec in new_records:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -272,6 +272,12 @@ def _merge_concurrent_record_updates(
                 continue
             if original.get(field) == latest_value and field not in concurrently_annotated:
                 continue
+            if field in {"deliverables", "deliverable_details"} and isinstance(latest_value, list):
+                current_value = getattr(record, field)
+                for item in latest_value:
+                    if item not in current_value:
+                        current_value.append(item)
+                continue
             if hasattr(record, field):
                 setattr(record, field, latest_value)
             else:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -95,25 +95,20 @@ _DEFAULT_BACKFILL_FIELDS: tuple[str, ...] = (
     "context_peak_bytes",
     "session_total_bytes",
 )
-_PI_ROUTE_BACKFILL_FIELDS: tuple[str, ...] = (
-    "provider",
-    "stop_reason",
-    "cost_usd",
-)
 
 
 def _usage_backfill_fields(harness: str | None) -> tuple[str, ...]:
     """Record fields that ``sync --signals`` should backfill for ``harness``.
 
     Copilot trajectories never contain token-count fields — only byte metrics
-    and model name are extractable. Pi extractors populate provider, stop
-    reason, and reported cost; skipping those on an otherwise complete record
-    leaves route metadata absent from the durable store and JSON/CSV exports.
+    and model name are extractable. Pi uses ``trajectory_revision`` as its
+    enrichment marker because several valid route/context fields can be absent;
+    missing-field checks would reparse unchanged history forever.
     """
     if harness == "copilot-cli":
         return _COPILOT_BACKFILL_FIELDS
     if harness == "pi":
-        return _DEFAULT_BACKFILL_FIELDS + _PI_ROUTE_BACKFILL_FIELDS
+        return ()
     return _DEFAULT_BACKFILL_FIELDS
 
 
@@ -163,6 +158,61 @@ def _apply_extract_result_to_record(record: SessionRecord, result: dict) -> bool
     if isinstance(usage, dict):
         for usage_key, record_key in _USAGE_FIELD_MAP.items():
             changed |= _assign_if_missing(record, record_key, usage.get(usage_key))
+
+    return changed
+
+
+def _refresh_pi_extract_result(record: SessionRecord, result: dict) -> bool:
+    """Monotonically refresh source-derived fields on a resumed Pi session.
+
+    Pi v3 has no terminal session record: a file whose latest assistant turn
+    stopped normally can be resumed later. Preserve caller/manual annotations,
+    while promoting trajectory outcomes, counters, and discovered deliverables
+    as the append-only native tree grows.
+    """
+    changed = _apply_extract_result_to_record(record, result)
+
+    if result.get("productive") and record.outcome in ("unknown", "noop"):
+        if record.outcome != "productive":
+            record.outcome = "productive"
+            changed = True
+
+    duration = int(result.get("session_duration_s") or 0)
+    if duration > record.duration_seconds:
+        record.duration_seconds = duration
+        changed = True
+
+    for field in ("deliverables", "deliverable_details"):
+        values = result.get(field)
+        if not isinstance(values, list):
+            continue
+        current = getattr(record, field)
+        merged = list(current)
+        for value in values:
+            if value not in merged:
+                merged.append(value)
+        if merged != current:
+            setattr(record, field, merged)
+            changed = True
+
+    usage = result.get("usage")
+    if not isinstance(usage, dict):
+        return changed
+
+    latest_fields = {"model", "provider", "stop_reason"}
+    for usage_key, record_key in _USAGE_FIELD_MAP.items():
+        value = usage.get(usage_key)
+        if value is None:
+            continue
+        current = getattr(record, record_key)
+        if record_key in latest_fields:
+            if current != value:
+                setattr(record, record_key, value)
+                changed = True
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            if current is None or value > current:
+                setattr(record, record_key, value)
+                changed = True
 
     return changed
 
@@ -346,6 +396,15 @@ def _normalize_session_path(path: str | Path) -> str:
         return str(candidate.resolve())
     except (OSError, RuntimeError):
         return str(candidate.absolute())
+
+
+def _trajectory_revision(path: Path) -> str | None:
+    """Return a cheap revision for append-only trajectory change detection."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return f"{stat.st_dev}:{stat.st_ino}:{stat.st_size}:{stat.st_mtime_ns}"
 
 
 def _existing_session_paths(records: list[SessionRecord]) -> set[str]:
@@ -2217,9 +2276,8 @@ def sync(
 
     # Warn when a large number of new sessions would be imported.
     # This catches accidental wide-window syncs (e.g. --since 90d) that inflate stats.
-    new_count_estimate = sum(
-        1 for entry in discovered if _normalize_session_path(entry["path"]) not in existing_by_path
-    )
+    discovered_paths = {_normalize_session_path(entry["path"]) for entry in discovered}
+    new_count_estimate = len(discovered_paths - existing_by_path.keys())
     if not dry_run and new_count_estimate > 100:
         window_warn = _fmt_since(since_days)
         click.echo(
@@ -2228,9 +2286,18 @@ def sync(
             err=True,
         )
 
+    seen_discovered_paths: set[str] = set()
     for entry in discovered:
         path_str = _normalize_session_path(entry["path"])
         traj_path = Path(path_str)
+
+        # Discovery normally canonicalizes aliases, but retain this import-side
+        # guard for alternative discovery providers and files that race through
+        # different spellings within one batch.
+        if path_str in seen_discovered_paths:
+            skipped += 1
+            continue
+        seen_discovered_paths.add(path_str)
 
         if path_str in existing_by_path:
             existing = existing_by_path[path_str]
@@ -2254,16 +2321,31 @@ def sync(
                 getattr(existing, field) is None
                 for field in _usage_backfill_fields(existing.harness)
             )
+            source_revision = _trajectory_revision(traj_path) if traj_path.is_file() else None
+            pi_source_changed = (
+                existing.harness == "pi"
+                and source_revision is not None
+                and source_revision != existing.trajectory_revision
+            )
 
             if (
                 with_signals
                 and traj_path.is_file()
-                and (existing.outcome == "unknown" or usage_backfill_needed)
+                and (existing.outcome == "unknown" or usage_backfill_needed or pi_source_changed)
             ):
                 if not dry_run:
                     try:
                         result = extract_from_path(traj_path)
-                        needs_update |= _apply_extract_result_to_record(existing, result)
+                        if existing.harness == "pi":
+                            needs_update |= _refresh_pi_extract_result(existing, result)
+                            # Persist the revision captured before extraction.
+                            # If Pi appends concurrently, the next sync sees a
+                            # different revision and re-extracts the unseen tail.
+                            if existing.trajectory_revision != source_revision:
+                                existing.trajectory_revision = source_revision
+                                needs_update = True
+                        else:
+                            needs_update |= _apply_extract_result_to_record(existing, result)
                     except Exception as exc:
                         click.echo(
                             f"  warning: signals extraction failed for {path_str}: {exc}",
@@ -2328,8 +2410,11 @@ def sync(
 
         if with_signals and traj_path.is_file() and not dry_run:
             try:
+                source_revision = _trajectory_revision(traj_path)
                 result = extract_from_path(traj_path)
                 _apply_extract_result_to_kwargs(record_kwargs, result)
+                if entry["harness"] == "pi":
+                    record_kwargs["trajectory_revision"] = source_revision
             except Exception as exc:
                 click.echo(
                     f"  warning: signals extraction failed for {path_str}: {exc}",

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -35,8 +35,8 @@ from .replay import (
     resolve_replay_target,
     resolve_session_record_prefix,
 )
-from .record import ATTEMPT_KINDS, SessionRecord, normalize_run_type
-from .pi import PiSessionFormatError
+from .record import ANNOTATABLE_FIELDS, ATTEMPT_KINDS, SessionRecord, normalize_run_type
+from .pi import PI_EXTRACTION_SCHEMA_VERSION, PiSessionFormatError
 from .signals import extract_from_path
 from .store import (
     SessionStore,
@@ -138,26 +138,35 @@ def _assign_if_missing(record: SessionRecord, field: str, value: object) -> bool
     return True
 
 
+def _assign_extracted_if_missing(record: SessionRecord, field: str, value: object) -> bool:
+    """Backfill an extracted value unless an operator explicitly overrode it."""
+    # Deliverables are additive evidence. ``annotate --add-deliverable`` must
+    # coexist with later source discoveries rather than freezing the list.
+    if field not in {"deliverables", "deliverable_details"} and field in record.annotated_fields:
+        return False
+    return _assign_if_missing(record, field, value)
+
+
 def _apply_extract_result_to_record(record: SessionRecord, result: dict) -> bool:
     """Backfill missing fields on an existing record from ``extract_from_path`` output."""
     changed = False
 
-    if record.outcome == "unknown":
+    if record.outcome == "unknown" and "outcome" not in record.annotated_fields:
         record.outcome = "productive" if result.get("productive") else "noop"
         changed = True
-    changed |= _assign_if_missing(
+    changed |= _assign_extracted_if_missing(
         record, "duration_seconds", int(result.get("session_duration_s") or 0)
     )
-    changed |= _assign_if_missing(record, "deliverables", result.get("deliverables", []))
-    changed |= _assign_if_missing(
+    changed |= _assign_extracted_if_missing(record, "deliverables", result.get("deliverables", []))
+    changed |= _assign_extracted_if_missing(
         record, "deliverable_details", result.get("deliverable_details", [])
     )
-    changed |= _assign_if_missing(record, "category", result.get("inferred_category"))
+    changed |= _assign_extracted_if_missing(record, "category", result.get("inferred_category"))
 
     usage = result.get("usage")
     if isinstance(usage, dict):
         for usage_key, record_key in _USAGE_FIELD_MAP.items():
-            changed |= _assign_if_missing(record, record_key, usage.get(usage_key))
+            changed |= _assign_extracted_if_missing(record, record_key, usage.get(usage_key))
 
     return changed
 
@@ -172,13 +181,29 @@ def _refresh_pi_extract_result(record: SessionRecord, result: dict) -> bool:
     """
     changed = _apply_extract_result_to_record(record, result)
 
-    if result.get("productive") and record.outcome in ("unknown", "noop"):
+    usage = result.get("usage")
+    # Older extraction semantics coerced absent cost to 0.0. If the current
+    # extractor has no cost key, that zero has no source evidence and must not
+    # become permanent when we stamp the new extraction schema version.
+    if (
+        record.cost_usd == 0.0
+        and "cost_usd" not in record.annotated_fields
+        and (not isinstance(usage, dict) or "cost" not in usage)
+    ):
+        record.cost_usd = None
+        changed = True
+
+    if (
+        "outcome" not in record.annotated_fields
+        and result.get("productive")
+        and record.outcome in ("unknown", "noop")
+    ):
         if record.outcome != "productive":
             record.outcome = "productive"
             changed = True
 
     duration = int(result.get("session_duration_s") or 0)
-    if duration > record.duration_seconds:
+    if "duration_seconds" not in record.annotated_fields and duration > record.duration_seconds:
         record.duration_seconds = duration
         changed = True
 
@@ -195,12 +220,13 @@ def _refresh_pi_extract_result(record: SessionRecord, result: dict) -> bool:
             setattr(record, field, merged)
             changed = True
 
-    usage = result.get("usage")
     if not isinstance(usage, dict):
         return changed
 
     latest_fields = {"model", "provider", "stop_reason"}
     for usage_key, record_key in _USAGE_FIELD_MAP.items():
+        if record_key in record.annotated_fields:
+            continue
         value = usage.get(usage_key)
         if value is None:
             continue
@@ -215,6 +241,35 @@ def _refresh_pi_extract_result(record: SessionRecord, result: dict) -> bool:
                 changed = True
 
     return changed
+
+
+def _merge_concurrent_annotations(
+    records: list[SessionRecord], latest_records: list[SessionRecord]
+) -> None:
+    """Merge operator annotations that landed after sync's initial store read.
+
+    Sync intentionally extracts outside the store lock because trajectory
+    parsing can be slow. Before rewriting, it re-reads under the lock and uses
+    this helper so a concurrent ``annotate`` cannot be clobbered by the stale
+    same-session object. Deliverables retain additive semantics.
+    """
+    latest_by_id = {record.session_id: record for record in latest_records}
+    for record in records:
+        latest = latest_by_id.get(record.session_id)
+        if latest is None:
+            continue
+
+        annotated_fields = list(dict.fromkeys([*record.annotated_fields, *latest.annotated_fields]))
+        for field in latest.annotated_fields:
+            if field in ANNOTATABLE_FIELDS:
+                setattr(record, field, getattr(latest, field))
+        record.annotated_fields = annotated_fields
+
+        merged_deliverables = list(record.deliverables)
+        for deliverable in latest.deliverables:
+            if deliverable not in merged_deliverables:
+                merged_deliverables.append(deliverable)
+        record.deliverables = merged_deliverables
 
 
 def _apply_extract_result_to_kwargs(record_kwargs: dict, result: dict) -> None:
@@ -1388,29 +1443,37 @@ def annotate(
 
         record = matches[0]
 
+        def set_annotated(field: str, value: object) -> None:
+            """Apply an explicit override and retain its operator provenance."""
+            if field not in ANNOTATABLE_FIELDS:
+                raise ValueError(f"unsupported annotation field: {field}")
+            setattr(record, field, value)
+            if field not in record.annotated_fields:
+                record.annotated_fields.append(field)
+
         # Apply only the fields that were explicitly provided
         if model is not None:
-            record.model = model
+            set_annotated("model", model)
         if harness is not None:
-            record.harness = harness
+            set_annotated("harness", harness)
         if run_type is not None:
-            record.run_type = normalize_run_type(run_type)
+            set_annotated("run_type", normalize_run_type(run_type))
         if category is not None:
-            record.category = category
+            set_annotated("category", category)
         if outcome is not None:
-            record.outcome = outcome
+            set_annotated("outcome", outcome)
         if duration is not None:
-            record.duration_seconds = duration
+            set_annotated("duration_seconds", duration)
         if journal_path is not None:
-            record.journal_path = journal_path
+            set_annotated("journal_path", journal_path)
         if selector_mode is not None:
-            record.selector_mode = selector_mode
+            set_annotated("selector_mode", selector_mode)
         if trigger is not None:
-            record.trigger = trigger
+            set_annotated("trigger", trigger)
         if token_count is not None:
-            record.token_count = token_count
+            set_annotated("token_count", token_count)
         if recommended_category is not None:
-            record.recommended_category = recommended_category
+            set_annotated("recommended_category", recommended_category)
         if add_deliverable:
             existing = list(record.deliverables or [])
             for d in add_deliverable:
@@ -2273,6 +2336,8 @@ def sync(
     imported = 0
     updated = 0
     skipped = 0
+    duplicates = 0
+    signal_failures = 0
 
     # Warn when a large number of new sessions would be imported.
     # This catches accidental wide-window syncs (e.g. --since 90d) that inflate stats.
@@ -2295,17 +2360,22 @@ def sync(
         # guard for alternative discovery providers and files that race through
         # different spellings within one batch.
         if path_str in seen_discovered_paths:
-            skipped += 1
+            duplicates += 1
             continue
         seen_discovered_paths.add(path_str)
 
         if path_str in existing_by_path:
             existing = existing_by_path[path_str]
             needs_update = False
+            signal_extraction_failed = False
 
             # Update model if it was previously unknown and we now know it.
             entry_model = entry.get("model")
-            if entry_model and (not existing.model or existing.model == "unknown"):
+            if (
+                entry_model
+                and "model" not in existing.annotated_fields
+                and (not existing.model or existing.model == "unknown")
+            ):
                 existing.model = entry_model
                 needs_update = True
 
@@ -2325,7 +2395,10 @@ def sync(
             pi_source_changed = (
                 existing.harness == "pi"
                 and source_revision is not None
-                and source_revision != existing.trajectory_revision
+                and (
+                    source_revision != existing.trajectory_revision
+                    or existing.trajectory_extract_version != PI_EXTRACTION_SCHEMA_VERSION
+                )
             )
 
             if (
@@ -2344,9 +2417,14 @@ def sync(
                             if existing.trajectory_revision != source_revision:
                                 existing.trajectory_revision = source_revision
                                 needs_update = True
+                            if existing.trajectory_extract_version != PI_EXTRACTION_SCHEMA_VERSION:
+                                existing.trajectory_extract_version = PI_EXTRACTION_SCHEMA_VERSION
+                                needs_update = True
                         else:
                             needs_update |= _apply_extract_result_to_record(existing, result)
                     except Exception as exc:
+                        signal_failures += 1
+                        signal_extraction_failed = True
                         click.echo(
                             f"  warning: signals extraction failed for {path_str}: {exc}",
                             err=True,
@@ -2370,7 +2448,7 @@ def sync(
                 else:
                     updated_paths.add(path_str)
                     updated += 1
-            else:
+            elif not signal_extraction_failed:
                 skipped += 1
             continue
 
@@ -2415,7 +2493,9 @@ def sync(
                 _apply_extract_result_to_kwargs(record_kwargs, result)
                 if entry["harness"] == "pi":
                     record_kwargs["trajectory_revision"] = source_revision
+                    record_kwargs["trajectory_extract_version"] = PI_EXTRACTION_SCHEMA_VERSION
             except Exception as exc:
+                signal_failures += 1
                 click.echo(
                     f"  warning: signals extraction failed for {path_str}: {exc}",
                     err=True,
@@ -2430,27 +2510,35 @@ def sync(
     if not dry_run:
         if updated_paths:
             # Rewrite the store to persist in-place mutations on existing_records.
-            # NOTE: existing_records was loaded once at the start of sync; any records
-            # appended to the store by a concurrent process after that load may be lost
-            # here.  See store.rewrite() docstring for details on this known trade-off.
-            store.rewrite(existing_records + new_records)
+            # Extraction happens outside the lock; merge annotations from a
+            # final locked re-read so an operator correction cannot be lost.
+            with store.lock():
+                _merge_concurrent_annotations(existing_records, store.load_all())
+                store.rewrite(existing_records + new_records)
         else:
             for rec in new_records:
                 store.append(rec)
 
     if dry_run:
         n_would_update = len(updated_paths)
-        n_would_import = len(discovered) - skipped - n_would_update
+        unique_found = len(seen_discovered_paths)
+        n_would_import = unique_found - skipped - n_would_update
         click.echo(
-            f"\n{len(discovered)} found, {skipped} unchanged, "
+            f"\n{unique_found} found, {skipped} unchanged, "
             f"{n_would_import} would be imported"
             + (f", {n_would_update} would be updated" if n_would_update else "")
+            + (f", {duplicates} duplicate aliases" if duplicates else "")
         )
     else:
         parts = [f"Imported {imported} session(s)"]
         if updated:
             parts.append(f"updated {updated}")
         parts.append(f"{skipped} unchanged.")
+        if duplicates:
+            parts.append(f"{duplicates} duplicate aliases.")
+        if signal_failures:
+            suffix = "" if signal_failures == 1 else "s"
+            parts.append(f"{signal_failures} signal extraction failure{suffix}.")
         click.echo(", ".join(parts))
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -71,20 +71,72 @@ def _get_copilot_state_dir() -> Path:
     return DEFAULT_COPILOT_STATE_DIR
 
 
+def _expand_pi_path(value: str) -> Path:
+    """Expand Pi's supported ``~`` spellings without Python's user lookup."""
+    if value == "~":
+        return Path.home()
+    if value.startswith("~/") or (os.name == "nt" and value.startswith("~\\")):
+        return Path.home() / value[2:]
+    return Path(value)
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    """Match JavaScript ``JSON.parse`` by rejecting NaN and infinities."""
+    raise ValueError(f"invalid JSON constant {value}")
+
+
 def _get_pi_sessions_dir() -> Path:
-    """Get Pi's native session directory from env or the upstream default.
+    """Get Pi's native session directory using Pi's startup precedence.
 
     ``PI_CODING_AGENT_SESSION_DIR`` is Pi's direct session-directory override.
-    When only ``PI_CODING_AGENT_DIR`` is set, Pi stores sessions below its
-    ``sessions`` child. The direct override therefore takes precedence.
+    Otherwise Pi merges global and project ``settings.json`` files, with the
+    project ``sessionDir`` winning. Relative configured paths resolve from the
+    startup working directory, matching Pi's ``SessionManager``. When no
+    override is configured, sessions live below the agent directory.
     """
     session_dir = os.environ.get("PI_CODING_AGENT_SESSION_DIR")
     if session_dir:
-        return Path(session_dir)
-    agent_dir = os.environ.get("PI_CODING_AGENT_DIR")
-    if agent_dir:
-        return Path(agent_dir) / "sessions"
-    return DEFAULT_PI_SESSIONS_DIR
+        return _expand_pi_path(session_dir)
+
+    agent_dir = _expand_pi_path(os.environ.get("PI_CODING_AGENT_DIR") or "~/.pi/agent")
+    configured_session_dir: str | None = None
+    for scope, settings_path in (
+        ("global", agent_dir / "settings.json"),
+        ("project", Path.cwd() / ".pi" / "settings.json"),
+    ):
+        try:
+            settings = json.loads(
+                settings_path.read_text(encoding="utf-8-sig"),
+                parse_constant=_reject_nonfinite_json,
+            )
+        except FileNotFoundError:
+            continue
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            logger.warning("Ignoring unreadable Pi %s settings %s: %s", scope, settings_path, exc)
+            continue
+        if not isinstance(settings, dict):
+            logger.warning("Ignoring non-object Pi %s settings: %s", scope, settings_path)
+            continue
+        if "sessionDir" not in settings:
+            continue
+        value = settings["sessionDir"]
+        # Pi's deep merge gives the project key precedence even when its value
+        # is null/empty. Such a value selects the normal default store rather
+        # than reviving a valid global override.
+        configured_session_dir = None
+        if value is None or value == "":
+            continue
+        if not isinstance(value, str) or not value:
+            logger.warning(
+                "Ignoring invalid Pi %s sessionDir %r in %s", scope, value, settings_path
+            )
+            continue
+        configured_session_dir = value
+
+    if configured_session_dir is not None:
+        configured = _expand_pi_path(configured_session_dir)
+        return configured if configured.is_absolute() else Path.cwd() / configured
+    return agent_dir / "sessions"
 
 
 def _session_in_range(session_name: str, start: date, end: date) -> bool:
@@ -146,6 +198,30 @@ def _quick_pi_header(jsonl_path: Path) -> dict | None:
         header = json.loads(first_line)
         return header if is_pi_session_header(header) else None
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def _pi_header_datetime(header: dict, jsonl_path: Path) -> datetime | None:
+    """Parse and UTC-normalize a Pi header timestamp without escaping failures."""
+    timestamp = header.get("timestamp")
+    if not isinstance(timestamp, str):
+        logger.warning(
+            "Skipping Pi session with invalid header timestamp %r: %s",
+            timestamp,
+            jsonl_path,
+        )
+        return None
+    try:
+        session_datetime = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        if session_datetime.tzinfo is None:
+            session_datetime = session_datetime.replace(tzinfo=timezone.utc)
+        return session_datetime.astimezone(timezone.utc)
+    except (OverflowError, ValueError):
+        logger.warning(
+            "Skipping Pi session with invalid header timestamp %r: %s",
+            timestamp,
+            jsonl_path,
+        )
         return None
 
 
@@ -579,6 +655,7 @@ def discover_pi_sessions(
         return []
 
     sessions_with_dates: list[tuple[datetime, Path]] = []
+    seen_paths: set[Path] = set()
 
     def _walk_error(error: OSError) -> None:
         logger.warning("Skipping unreadable Pi session directory: %s", error)
@@ -597,6 +674,17 @@ def discover_pi_sessions(
             except OSError as exc:
                 logger.warning("Skipping unreadable Pi session candidate %s: %s", jsonl_file, exc)
                 continue
+
+            # Date-filter from the small header before materializing the full
+            # tree. The authoritative snapshot is checked again below in case
+            # a file changes between these two read-only operations.
+            quick_header = _quick_pi_header(jsonl_file)
+            if quick_header is not None:
+                quick_datetime = _pi_header_datetime(quick_header, jsonl_file)
+                if quick_datetime is None:
+                    continue
+                if not (start <= quick_datetime.date() <= end):
+                    continue
             try:
                 records = _load_pi_native_records(jsonl_file)
             except PiSessionFormatError as exc:
@@ -604,21 +692,14 @@ def discover_pi_sessions(
                 continue
             if records is None:
                 continue
-            timestamp = records[0]["timestamp"]
-            try:
-                session_datetime = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-            except (TypeError, ValueError):
-                logger.warning(
-                    "Skipping Pi session with invalid header timestamp %r: %s",
-                    timestamp,
-                    jsonl_file,
-                )
+            session_datetime = _pi_header_datetime(records[0], jsonl_file)
+            if session_datetime is None:
                 continue
-            if session_datetime.tzinfo is None:
-                session_datetime = session_datetime.replace(tzinfo=timezone.utc)
-            session_datetime = session_datetime.astimezone(timezone.utc)
             if start <= session_datetime.date() <= end:
-                sessions_with_dates.append((session_datetime, jsonl_file.resolve()))
+                resolved = jsonl_file.resolve()
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    sessions_with_dates.append((session_datetime, resolved))
     return [path for _, path in sorted(sessions_with_dates)]
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -22,6 +22,7 @@ from .pi import (
     PiSessionFormatError,
     active_pi_records,
     is_pi_session_header,
+    reject_nonfinite_json,
     validate_pi_records,
 )
 
@@ -80,11 +81,6 @@ def _expand_pi_path(value: str) -> Path:
     return Path(value)
 
 
-def _reject_nonfinite_json(value: str) -> None:
-    """Match JavaScript ``JSON.parse`` by rejecting NaN and infinities."""
-    raise ValueError(f"invalid JSON constant {value}")
-
-
 def _get_pi_sessions_dir() -> Path:
     """Get Pi's native session directory using Pi's startup precedence.
 
@@ -107,7 +103,7 @@ def _get_pi_sessions_dir() -> Path:
         try:
             settings = json.loads(
                 settings_path.read_text(encoding="utf-8-sig"),
-                parse_constant=_reject_nonfinite_json,
+                parse_constant=reject_nonfinite_json,
             )
         except FileNotFoundError:
             continue
@@ -195,9 +191,9 @@ def _quick_pi_header(jsonl_path: Path) -> dict | None:
             first_line = session_file.readline(8192).strip()
         if not first_line:
             return None
-        header = json.loads(first_line)
+        header = json.loads(first_line, parse_constant=reject_nonfinite_json)
         return header if is_pi_session_header(header) else None
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, ValueError, RecursionError):
         return None
 
 
@@ -597,7 +593,7 @@ def _load_pi_native_records(jsonl_path: Path) -> list[dict] | None:
         if not line:
             continue
         try:
-            record = json.loads(line)
+            record = json.loads(line, parse_constant=reject_nonfinite_json)
         except json.JSONDecodeError as exc:
             if pi_session and incomplete_tail and line_number == len(lines):
                 logger.warning(
@@ -608,6 +604,12 @@ def _load_pi_native_records(jsonl_path: Path) -> list[dict] | None:
             if pi_session:
                 raise PiSessionFormatError(
                     f"{jsonl_path}: invalid JSON on line {line_number}: {exc.msg}"
+                ) from exc
+            return None
+        except (ValueError, RecursionError) as exc:
+            if pi_session:
+                raise PiSessionFormatError(
+                    f"{jsonl_path}: invalid JSON on line {line_number}: {exc}"
                 ) from exc
             return None
 
@@ -649,7 +651,10 @@ def discover_pi_sessions(
     """
     if pi_dir is None:
         pi_dir = _get_pi_sessions_dir()
-    pi_dir = pi_dir.expanduser().absolute()
+    # ``_get_pi_sessions_dir`` already applies exactly Pi's supported `~`
+    # spellings. A second Path.expanduser() would reinterpret literal
+    # ``~username`` paths that Pi resolves relative to its startup cwd.
+    pi_dir = pi_dir.absolute()
     if not pi_dir.exists():
         logger.debug("Pi sessions directory does not exist: %s", pi_dir)
         return []

--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -22,6 +22,7 @@ from .pi import (
     PiSessionFormatError,
     active_pi_records,
     is_pi_session_header,
+    parse_finite_json_float,
     reject_nonfinite_json,
     validate_pi_records,
 )
@@ -104,10 +105,11 @@ def _get_pi_sessions_dir() -> Path:
             settings = json.loads(
                 settings_path.read_text(encoding="utf-8-sig"),
                 parse_constant=reject_nonfinite_json,
+                parse_float=parse_finite_json_float,
             )
         except FileNotFoundError:
             continue
-        except (OSError, UnicodeDecodeError, ValueError) as exc:
+        except (OSError, UnicodeDecodeError, ValueError, RecursionError) as exc:
             logger.warning("Ignoring unreadable Pi %s settings %s: %s", scope, settings_path, exc)
             continue
         if not isinstance(settings, dict):
@@ -191,7 +193,11 @@ def _quick_pi_header(jsonl_path: Path) -> dict | None:
             first_line = session_file.readline(8192).strip()
         if not first_line:
             return None
-        header = json.loads(first_line, parse_constant=reject_nonfinite_json)
+        header = json.loads(
+            first_line,
+            parse_constant=reject_nonfinite_json,
+            parse_float=parse_finite_json_float,
+        )
         return header if is_pi_session_header(header) else None
     except (OSError, UnicodeDecodeError, ValueError, RecursionError):
         return None
@@ -593,7 +599,11 @@ def _load_pi_native_records(jsonl_path: Path) -> list[dict] | None:
         if not line:
             continue
         try:
-            record = json.loads(line, parse_constant=reject_nonfinite_json)
+            record = json.loads(
+                line,
+                parse_constant=reject_nonfinite_json,
+                parse_float=parse_finite_json_float,
+            )
         except json.JSONDecodeError as exc:
             if pi_session and incomplete_tail and line_number == len(lines):
                 logger.warning(

--- a/packages/gptme-sessions/src/gptme_sessions/pi.py
+++ b/packages/gptme-sessions/src/gptme_sessions/pi.py
@@ -63,7 +63,7 @@ def validate_pi_records(records: list[dict]) -> list[dict]:
         if not isinstance(entry, dict):
             raise PiSessionFormatError(f"Pi entry on JSONL line {index} is not an object")
         entry_type = entry.get("type")
-        if entry_type not in _PI_ENTRY_TYPES:
+        if not isinstance(entry_type, str) or entry_type not in _PI_ENTRY_TYPES:
             raise PiSessionFormatError(
                 f"unsupported Pi v3 entry type {entry_type!r} on JSONL line {index}"
             )

--- a/packages/gptme-sessions/src/gptme_sessions/pi.py
+++ b/packages/gptme-sessions/src/gptme_sessions/pi.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 PI_SESSION_VERSION = 3
+# Bump whenever Pi extraction output or field semantics change. Sync persists
+# this separately from the source-file revision so unchanged trajectories are
+# reprocessed once after parser/schema improvements.
+PI_EXTRACTION_SCHEMA_VERSION = 1
 
 _PI_ENTRY_TYPES = frozenset(
     {
@@ -23,6 +27,11 @@ _PI_ENTRY_TYPES = frozenset(
 
 class PiSessionFormatError(ValueError):
     """Raised when a Pi-looking JSONL file is not a supported native session."""
+
+
+def reject_nonfinite_json(value: str) -> None:
+    """Match JavaScript ``JSON.parse`` by rejecting NaN and infinities."""
+    raise ValueError(f"invalid JSON constant {value}")
 
 
 def is_pi_session_header(record: object) -> bool:

--- a/packages/gptme-sessions/src/gptme_sessions/pi.py
+++ b/packages/gptme-sessions/src/gptme_sessions/pi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterable
 
 PI_SESSION_VERSION = 3
@@ -32,6 +33,14 @@ class PiSessionFormatError(ValueError):
 def reject_nonfinite_json(value: str) -> None:
     """Match JavaScript ``JSON.parse`` by rejecting NaN and infinities."""
     raise ValueError(f"invalid JSON constant {value}")
+
+
+def parse_finite_json_float(value: str) -> float:
+    """Parse a JSON float while rejecting values outside finite float range."""
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"JSON number is not finite: {value}")
+    return parsed
 
 
 def is_pi_session_header(record: object) -> bool:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -327,6 +327,12 @@ class SessionRecord:
     # this may be nominal API-equivalent cost, not incremental billed spend.
     cost_usd: float | None = None
 
+    # Cheap source revision captured after a successful trajectory extraction.
+    # Pi sessions are append-only and resumable, so sync uses this to refresh
+    # cumulative signals when the native JSONL grows without reparsing
+    # unchanged historical sessions on every run.
+    trajectory_revision: str | None = None
+
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``recommended_confidence``, ``notes``).

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -39,6 +39,25 @@ ATTEMPT_KINDS: frozenset[str] = frozenset(["repetition", "infra_retry", "unknown
 # Valid values for the dropout_depth field.
 DROPOUT_DEPTH_VALUES: frozenset[str] = frozenset(["shallow", "deep"])
 
+# Scalar fields the ``annotate`` CLI can explicitly override. Persisting this
+# provenance lets later source extraction distinguish operator decisions from
+# values it owns and may refresh.
+ANNOTATABLE_FIELDS: frozenset[str] = frozenset(
+    [
+        "model",
+        "harness",
+        "run_type",
+        "category",
+        "outcome",
+        "duration_seconds",
+        "journal_path",
+        "selector_mode",
+        "trigger",
+        "token_count",
+        "recommended_category",
+    ]
+)
+
 # Normalize model names to short canonical forms
 MODEL_ALIASES: dict[str, str] = {
     # Anthropic Claude models (bare) — dash and dot variants
@@ -332,6 +351,12 @@ class SessionRecord:
     # cumulative signals when the native JSONL grows without reparsing
     # unchanged historical sessions on every run.
     trajectory_revision: str | None = None
+    trajectory_extract_version: int | None = None
+
+    # Fields explicitly overridden through ``gptme-sessions annotate``. Source
+    # refreshes must not silently replace these operator decisions, including
+    # an override that happens to equal the source value at annotation time.
+    annotated_fields: list[str] = field(default_factory=list)
 
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
@@ -354,10 +379,25 @@ class SessionRecord:
         # Guard against JSON null for integer field
         if self.duration_seconds is None:
             self.duration_seconds = 0
+        if self.deliverables is None:
+            self.deliverables = []
         if self.deliverable_details is None:
             self.deliverable_details = []
         if self.lesson_events is None:
             self.lesson_events = []
+        if not isinstance(self.annotated_fields, list):
+            self.annotated_fields = []
+        else:
+            # Preserve first-write order for readable JSON while preventing
+            # corrupt payloads from turning membership checks into substring
+            # checks (a bare JSON string) or retaining non-field values.
+            self.annotated_fields = list(
+                dict.fromkeys(
+                    value
+                    for value in self.annotated_fields
+                    if isinstance(value, str) and value in ANNOTATABLE_FIELDS
+                )
+            )
         if self.grades is None:
             self.grades = {}
         if self.grade_reasons is None:

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -32,6 +32,7 @@ from .pi import (
     is_pi_session_header,
     pi_content_text,
     pi_usage_sources,
+    reject_nonfinite_json,
     validate_pi_records,
 )
 
@@ -228,11 +229,17 @@ def parse_trajectory(jsonl_path: Path) -> list[dict]:
             if not line:
                 continue
             try:
-                record = json.loads(line)
+                record = json.loads(line, parse_constant=reject_nonfinite_json)
             except json.JSONDecodeError as exc:
                 if pi_session:
                     raise PiSessionFormatError(
                         f"invalid JSON in Pi session on line {line_number}: {exc.msg}"
+                    ) from exc
+                continue
+            except (ValueError, RecursionError) as exc:
+                if pi_session:
+                    raise PiSessionFormatError(
+                        f"invalid JSON in Pi session on line {line_number}: {exc}"
                     ) from exc
                 continue
             msgs.append(record)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -30,6 +30,7 @@ from .pi import (
     PiSessionFormatError,
     active_pi_records,
     is_pi_session_header,
+    parse_finite_json_float,
     pi_content_text,
     pi_usage_sources,
     reject_nonfinite_json,
@@ -229,7 +230,11 @@ def parse_trajectory(jsonl_path: Path) -> list[dict]:
             if not line:
                 continue
             try:
-                record = json.loads(line, parse_constant=reject_nonfinite_json)
+                record = json.loads(
+                    line,
+                    parse_constant=reject_nonfinite_json,
+                    parse_float=parse_finite_json_float,
+                )
             except json.JSONDecodeError as exc:
                 if pi_session:
                     raise PiSessionFormatError(

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1642,14 +1642,14 @@ class TestFmtSince:
 class TestSyncRouteBackfill:
     """sync --signals must backfill Pi route metadata on complete legacy records."""
 
-    def test_usage_backfill_fields_include_pi_route_metadata(self) -> None:
+    def test_pi_uses_source_revision_instead_of_missing_field_backfill(self) -> None:
         from gptme_sessions.cli import _usage_backfill_fields
 
         pi_fields = _usage_backfill_fields("pi")
-        assert "provider" in pi_fields
-        assert "stop_reason" in pi_fields
-        assert "cost_usd" in pi_fields
-        assert "token_count" in pi_fields
+        # Pi fields such as cost/provider/stop reason can legitimately be
+        # absent. A durable trajectory revision drives the one-time legacy
+        # enrichment and later resumed-session refresh instead.
+        assert pi_fields == ()
 
         copilot_fields = _usage_backfill_fields("copilot-cli")
         assert "provider" not in copilot_fields

--- a/packages/gptme-sessions/tests/test_cli_pi.py
+++ b/packages/gptme-sessions/tests/test_cli_pi.py
@@ -251,7 +251,35 @@ def test_sync_pi_deduplicates_aliases_within_one_run(tmp_path: Path, monkeypatch
 
     assert result.exit_code == 0, result.output
     assert "Imported 1 session(s)" in result.output
+    assert "0 unchanged" in result.output
+    assert "2 duplicate aliases" in result.output
     assert len(SessionStore(sessions_dir=sessions_dir).load_all()) == 1
+
+
+def test_sync_pi_dry_run_reports_unique_alias_accounting(tmp_path: Path, monkeypatch) -> None:
+    alias_a = tmp_path / "alias-a.jsonl"
+    alias_b = tmp_path / "alias-b.jsonl"
+    alias_a.symlink_to(PI_FIXTURE.resolve())
+    alias_b.symlink_to(PI_FIXTURE.resolve())
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [alias_a, PI_FIXTURE, alias_b],
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--sessions-dir",
+            str(tmp_path / "records"),
+            "sync",
+            "--harness",
+            "pi",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "1 found, 0 unchanged, 1 would be imported, 2 duplicate aliases" in result.output
 
 
 def test_sync_pi_refreshes_resumed_session_monotonically(tmp_path: Path, monkeypatch) -> None:
@@ -320,6 +348,195 @@ def test_sync_pi_refreshes_resumed_session_monotonically(tmp_path: Path, monkeyp
     assert stable.to_dict() == complete.to_dict()
 
 
+def test_sync_pi_refresh_preserves_explicit_annotations(tmp_path: Path, monkeypatch) -> None:
+    """A resumed trajectory refreshes signals but never operator overrides."""
+    source = tmp_path / "annotated-resume.jsonl"
+    fixture_lines = PI_FIXTURE.read_text().splitlines(keepends=True)
+    source.write_text("".join(fixture_lines[:7]))
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    sessions_dir = tmp_path / "records"
+    runner = CliRunner()
+    sync_command = [
+        "--sessions-dir",
+        str(sessions_dir),
+        "sync",
+        "--harness",
+        "pi",
+        "--signals",
+    ]
+
+    first = runner.invoke(cli, sync_command)
+    assert first.exit_code == 0, first.output
+    [partial] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert partial.outcome == "noop"
+
+    annotated = runner.invoke(
+        cli,
+        [
+            "--sessions-dir",
+            str(sessions_dir),
+            "annotate",
+            partial.session_id,
+            "--outcome",
+            "noop",
+            "--model",
+            "operator-model",
+            "--duration",
+            "1",
+            "--token-count",
+            "123",
+        ],
+    )
+    assert annotated.exit_code == 0, annotated.output
+
+    source.write_text("".join(fixture_lines))
+    refreshed = runner.invoke(cli, sync_command)
+    assert refreshed.exit_code == 0, refreshed.output
+    assert "updated 1" in refreshed.output
+    [complete] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert complete.outcome == "noop"
+    assert complete.model == "operator-model"
+    assert complete.duration_seconds == 1
+    assert complete.token_count == 123
+    assert complete.provider == "openai-codex"
+    assert complete.stop_reason == "stop"
+    assert complete.input_tokens == 1154
+    assert complete.cost_usd == pytest.approx(0.0004264)
+    assert "test: create Pi fixture (526d692)" in complete.deliverables
+    assert complete.annotated_fields == [
+        "model",
+        "outcome",
+        "duration_seconds",
+        "token_count",
+    ]
+
+
+def test_sync_pi_merges_annotation_that_lands_during_extraction(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The final locked re-read wins over sync's stale same-session object."""
+    import gptme_sessions.cli as cli_module
+
+    source = tmp_path / "concurrent-annotation.jsonl"
+    fixture_lines = PI_FIXTURE.read_text().splitlines(keepends=True)
+    source.write_text("".join(fixture_lines[:7]))
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    sessions_dir = tmp_path / "records"
+    runner = CliRunner()
+    command = [
+        "--sessions-dir",
+        str(sessions_dir),
+        "sync",
+        "--harness",
+        "pi",
+        "--signals",
+    ]
+    first = runner.invoke(cli, command)
+    assert first.exit_code == 0, first.output
+
+    real_extract = cli_module.extract_from_path
+
+    def annotate_after_sync_read(path: Path) -> dict:
+        result = real_extract(path)
+        concurrent_store = SessionStore(sessions_dir=sessions_dir)
+        with concurrent_store.lock():
+            [latest] = concurrent_store.load_all()
+            latest.model = "concurrent-model"
+            latest.outcome = "noop"
+            latest.annotated_fields.extend(["model", "outcome"])
+            latest.deliverables.append("manual:operator-note")
+            concurrent_store.rewrite([latest])
+        return result
+
+    monkeypatch.setattr("gptme_sessions.cli.extract_from_path", annotate_after_sync_read)
+    source.write_text("".join(fixture_lines))
+    refreshed = runner.invoke(cli, command)
+
+    assert refreshed.exit_code == 0, refreshed.output
+    [complete] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert complete.model == "concurrent-model"
+    assert complete.outcome == "noop"
+    assert complete.annotated_fields == ["model", "outcome"]
+    assert "manual:operator-note" in complete.deliverables
+    assert complete.token_count == 1317
+    assert complete.stop_reason == "stop"
+
+
+def test_pi_extraction_schema_upgrade_repairs_false_missing_cost(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An unchanged legacy Pi record is re-extracted after schema changes."""
+    import gptme_sessions.cli as cli_module
+
+    source = tmp_path / "legacy-cost.jsonl"
+    source.write_bytes(PI_FIXTURE.read_bytes())
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    sessions_dir = tmp_path / "records"
+    store = SessionStore(sessions_dir=sessions_dir)
+    legacy = SessionRecord(
+        harness="pi",
+        trajectory_path=str(source.resolve()),
+        outcome="productive",
+        cost_usd=0.0,
+        trajectory_revision=cli_module._trajectory_revision(source),
+        trajectory_extract_version=None,
+    )
+    store.append(legacy)
+    real_extract = cli_module.extract_from_path
+
+    def extract_without_reported_cost(path: Path) -> dict:
+        result = real_extract(path)
+        result["usage"].pop("cost", None)
+        return result
+
+    monkeypatch.setattr("gptme_sessions.cli.extract_from_path", extract_without_reported_cost)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--sessions-dir",
+            str(sessions_dir),
+            "sync",
+            "--harness",
+            "pi",
+            "--signals",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "updated 1" in result.output
+    [repaired] = store.load_all()
+    assert repaired.cost_usd is None
+    assert repaired.trajectory_extract_version == cli_module.PI_EXTRACTION_SCHEMA_VERSION
+
+
+def test_session_record_normalizes_malformed_annotation_provenance() -> None:
+    assert SessionRecord.from_dict({"annotated_fields": "model"}).annotated_fields == []
+    record = SessionRecord.from_dict(
+        {
+            "annotated_fields": [
+                "model",
+                7,
+                "model",
+                None,
+                "model_normalized",
+                "outcome",
+            ],
+            "deliverables": None,
+        }
+    )
+    assert record.annotated_fields == ["model", "outcome"]
+    assert record.deliverables == []
+
+
 def test_sync_pi_extraction_failure_does_not_advance_revision(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "retry.jsonl"
     source.write_bytes(PI_FIXTURE.read_bytes())
@@ -347,8 +564,25 @@ def test_sync_pi_extraction_failure_does_not_advance_revision(tmp_path: Path, mo
 
     assert result.exit_code == 0, result.output
     assert "signals extraction failed" in result.output
+    assert "0 unchanged" in result.output
+    assert "1 signal extraction failure" in result.output
     [record] = SessionStore(sessions_dir=sessions_dir).load_all()
     assert record.trajectory_revision is None
+
+    retry = CliRunner().invoke(
+        cli,
+        [
+            "--sessions-dir",
+            str(sessions_dir),
+            "sync",
+            "--harness",
+            "pi",
+            "--signals",
+        ],
+    )
+    assert retry.exit_code == 0, retry.output
+    assert "0 unchanged" in retry.output
+    assert "1 signal extraction failure" in retry.output
 
 
 def test_sync_pi_extractor_time_append_keeps_pre_read_revision(tmp_path: Path, monkeypatch) -> None:

--- a/packages/gptme-sessions/tests/test_cli_pi.py
+++ b/packages/gptme-sessions/tests/test_cli_pi.py
@@ -414,6 +414,58 @@ def test_sync_pi_refresh_preserves_explicit_annotations(tmp_path: Path, monkeypa
     ]
 
 
+def test_sync_pi_preserves_record_updates_that_land_during_extraction(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The final locked merge keeps unrelated concurrent record mutations."""
+    import gptme_sessions.cli as cli_module
+
+    source = tmp_path / "concurrent-record-update.jsonl"
+    fixture_lines = PI_FIXTURE.read_text().splitlines(keepends=True)
+    source.write_text("".join(fixture_lines[:7]))
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    sessions_dir = tmp_path / "records"
+    runner = CliRunner()
+    command = [
+        "--sessions-dir",
+        str(sessions_dir),
+        "sync",
+        "--harness",
+        "pi",
+        "--signals",
+    ]
+    first = runner.invoke(cli, command)
+    assert first.exit_code == 0, first.output
+
+    real_extract = cli_module.extract_from_path
+
+    def update_after_sync_read(path: Path) -> dict:
+        result = real_extract(path)
+        concurrent_store = SessionStore(sessions_dir=sessions_dir)
+        with concurrent_store.lock():
+            [latest] = concurrent_store.load_all()
+            latest.category = "concurrent-category"
+            latest.timestamp = "2026-08-31T20:00:00+00:00"
+            latest.attempt_kind = "infra_retry"
+            concurrent_store.rewrite([latest])
+        return result
+
+    monkeypatch.setattr("gptme_sessions.cli.extract_from_path", update_after_sync_read)
+    source.write_text("".join(fixture_lines))
+    refreshed = runner.invoke(cli, command)
+
+    assert refreshed.exit_code == 0, refreshed.output
+    [complete] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert complete.category == "concurrent-category"
+    assert complete.timestamp == "2026-08-31T20:00:00+00:00"
+    assert complete.attempt_kind == "infra_retry"
+    assert complete.token_count == 1317
+    assert complete.stop_reason == "stop"
+
+
 def test_sync_pi_merges_annotation_that_lands_during_extraction(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/packages/gptme-sessions/tests/test_cli_pi.py
+++ b/packages/gptme-sessions/tests/test_cli_pi.py
@@ -516,6 +516,11 @@ def test_sync_pi_merges_annotation_that_lands_during_extraction(
     assert complete.outcome == "noop"
     assert complete.annotated_fields == ["model", "outcome"]
     assert "manual:operator-note" in complete.deliverables
+    assert "test: create Pi fixture (526d692)" in complete.deliverables
+    assert any(
+        detail["value"] == "test: create Pi fixture (526d692)"
+        for detail in complete.deliverable_details
+    )
     assert complete.token_count == 1317
     assert complete.stop_reason == "stop"
 

--- a/packages/gptme-sessions/tests/test_cli_pi.py
+++ b/packages/gptme-sessions/tests/test_cli_pi.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from gptme_sessions import SessionRecord
 from gptme_sessions.cli import _discover_all, cli
 from gptme_sessions.discovery import extract_session_name
 from gptme_sessions.pi import PiSessionFormatError
@@ -108,6 +109,9 @@ def test_sync_pi_with_signals_retains_source_and_deduplicates(tmp_path: Path, mo
     assert record.session_name == "pi-fixture-productive-codex-001"
     assert record.project == "/workspace/pi-fixture-productive"
     assert record.model == "gpt-5.6-luna"
+    assert record.provider == "openai-codex"
+    assert record.stop_reason == "stop"
+    assert record.cost_usd == pytest.approx(0.0004264)
     assert record.outcome == "productive"
     assert record.token_count == 1317
     assert record.input_tokens == 1154
@@ -153,6 +157,53 @@ def test_sync_pi_with_signals_retains_source_and_deduplicates(tmp_path: Path, mo
     assert after_stat.st_mode == source_stat.st_mode
 
 
+def test_sync_pi_missing_revision_backfills_route_metadata_once(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A pre-revision Pi record gets one enrichment pass, then stays stable."""
+    source = tmp_path / "legacy.jsonl"
+    source.write_bytes(PI_FIXTURE.read_bytes())
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    sessions_dir = tmp_path / "records"
+    store = SessionStore(sessions_dir=sessions_dir)
+    store.append(
+        SessionRecord(
+            harness="pi",
+            trajectory_path=str(source.resolve()),
+            outcome="productive",
+            token_count=1317,
+        )
+    )
+    command = [
+        "--sessions-dir",
+        str(sessions_dir),
+        "sync",
+        "--harness",
+        "pi",
+        "--signals",
+    ]
+    runner = CliRunner()
+
+    first = runner.invoke(cli, command)
+    assert first.exit_code == 0, first.output
+    assert "updated 1" in first.output
+    [enriched] = store.load_all()
+    assert enriched.provider == "openai-codex"
+    assert enriched.model == "gpt-5.6-luna"
+    assert enriched.stop_reason == "stop"
+    assert enriched.cost_usd == pytest.approx(0.0004264)
+    assert enriched.trajectory_revision is not None
+
+    second = runner.invoke(cli, command)
+    assert second.exit_code == 0, second.output
+    assert "1 unchanged" in second.output
+    [stable] = store.load_all()
+    assert stable.to_dict() == enriched.to_dict()
+
+
 def test_sync_pi_canonicalizes_symlink_aliases(tmp_path: Path, monkeypatch) -> None:
     alias = tmp_path / "pi-alias.jsonl"
     alias.symlink_to(PI_FIXTURE.resolve())
@@ -180,6 +231,173 @@ def test_sync_pi_canonicalizes_symlink_aliases(tmp_path: Path, monkeypatch) -> N
     assert second.exit_code == 0, second.output
     assert "1 unchanged" in second.output
     assert len(SessionStore(sessions_dir=sessions_dir).load_all()) == 1
+
+
+def test_sync_pi_deduplicates_aliases_within_one_run(tmp_path: Path, monkeypatch) -> None:
+    alias_a = tmp_path / "pi-alias-a.jsonl"
+    alias_b = tmp_path / "pi-alias-b.jsonl"
+    alias_a.symlink_to(PI_FIXTURE.resolve())
+    alias_b.symlink_to(PI_FIXTURE.resolve())
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [alias_a, PI_FIXTURE, alias_b],
+    )
+    sessions_dir = tmp_path / "records"
+
+    result = CliRunner().invoke(
+        cli,
+        ["--sessions-dir", str(sessions_dir), "sync", "--harness", "pi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Imported 1 session(s)" in result.output
+    assert len(SessionStore(sessions_dir=sessions_dir).load_all()) == 1
+
+
+def test_sync_pi_refreshes_resumed_session_monotonically(tmp_path: Path, monkeypatch) -> None:
+    """A Pi file is resumable after any turn; changed revisions refresh signals."""
+    source = tmp_path / "resumed.jsonl"
+    fixture_lines = PI_FIXTURE.read_text().splitlines(keepends=True)
+    source.write_text(fixture_lines[0])
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    sessions_dir = tmp_path / "records"
+    runner = CliRunner()
+    command = [
+        "--sessions-dir",
+        str(sessions_dir),
+        "sync",
+        "--harness",
+        "pi",
+        "--signals",
+    ]
+
+    first = runner.invoke(cli, command)
+    assert first.exit_code == 0, first.output
+    [initial] = SessionStore(sessions_dir=sessions_dir).load_all()
+    initial_id = initial.session_id
+    initial_revision = initial.trajectory_revision
+    assert initial.outcome == "noop"
+    assert initial.duration_seconds == 0
+    assert initial.token_count is None
+    assert initial_revision is not None
+
+    source.write_text("".join(fixture_lines[:7]))
+    second = runner.invoke(cli, command)
+    assert second.exit_code == 0, second.output
+    assert "updated 1" in second.output
+    [midway] = SessionStore(sessions_dir=sessions_dir).load_all()
+    midway_revision = midway.trajectory_revision
+    assert midway.session_id == initial_id
+    assert midway.outcome == "noop"
+    assert midway.duration_seconds == 2
+    assert midway.token_count == 344
+    assert midway.stop_reason == "toolUse"
+    assert midway.cost_usd == pytest.approx(0.0001448)
+    assert midway_revision not in (None, initial_revision)
+
+    source.write_text("".join(fixture_lines))
+    third = runner.invoke(cli, command)
+    assert third.exit_code == 0, third.output
+    assert "updated 1" in third.output
+    [complete] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert complete.session_id == initial_id
+    assert complete.outcome == "productive"
+    assert complete.duration_seconds == 6
+    assert complete.token_count == 1317
+    assert complete.provider == "openai-codex"
+    assert complete.stop_reason == "stop"
+    assert complete.cost_usd == pytest.approx(0.0004264)
+    assert "test: create Pi fixture (526d692)" in complete.deliverables
+    assert complete.trajectory_revision not in (None, midway_revision)
+
+    unchanged = runner.invoke(cli, command)
+    assert unchanged.exit_code == 0, unchanged.output
+    assert "1 unchanged" in unchanged.output
+    [stable] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert stable.to_dict() == complete.to_dict()
+
+
+def test_sync_pi_extraction_failure_does_not_advance_revision(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "retry.jsonl"
+    source.write_bytes(PI_FIXTURE.read_bytes())
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    monkeypatch.setattr(
+        "gptme_sessions.cli.extract_from_path",
+        lambda path: (_ for _ in ()).throw(RuntimeError("injected extraction failure")),
+    )
+    sessions_dir = tmp_path / "records"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--sessions-dir",
+            str(sessions_dir),
+            "sync",
+            "--harness",
+            "pi",
+            "--signals",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "signals extraction failed" in result.output
+    [record] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert record.trajectory_revision is None
+
+
+def test_sync_pi_extractor_time_append_keeps_pre_read_revision(tmp_path: Path, monkeypatch) -> None:
+    """An append during extraction must force another refresh on the next sync."""
+    import gptme_sessions.cli as cli_module
+
+    source = tmp_path / "concurrent.jsonl"
+    fixture_lines = PI_FIXTURE.read_text().splitlines(keepends=True)
+    source.write_text("".join(fixture_lines[:7]))
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_pi_sessions",
+        lambda start, end: [source],
+    )
+    real_extract = cli_module.extract_from_path
+    revision_during_extract: str | None = None
+
+    def append_after_extract(path: Path) -> dict:
+        nonlocal revision_during_extract
+        result = real_extract(path)
+        revision_during_extract = cli_module._trajectory_revision(path)
+        path.write_text("".join(fixture_lines))
+        return result
+
+    monkeypatch.setattr("gptme_sessions.cli.extract_from_path", append_after_extract)
+    sessions_dir = tmp_path / "records"
+    command = [
+        "--sessions-dir",
+        str(sessions_dir),
+        "sync",
+        "--harness",
+        "pi",
+        "--signals",
+    ]
+    runner = CliRunner()
+
+    first = runner.invoke(cli, command)
+    assert first.exit_code == 0, first.output
+    [partial] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert partial.token_count == 344
+    assert partial.trajectory_revision == revision_during_extract
+    assert partial.trajectory_revision != cli_module._trajectory_revision(source)
+
+    monkeypatch.setattr("gptme_sessions.cli.extract_from_path", real_extract)
+    second = runner.invoke(cli, command)
+    assert second.exit_code == 0, second.output
+    assert "updated 1" in second.output
+    [complete] = SessionStore(sessions_dir=sessions_dir).load_all()
+    assert complete.token_count == 1317
+    assert complete.outcome == "productive"
 
 
 def test_sync_pi_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> None:

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -852,6 +852,30 @@ def test_discover_pi_sessions_uses_global_settings_session_dir(
     assert result == [session.resolve()]
 
 
+def test_discover_pi_sessions_isolates_recursive_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    agent = tmp_path / "agent"
+    sessions = agent / "sessions"
+    agent.mkdir()
+    (agent / "settings.json").write_text("[" * 10000 + "0" + "]" * 10000)
+    session = _make_pi_session(
+        sessions,
+        "default.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-default",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PI_CODING_AGENT_SESSION_DIR", raising=False)
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent))
+
+    with caplog.at_level(logging.WARNING):
+        result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
+
+    assert result == [session.resolve()]
+    assert "Ignoring unreadable Pi global settings" in caplog.text
+
+
 def test_discover_pi_sessions_keeps_tiny_noop_and_does_not_mutate(tmp_path: Path) -> None:
     """Small genuine sessions are retained; discovery only reads source bytes."""
     session = _make_pi_session(
@@ -1045,9 +1069,10 @@ def test_discover_pi_sessions_rejects_malformed_native_json(
     "invalid_value",
     [
         "NaN",
+        "1e400",
         "[" * 10000 + "0" + "]" * 10000,
     ],
-    ids=["nonfinite", "recursive"],
+    ids=["nonfinite-constant", "nonfinite-exponent", "recursive"],
 )
 def test_discover_pi_sessions_isolates_strict_json_failures(
     tmp_path: Path,

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -737,6 +737,25 @@ def test_discover_pi_sessions_direct_env_override_wins(
     assert result == [direct_session.resolve()]
 
 
+def test_discover_pi_sessions_keeps_named_user_env_path_literal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pi only expands bare ``~``/``~/``; ``~username`` stays cwd-relative."""
+    literal_sessions = tmp_path / "~pi-user-that-does-not-exist" / "sessions"
+    session = _make_pi_session(
+        literal_sessions,
+        "literal.jsonl",
+        "2026-03-05T10:00:00Z",
+        "pi-literal-env",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PI_CODING_AGENT_SESSION_DIR", "~pi-user-that-does-not-exist/sessions")
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
+
+    assert result == [session.resolve()]
+
+
 def test_discover_pi_sessions_agent_dir_env_fallback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -787,6 +806,28 @@ def test_discover_pi_sessions_uses_project_settings_session_dir(
     result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
 
     assert result == [project_session.resolve()]
+
+
+def test_discover_pi_sessions_keeps_named_user_setting_path_literal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (tmp_path / ".pi").mkdir()
+    (tmp_path / ".pi" / "settings.json").write_text(json.dumps({"sessionDir": "~bob/pi-literal"}))
+    session = _make_pi_session(
+        tmp_path / "~bob" / "pi-literal",
+        "literal.jsonl",
+        "2026-03-05T10:00:00Z",
+        "pi-literal-setting",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PI_CODING_AGENT_SESSION_DIR", raising=False)
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent))
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
+
+    assert result == [session.resolve()]
 
 
 def test_discover_pi_sessions_uses_global_settings_session_dir(
@@ -985,6 +1026,50 @@ def test_discover_pi_sessions_rejects_malformed_native_json(
             }
         )
         + "\n{not-json\n"
+    )
+    valid = _make_pi_session(
+        tmp_path,
+        "valid.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-valid",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5), pi_dir=tmp_path)
+
+    assert result == [valid.resolve()]
+    assert "invalid JSON on line 2" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "NaN",
+        "[" * 10000 + "0" + "]" * 10000,
+    ],
+    ids=["nonfinite", "recursive"],
+)
+def test_discover_pi_sessions_isolates_strict_json_failures(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    invalid_value: str,
+) -> None:
+    malformed = tmp_path / "strict-json-failure.jsonl"
+    malformed.write_text(
+        json.dumps(
+            {
+                "type": "session",
+                "version": 3,
+                "id": "strict-json-failure",
+                "timestamp": "2026-03-05T10:00:00Z",
+                "cwd": "/workspace",
+            }
+        )
+        + "\n"
+        + '{"type":"custom","id":"bad","parentId":null,'
+        + '"timestamp":"2026-03-05T10:00:01Z","value":'
+        + invalid_value
+        + "}\n"
     )
     valid = _make_pi_session(
         tmp_path,

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -755,6 +755,62 @@ def test_discover_pi_sessions_agent_dir_env_fallback(
     assert result == [session.resolve()]
 
 
+def test_discover_pi_sessions_uses_project_settings_session_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pi's project setting overrides its global setting and agent default."""
+    agent = tmp_path / "agent"
+    global_sessions = tmp_path / "global-sessions"
+    project_sessions = tmp_path / ".pi" / "custom-sessions"
+    agent.mkdir()
+    (tmp_path / ".pi").mkdir()
+    (agent / "settings.json").write_text(json.dumps({"sessionDir": str(global_sessions)}))
+    (tmp_path / ".pi" / "settings.json").write_text(
+        json.dumps({"sessionDir": ".pi/custom-sessions"})
+    )
+    _make_pi_session(
+        global_sessions,
+        "global.jsonl",
+        "2026-03-05T10:00:00Z",
+        "pi-global",
+    )
+    project_session = _make_pi_session(
+        project_sessions,
+        "project.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-project",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PI_CODING_AGENT_SESSION_DIR", raising=False)
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent))
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
+
+    assert result == [project_session.resolve()]
+
+
+def test_discover_pi_sessions_uses_global_settings_session_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent = tmp_path / "agent"
+    configured_sessions = tmp_path / "configured-sessions"
+    agent.mkdir()
+    (agent / "settings.json").write_text(json.dumps({"sessionDir": str(configured_sessions)}))
+    session = _make_pi_session(
+        configured_sessions,
+        "configured.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-configured",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PI_CODING_AGENT_SESSION_DIR", raising=False)
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(agent))
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
+
+    assert result == [session.resolve()]
+
+
 def test_discover_pi_sessions_keeps_tiny_noop_and_does_not_mutate(tmp_path: Path) -> None:
     """Small genuine sessions are retained; discovery only reads source bytes."""
     session = _make_pi_session(
@@ -875,6 +931,45 @@ def test_discover_pi_sessions_rejects_non_native_pi_formats(
     assert error_match in caplog.text
 
 
+def test_discover_pi_sessions_isolates_unhashable_entry_type(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    malformed = tmp_path / "unhashable-entry-type.jsonl"
+    malformed.write_text(
+        json.dumps(
+            {
+                "type": "session",
+                "version": 3,
+                "id": "unhashable-entry-type",
+                "timestamp": "2026-03-05T10:00:00Z",
+                "cwd": "/workspace",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": [],
+                "id": "bad-entry",
+                "parentId": None,
+                "timestamp": "2026-03-05T10:00:01Z",
+            }
+        )
+        + "\n"
+    )
+    valid = _make_pi_session(
+        tmp_path,
+        "valid.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-valid",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5), pi_dir=tmp_path)
+
+    assert result == [valid.resolve()]
+    assert "unsupported Pi v3 entry type []" in caplog.text
+
+
 def test_discover_pi_sessions_rejects_malformed_native_json(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -933,6 +1028,84 @@ def test_discover_pi_sessions_skips_invalid_timestamp_but_keeps_sibling(
 
     assert result == [valid.resolve()]
     assert "invalid header timestamp" in caplog.text
+
+
+def test_discover_pi_sessions_skips_overflowing_utc_timestamp_but_keeps_sibling(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    overflowing = tmp_path / "overflowing-timestamp.jsonl"
+    overflowing.write_text(
+        json.dumps(
+            {
+                "type": "session",
+                "version": 3,
+                "id": "overflowing-timestamp",
+                "timestamp": "9999-12-31T23:59:59-14:00",
+                "cwd": "/workspace",
+            }
+        )
+        + "\n"
+    )
+    valid = _make_pi_session(
+        tmp_path,
+        "valid.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-valid",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5), pi_dir=tmp_path)
+
+    assert result == [valid.resolve()]
+    assert "invalid header timestamp" in caplog.text
+
+
+def test_discover_pi_sessions_filters_old_headers_before_full_parse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gptme_sessions.discovery as discovery_module
+
+    old = _make_pi_session(
+        tmp_path,
+        "old.jsonl",
+        "2020-03-05T11:00:00Z",
+        "pi-old",
+    )
+    current = _make_pi_session(
+        tmp_path,
+        "current.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-current",
+    )
+    real_load = discovery_module._load_pi_native_records
+    fully_loaded: list[Path] = []
+
+    def recording_load(path: Path) -> list[dict] | None:
+        fully_loaded.append(path)
+        return real_load(path)
+
+    monkeypatch.setattr(discovery_module, "_load_pi_native_records", recording_load)
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5), pi_dir=tmp_path)
+
+    assert result == [current.resolve()]
+    assert fully_loaded == [current]
+    assert old not in fully_loaded
+
+
+def test_discover_pi_sessions_deduplicates_canonical_aliases(tmp_path: Path) -> None:
+    target = _make_pi_session(
+        tmp_path,
+        "target.jsonl",
+        "2026-03-05T11:00:00Z",
+        "pi-target",
+    )
+    (tmp_path / "alias-a.jsonl").symlink_to(target)
+    (tmp_path / "alias-b.jsonl").symlink_to(target)
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5), pi_dir=tmp_path)
+
+    assert result == [target.resolve()]
 
 
 def test_discover_pi_sessions_skips_unreadable_file_but_keeps_sibling(

--- a/packages/gptme-sessions/tests/test_signals_pi.py
+++ b/packages/gptme-sessions/tests/test_signals_pi.py
@@ -269,8 +269,8 @@ def test_malformed_pi_json_fails_visibly(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "invalid_value",
-    ["NaN", "[" * 10000 + "0" + "]" * 10000],
-    ids=["nonfinite", "recursive"],
+    ["NaN", "1e400", "[" * 10000 + "0" + "]" * 10000],
+    ids=["nonfinite-constant", "nonfinite-exponent", "recursive"],
 )
 def test_strict_pi_json_failures_fail_visibly(tmp_path: Path, invalid_value: str) -> None:
     path = tmp_path / "strict-invalid.jsonl"

--- a/packages/gptme-sessions/tests/test_signals_pi.py
+++ b/packages/gptme-sessions/tests/test_signals_pi.py
@@ -267,6 +267,27 @@ def test_malformed_pi_json_fails_visibly(tmp_path: Path) -> None:
         parse_trajectory(path)
 
 
+@pytest.mark.parametrize(
+    "invalid_value",
+    ["NaN", "[" * 10000 + "0" + "]" * 10000],
+    ids=["nonfinite", "recursive"],
+)
+def test_strict_pi_json_failures_fail_visibly(tmp_path: Path, invalid_value: str) -> None:
+    path = tmp_path / "strict-invalid.jsonl"
+    path.write_text(
+        json.dumps(_header())
+        + "\n"
+        + '{"type":"custom","id":"bad","parentId":null,'
+        + '"timestamp":"2026-08-31T12:00:01Z","value":'
+        + invalid_value
+        + "}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PiSessionFormatError, match="invalid JSON.*line 2"):
+        parse_trajectory(path)
+
+
 def test_provider_error_and_failed_tool_are_errors() -> None:
     records = [
         _header(),


### PR DESCRIPTION
## Summary

- mirror Pi 0.84.4 session directory precedence across direct env, global settings, project settings, and agent defaults, including literal named-user tilde paths
- isolate malformed JSON, entry types, non-finite constants and exponent overflow, recursion, and UTC overflow per file; prefilter old sessions; deduplicate canonical aliases with honest accounting
- track both the native source revision and an extraction-schema version so resumed Pi sessions refresh after appends or parser semantic changes
- preserve explicit operator annotations and unrelated concurrent record edits through resumed-session refreshes, while retaining additive source and manual deliverables
- apply Pi-only monotonic refresh semantics for source-owned outcome, duration, usage, route metadata, and additive deliverables
- retain the pre-extraction revision so concurrent appends force another refresh instead of freezing stale totals
- report failed signal extraction as retryable failure rather than unchanged history

Follow-up to #1571 after independent adversarial review.

## Required merge order

Satisfied: #1573 merged before this PR. `PI_EXTRACTION_SCHEMA_VERSION = 1` therefore represents the post-#1573 missing-cost semantics.

## Verification

- 1,294 gptme-sessions tests passed
- canonical MyPy passed for 23 source files
- Ruff checks passed
- exact-file pre-commit hooks passed
- staged native replay covered header-only to partial to complete resume: noop and 0 tokens, then noop and 344 tokens, then productive and 1,317 tokens on one stable record
- two independent final reviews found no remaining P1/P2 code issue on head `81c44eda`

## Review findings covered

- resumed native sessions no longer freeze an early NOOP or stale counters
- explicit annotations are durable provenance and win over source refresh, even when annotation races with extraction
- unrelated concurrent record edits survive extraction; source and manual deliverables/details are unioned
- unchanged history is not reparsed forever, while extractor schema bumps still reprocess it once
- missing historical cost is repaired from false 0.0 to absent when the current extractor reports no cost
- extraction failure does not advance the revision or count as unchanged
- an append during extraction is retried on the next sync
- malformed, non-finite, exponent-overflowed, deeply nested, or aliased siblings cannot abort or duplicate the batch
- deeply nested Pi settings fall back safely instead of aborting discovery

## Nonblocking follow-up

Pi also accepts `file://` sessionDir values. That parity edge is intentionally left out of this hardening head and remains follow-up scope.
