### PR TITLE
fix(gptme-sessions): parse Codex wait continuations

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -59,20 +59,25 @@ def _codex_output_text(raw_output: object) -> str:
     return ""
 
 
-# Codex JS-tool wrapper header. Must start the payload; later application text
-# mentioning "Script completed" is not wrapper metadata.
+# Codex tool wrapper header. Must start the payload; later application text
+# mentioning wrapper status phrases is not metadata.
 _CODEX_WRAPPER_HEADER_RE = re.compile(
-    r"^Script completed(?:\n(?:Wall time [^\n]+|Process exited with code \d+|Output:|\s*))*"
+    r"^(?:Script completed(?:\n(?:Wall time [^\n]+|Process exited with code \d+|Output:|\s*))*"
+    r"|Process exited with code \d+(?:\nOutput:)?)"
 )
 
 
 def _codex_output_metadata(output: str) -> tuple[str, int | None]:
     """Decode nested command output and exit code from a Codex wrapper."""
-    code_match = re.search(r"Process exited with code (\d+)", output)
+    header_match = _CODEX_WRAPPER_HEADER_RE.match(output)
+    code_match = (
+        re.search(r"Process exited with code (\d+)", header_match.group(0))
+        if header_match
+        else None
+    )
     wrapper_exit_code = int(code_match.group(1)) if code_match else None
     nested_parts: list[str] = []
     nested_exit_codes: list[int] = []
-    header_match = _CODEX_WRAPPER_HEADER_RE.match(output)
     if header_match:
         remainder = output[header_match.end() :].lstrip("\n")
         for line in remainder.splitlines():

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -59,27 +59,41 @@ def _codex_output_text(raw_output: object) -> str:
     return ""
 
 
+# Codex JS-tool wrapper header. Must start the payload; later application text
+# mentioning "Script completed" is not wrapper metadata.
+_CODEX_WRAPPER_HEADER_RE = re.compile(
+    r"^Script completed(?:\n(?:Wall time [^\n]+|Process exited with code \d+|Output:|\s*))*"
+)
+
+
 def _codex_output_metadata(output: str) -> tuple[str, int | None]:
     """Decode nested command output and exit code from a Codex wrapper."""
     code_match = re.search(r"Process exited with code (\d+)", output)
     wrapper_exit_code = int(code_match.group(1)) if code_match else None
     nested_parts: list[str] = []
     nested_exit_codes: list[int] = []
-    # The JavaScript tool wrapper emits this marker before its JSON result.
-    # Without it, an application may simply have printed similarly shaped JSON.
-    if "Script completed" in output:
-        for candidate in re.findall(r"\{[^\n]*\}", output):
+    header_match = _CODEX_WRAPPER_HEADER_RE.match(output)
+    if header_match:
+        remainder = output[header_match.end() :].lstrip("\n")
+        for line in remainder.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if not stripped.startswith("{"):
+                break
             try:
-                value = json.loads(candidate)
+                value = json.loads(stripped)
             except (json.JSONDecodeError, TypeError):
-                continue
+                break
             if not isinstance(value, dict):
-                continue
+                break
             nested_output = value.get("output")
             nested_code = value.get("exit_code")
             if isinstance(nested_output, str) and isinstance(nested_code, int):
                 nested_parts.append(nested_output)
                 nested_exit_codes.append(nested_code)
+            else:
+                break
     # Raw JSON has escaped newlines that make commit regexes consume the whole
     # object as a message. Prefer decoded command output when it is available,
     # but never let command output override an explicit wrapper status.

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -59,17 +59,23 @@ def _codex_output_text(raw_output: object) -> str:
     return ""
 
 
-# Codex tool wrapper header. Must start the payload; later application text
-# mentioning wrapper status phrases is not metadata.
-_CODEX_WRAPPER_HEADER_RE = re.compile(
-    r"^(?:Script completed(?:\n(?:Wall time [^\n]+|Process exited with code \d+|Output:|\s*))*"
-    r"|Process exited with code \d+(?:\nOutput:)?)"
+# The JS ``exec``/``wait`` wrapper identifies itself with ``Script completed``.
+# Legacy ``exec_command`` output has no such marker, so its status is trusted only
+# when the caller is known to be that tool. This keeps arbitrary JS-tool output
+# beginning with ``Process exited with code N`` from impersonating metadata.
+_CODEX_SCRIPT_WRAPPER_HEADER_RE = re.compile(
+    r"^Script completed(?:\n(?:Wall time [^\n]+|Process exited with code \d+|Output:|\s*))*"
 )
+_CODEX_EXEC_COMMAND_HEADER_RE = re.compile(r"^Process exited with code \d+(?:\nOutput:)?")
 
 
-def _codex_output_metadata(output: str) -> tuple[str, int | None]:
+def _codex_output_metadata(
+    output: str, *, allow_legacy_exec_command: bool = False
+) -> tuple[str, int | None]:
     """Decode nested command output and exit code from a Codex wrapper."""
-    header_match = _CODEX_WRAPPER_HEADER_RE.match(output)
+    header_match = _CODEX_SCRIPT_WRAPPER_HEADER_RE.match(output)
+    if header_match is None and allow_legacy_exec_command:
+        header_match = _CODEX_EXEC_COMMAND_HEADER_RE.match(output)
     code_match = (
         re.search(r"Process exited with code (\d+)", header_match.group(0))
         if header_match
@@ -1715,7 +1721,10 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
 
                 # Error detection from shell output. Async ``wait`` output often
                 # nests the actual command result as escaped JSON.
-                scan_output, exit_code = _codex_output_metadata(output)
+                scan_output, exit_code = _codex_output_metadata(
+                    output,
+                    allow_legacy_exec_command=(tool_name == "exec_command"),
+                )
                 if exit_code is not None and exit_code != 0:
                     error_count += 1
 

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -64,7 +64,7 @@ def _codex_output_text(raw_output: object) -> str:
 # when the caller is known to be that tool. This keeps arbitrary JS-tool output
 # beginning with ``Process exited with code N`` from impersonating metadata.
 _CODEX_SCRIPT_WRAPPER_HEADER_RE = re.compile(
-    r"^Script completed(?:\n(?:Wall time [^\n]+|Process exited with code \d+|Output:|\s*))*"
+    r"^Script completed\nWall time [^\n]+" r"(?:\nProcess exited with code \d+)?\nOutput:"
 )
 _CODEX_EXEC_COMMAND_HEADER_RE = re.compile(r"^Process exited with code \d+(?:\nOutput:)?")
 

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -47,6 +47,41 @@ _CC_WRITE_TOOLS = {"Write", "Edit", "NotebookEdit"}
 
 _WARNING_PHRASE_RE = re.compile(r"error:|\bfailed\b|\bfailures?\b|\btraceback\b|\bexception\b")
 
+
+def _codex_output_text(raw_output: object) -> str:
+    """Normalize Codex string or content-block-list tool output to text."""
+    if isinstance(raw_output, str):
+        return raw_output
+    if isinstance(raw_output, list):
+        return "\n".join(
+            str(block.get("text", "")) for block in raw_output if isinstance(block, dict)
+        )
+    return ""
+
+
+def _codex_output_metadata(output: str) -> tuple[str, int | None]:
+    """Decode nested command output and exit code from a Codex wrapper."""
+    code_match = re.search(r"Process exited with code (\d+)", output)
+    exit_code = int(code_match.group(1)) if code_match else None
+    nested_parts: list[str] = []
+    for candidate in re.findall(r"\{[^\n]*\}", output):
+        try:
+            value = json.loads(candidate)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(value, dict):
+            continue
+        nested_output = value.get("output")
+        if isinstance(nested_output, str):
+            nested_parts.append(nested_output)
+        nested_code = value.get("exit_code")
+        if isinstance(nested_code, int):
+            exit_code = nested_code
+    # Raw JSON has escaped newlines that make commit regexes consume the whole
+    # object as a message. Prefer decoded command output when it is available.
+    return ("\n".join(nested_parts) if nested_parts else output, exit_code)
+
+
 # Regex to detect background bash task output file paths in CC sessions.
 # When CC runs a Bash command in background mode, the tool result contains:
 # "Command running in background with ID: TASKID. Output is being written to: PATH"
@@ -1644,15 +1679,15 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                         )
 
             elif payload_type == "function_call_output":
-                output = payload.get("output") or ""
+                output = _codex_output_text(payload.get("output"))
                 call_id = payload.get("call_id", "")
                 tool_name = call_id_to_name.get(call_id, "")
 
-                # Error detection from shell output
-                if "Process exited with code " in output:
-                    code_match = re.search(r"Process exited with code (\d+)", output)
-                    if code_match and code_match.group(1) != "0":
-                        error_count += 1
+                # Error detection from shell output. Async ``wait`` output often
+                # nests the actual command result as escaped JSON.
+                scan_output, exit_code = _codex_output_metadata(output)
+                if exit_code is not None and exit_code != 0:
+                    error_count += 1
 
                 # Git commit detection from shell output. Codex uses a persistent
                 # shell session: an initial exec_command spawns the shell, and
@@ -1661,8 +1696,8 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                 # attached to a write_stdin call. Codex outputs are also verbose
                 # (full file dumps), so scan a wider window than the legacy
                 # 500-char head.
-                if tool_name in ("exec_command", "write_stdin"):
-                    for commit_match in _COMMIT_RE.finditer(output[:8000]):
+                if tool_name in ("exec_command", "write_stdin", "wait"):
+                    for commit_match in _COMMIT_RE.finditer(scan_output[:8000]):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
                         commit_value = f"{commit_msg} ({commit_hash})"
@@ -1683,23 +1718,14 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                 tool_name = call_id_to_name.get(call_id, "")
 
                 if tool_name == "exec":
-                    raw_output = payload.get("output")
-                    if isinstance(raw_output, str):
-                        output = raw_output
-                    elif isinstance(raw_output, list):
-                        output = "\n".join(
-                            block.get("text", "") for block in raw_output if isinstance(block, dict)
-                        )
-                    else:
-                        output = ""
+                    output = _codex_output_text(payload.get("output"))
 
                     # Error detection from shell output
-                    if "Process exited with code " in output:
-                        code_match = re.search(r"Process exited with code (\d+)", output)
-                        if code_match and code_match.group(1) != "0":
-                            error_count += 1
+                    scan_output, exit_code = _codex_output_metadata(output)
+                    if exit_code is not None and exit_code != 0:
+                        error_count += 1
 
-                    for commit_match in _COMMIT_RE.finditer(output):
+                    for commit_match in _COMMIT_RE.finditer(scan_output):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
                         commit_value = f"{commit_msg} ({commit_hash})"
@@ -1711,6 +1737,34 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                             provenance_class="session_committed",
                             evidence={"source": "trajectory", "tool_name": "exec"},
                         )
+
+        elif rec_type == "event_msg":
+            payload = record.get("payload") or {}
+            if payload.get("type") == "patch_apply_end" and payload.get("success") is True:
+                changes = payload.get("changes") or {}
+                if not isinstance(changes, dict):
+                    continue
+                tool_calls["apply_patch"] = tool_calls.get("apply_patch", 0) + 1
+                current_turn_has_tool = True
+                for raw_path, change in changes.items():
+                    if not isinstance(raw_path, str) or not isinstance(change, dict):
+                        continue
+                    if change.get("type") == "delete":
+                        continue
+                    path = raw_path.strip()
+                    if not path:
+                        continue
+                    if "/journal/" in path or path.startswith("journal/"):
+                        journal_paths.append(path)
+                        continue
+                    file_writes.append(path)
+                    _record_deliverable_detail(
+                        detail_by_value,
+                        value=path,
+                        kind="file",
+                        provenance_class="tool_authored",
+                        evidence={"source": "trajectory", "tool_name": "apply_patch"},
+                    )
 
     # Finalize the last turn (not followed by another turn_context)
     if current_turn_has_tool:

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -62,23 +62,34 @@ def _codex_output_text(raw_output: object) -> str:
 def _codex_output_metadata(output: str) -> tuple[str, int | None]:
     """Decode nested command output and exit code from a Codex wrapper."""
     code_match = re.search(r"Process exited with code (\d+)", output)
-    exit_code = int(code_match.group(1)) if code_match else None
+    wrapper_exit_code = int(code_match.group(1)) if code_match else None
     nested_parts: list[str] = []
-    for candidate in re.findall(r"\{[^\n]*\}", output):
-        try:
-            value = json.loads(candidate)
-        except (json.JSONDecodeError, TypeError):
-            continue
-        if not isinstance(value, dict):
-            continue
-        nested_output = value.get("output")
-        if isinstance(nested_output, str):
-            nested_parts.append(nested_output)
-        nested_code = value.get("exit_code")
-        if isinstance(nested_code, int):
-            exit_code = nested_code
+    nested_exit_codes: list[int] = []
+    # The JavaScript tool wrapper emits this marker before its JSON result.
+    # Without it, an application may simply have printed similarly shaped JSON.
+    if "Script completed" in output:
+        for candidate in re.findall(r"\{[^\n]*\}", output):
+            try:
+                value = json.loads(candidate)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(value, dict):
+                continue
+            nested_output = value.get("output")
+            nested_code = value.get("exit_code")
+            if isinstance(nested_output, str) and isinstance(nested_code, int):
+                nested_parts.append(nested_output)
+                nested_exit_codes.append(nested_code)
     # Raw JSON has escaped newlines that make commit regexes consume the whole
-    # object as a message. Prefer decoded command output when it is available.
+    # object as a message. Prefer decoded command output when it is available,
+    # but never let command output override an explicit wrapper status.
+    exit_code = (
+        wrapper_exit_code
+        if wrapper_exit_code is not None
+        else nested_exit_codes[-1]
+        if nested_exit_codes
+        else None
+    )
     return ("\n".join(nested_parts) if nested_parts else output, exit_code)
 
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4240,6 +4240,142 @@ def test_extract_signals_codex_exec_commit_after_8k_chars():
     assert "build: big (feed1234)" in signals["git_commits"]
 
 
+def test_extract_signals_codex_wait_continuation_block_output():
+    """Async exec output returned by ``wait`` remains productive.
+
+    Sanitized from a real Codex trajectory where ``exec`` first returned only
+    a cell ID and the later ``wait`` output carried the commit line.
+    """
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:30Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec_async",
+                "name": "exec",
+                "input": (
+                    'const r = await tools.exec_command({"cmd":"git commit -m '
+                    '\\"feat: async work\\""});\ntext(r.output);\n'
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:40Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_async",
+                "output": "Script running with cell ID 123\nWall time 10.0 seconds\nOutput:\n",
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:41Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "wait",
+                "call_id": "call_wait_async",
+                "arguments": '{"cell_id":"123","yield_time_ms":30000}',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_wait_async",
+                "output": [
+                    {
+                        "type": "input_text",
+                        "text": "Script completed\nWall time 9.7 seconds\nOutput:\n",
+                    },
+                    {
+                        "type": "input_text",
+                        "text": (
+                            '{"exit_code":0,"output":"[master 07388abc6c] '
+                            'feat: async work\\n 2 files changed\\n"}'
+                        ),
+                    },
+                ],
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["tool_calls"] == {"exec": 1, "wait": 1}
+    assert signals["error_count"] == 0
+    assert signals["git_commits"] == ["feat: async work (07388abc6c)"]
+    assert is_productive(signals) is True
+
+
+def test_extract_signals_codex_wait_continuation_failure():
+    """A failed async command reported by ``wait`` counts as an error."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:41Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "wait",
+                "call_id": "call_wait_failure",
+                "arguments": '{"cell_id":"124","yield_time_ms":30000}',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_wait_failure",
+                "output": [
+                    {"type": "input_text", "text": "Script completed\n"},
+                    {
+                        "type": "input_text",
+                        "text": '{"exit_code":1,"output":"tests failed"}',
+                    },
+                ],
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["tool_calls"] == {"wait": 1}
+    assert signals["error_count"] == 1
+    assert signals["git_commits"] == []
+
+
+def test_extract_signals_codex_patch_apply_end_file_writes():
+    """Successful nested patch events expose their changed files."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T21:15:57Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "call_id": "exec-patch-1",
+                "success": True,
+                "changes": {
+                    "/workspace/src/new.py": {"type": "add"},
+                    "/workspace/src/existing.py": {"type": "update"},
+                    "/workspace/src/removed.py": {"type": "delete"},
+                },
+            },
+        }
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["tool_calls"] == {"apply_patch": 1}
+    assert signals["file_writes"] == [
+        "/workspace/src/new.py",
+        "/workspace/src/existing.py",
+    ]
+    assert is_productive(signals) is True
+
+
 def test_extract_usage_codex():
     """Extract model, token, and rate-limit info from Codex trajectory."""
     msgs = [

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4347,6 +4347,72 @@ def test_extract_signals_codex_wait_continuation_failure():
     assert signals["git_commits"] == []
 
 
+def test_extract_signals_codex_wrapper_exit_code_takes_precedence():
+    """Command JSON output cannot override the Codex wrapper exit status."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "wait",
+                "call_id": "call_wait_wrapper_status",
+                "arguments": '{"cell_id":"125","yield_time_ms":30000}',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:51Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_wait_wrapper_status",
+                "output": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "Script completed\nProcess exited with code 0\nOutput:\n"
+                            '{"exit_code":1,"output":"application data"}'
+                        ),
+                    }
+                ],
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["error_count"] == 0
+
+
+def test_extract_signals_codex_ignores_unwrapped_exit_code_json():
+    """Arbitrary command JSON is not interpreted as Codex metadata."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "call_id": "call_exec_json",
+                "input": 'const r = await tools.exec_command({"cmd":"cat result.json"});',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:51Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_json",
+                "output": '{"exit_code":1,"output":"application data"}',
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["error_count"] == 0
+
+
 def test_extract_signals_codex_patch_apply_end_file_writes():
     """Successful nested patch events expose their changed files."""
     msgs = [

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4413,6 +4413,37 @@ def test_extract_signals_codex_ignores_unwrapped_exit_code_json():
     assert signals["error_count"] == 0
 
 
+def test_extract_signals_codex_ignores_embedded_script_completed_json():
+    """Application text mentioning Script completed is not wrapper metadata."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "call_id": "call_exec_embedded_wrapper",
+                "input": 'const r = await tools.exec_command({"cmd":"cat result.json"});',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:51Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_embedded_wrapper",
+                "output": (
+                    "command ok\nScript completed\n" '{"exit_code":1,"output":"application data"}'
+                ),
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["error_count"] == 0
+
+
 def test_extract_signals_codex_patch_apply_end_file_writes():
     """Successful nested patch events expose their changed files."""
     msgs = [

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4330,7 +4330,10 @@ def test_extract_signals_codex_wait_continuation_failure():
                 "type": "function_call_output",
                 "call_id": "call_wait_failure",
                 "output": [
-                    {"type": "input_text", "text": "Script completed\n"},
+                    {
+                        "type": "input_text",
+                        "text": "Script completed\nWall time 1.2 seconds\nOutput:\n",
+                    },
                     {
                         "type": "input_text",
                         "text": '{"exit_code":1,"output":"tests failed"}',
@@ -4370,7 +4373,8 @@ def test_extract_signals_codex_wrapper_exit_code_takes_precedence():
                     {
                         "type": "input_text",
                         "text": (
-                            "Script completed\nProcess exited with code 0\nOutput:\n"
+                            "Script completed\nWall time 1.2 seconds\n"
+                            "Process exited with code 0\nOutput:\n"
                             '{"exit_code":1,"output":"application data"}'
                         ),
                     }
@@ -4440,6 +4444,35 @@ def test_extract_signals_codex_ignores_application_process_exit_phrase(output: s
                 "type": "custom_tool_call_output",
                 "call_id": "call_exec_application_status",
                 "output": output,
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["error_count"] == 0
+
+
+def test_extract_signals_codex_ignores_status_after_statusless_script_wrapper():
+    """A status-like first application line is not wrapper metadata."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "wait",
+                "call_id": "call_wait_statusless_wrapper",
+                "arguments": '{"cell_id":"126","yield_time_ms":30000}',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:51Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_wait_statusless_wrapper",
+                "output": "Script completed\nProcess exited with code 1\napplication output",
             },
         },
     ]

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4413,6 +4413,35 @@ def test_extract_signals_codex_ignores_unwrapped_exit_code_json():
     assert signals["error_count"] == 0
 
 
+def test_extract_signals_codex_ignores_embedded_process_exit_phrase():
+    """Application text containing a wrapper status phrase is not metadata."""
+    msgs = [
+        {
+            "timestamp": "2026-08-26T06:35:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "call_id": "call_exec_embedded_status",
+                "input": 'const r = await tools.exec_command({"cmd":"cat output.txt"});',
+            },
+        },
+        {
+            "timestamp": "2026-08-26T06:35:51Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_embedded_status",
+                "output": "command ok\nProcess exited with code 1\nstill application output",
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["error_count"] == 0
+
+
 def test_extract_signals_codex_ignores_embedded_script_completed_json():
     """Application text mentioning Script completed is not wrapper metadata."""
     msgs = [

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4413,7 +4413,14 @@ def test_extract_signals_codex_ignores_unwrapped_exit_code_json():
     assert signals["error_count"] == 0
 
 
-def test_extract_signals_codex_ignores_embedded_process_exit_phrase():
+@pytest.mark.parametrize(
+    "output",
+    [
+        "command ok\nProcess exited with code 1\nstill application output",
+        "Process exited with code 1\nstill application output",
+    ],
+)
+def test_extract_signals_codex_ignores_application_process_exit_phrase(output: str):
     """Application text containing a wrapper status phrase is not metadata."""
     msgs = [
         {
@@ -4422,7 +4429,7 @@ def test_extract_signals_codex_ignores_embedded_process_exit_phrase():
             "payload": {
                 "type": "custom_tool_call",
                 "name": "exec",
-                "call_id": "call_exec_embedded_status",
+                "call_id": "call_exec_application_status",
                 "input": 'const r = await tools.exec_command({"cmd":"cat output.txt"});',
             },
         },
@@ -4431,8 +4438,8 @@ def test_extract_signals_codex_ignores_embedded_process_exit_phrase():
             "type": "response_item",
             "payload": {
                 "type": "custom_tool_call_output",
-                "call_id": "call_exec_embedded_status",
-                "output": "command ok\nProcess exited with code 1\nstill application output",
+                "call_id": "call_exec_application_status",
+                "output": output,
             },
         },
     ]


### PR DESCRIPTION
## Summary

- normalize Codex string/content-block tool outputs and decode nested command metadata
- recognize commits and failures returned by asynchronous `wait` continuations
- count successful `patch_apply_end` events and expose added/updated paths as file writes

## Reproduction

A Codex `custom_tool_call(name="exec")` can initially return only `Script running with cell ID ...`; the real command output later arrives as a content-block-list `function_call_output` for `wait`, often with JSON-escaped newlines. The previous extractor counted `wait` but never scanned that output, so productive sessions could retain an empty deliverable set.

## Verification

- `uv run --package gptme-sessions pytest -q packages/gptme-sessions/tests/test_sessions.py packages/gptme-sessions/tests/test_post_session.py --tb=short` — 377 passed
- `uv run ruff check packages/gptme-sessions/src/gptme_sessions/signals.py packages/gptme-sessions/tests/test_sessions.py`
- replayed two sanitized-source real trajectories:
  - wait-heavy run: productive, 4 commits, 12 file writes, 47 waits, 11 patch events
  - nested-patch run: productive, 15 file writes, 13 patch events

Closes #1567
