### PR TITLE
feat(gptme-voice): add remote body adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Reusable Python packages, installable individually. See [packages/README.md](./p
 | [gptme-activity-summary](./packages/gptme-activity-summary/) | Activity summarization — journals, GitHub, sessions, tweets, email |
 | [gptme-backoff](./packages/gptme-backoff/) | Retry utilities: exponential backoff, jitter, async/sync decorators |
 | [gptme-bob-status](./packages/gptme-bob-status/) | Bob-specific StatusProvider for `gptme-util status` |
+| [gptme-body-protocol](./packages/gptme-body-protocol/) | Neutral versioned wire DTOs for body-node clients and servers |
 | [gptme-cc-memory](./packages/gptme-cc-memory/) | Typed, git-tracked, hook-injected session memory for Claude Code |
 | [gptme-codegraph](./packages/gptme-codegraph/) | Structural code retrieval with tree-sitter (call graph, blast/impact analysis, MCP tools) |
 | [gptme-contrib-lib](./packages/gptme-contrib-lib/) | Shared utilities |

--- a/packages/README.md
+++ b/packages/README.md
@@ -14,6 +14,7 @@ Python packages for gptme agents.
 | **gptodo** | Task management and work queues | `uv pip install -e packages/gptodo` |
 | **gptme-activity-summary** | Activity summarization (journals, GitHub, sessions, tweets, email) | `uv pip install -e packages/gptme-activity-summary` |
 | **gptme-browser-semantic** | Semantic observe/act/extract over gptme's ARIA snapshot (Path A; no stagehand) | `uv pip install -e packages/gptme-browser-semantic` |
+| **gptme-body-protocol** | Neutral versioned wire DTOs shared by voice clients and body nodes | `uv pip install -e packages/gptme-body-protocol` |
 | **gptme-sessions** | Session tracking, analytics, and trajectory extraction | `uv pip install -e packages/gptme-sessions` |
 | **gptme-voice** | Voice interface using OpenAI Realtime API | `uv pip install -e packages/gptme-voice` |
 | **gptme-whatsapp** | WhatsApp integration for agents | `uv pip install -e packages/gptme-whatsapp` |

--- a/packages/gptme-body-protocol/README.md
+++ b/packages/gptme-body-protocol/README.md
@@ -1,0 +1,17 @@
+# gptme-body-protocol
+
+Small, transport-neutral wire models for a gptme Brain↔Body connection.
+
+`gptme-voice` and a body node need to agree on authenticated handshakes and
+bounded goal commands without importing one another's runtime. This package is
+that shared seam. The initial `bob-body/0` protocol supports:
+
+- an authenticated controller handshake;
+- stable controller and command IDs;
+- command TTLs;
+- `status`, relative `move`, relative `turn`, preemptive `stop`, and `interact`;
+- newline-framed JSON encoding for the current native-local transport.
+
+The package defines DTOs and framing only. Controller leases, idempotency,
+deadman behavior, collision safety, and telemetry production belong to the body
+node. Model-facing schemas and global request bounds belong to `gptme-voice`.

--- a/packages/gptme-body-protocol/README.md
+++ b/packages/gptme-body-protocol/README.md
@@ -6,8 +6,8 @@ Small, transport-neutral wire models for a gptme Brain↔Body connection.
 bounded goal commands without importing one another's runtime. This package is
 that shared seam. The initial `bob-body/0` protocol supports:
 
-- an authenticated controller handshake;
-- stable controller and command IDs;
+- an authenticated controller handshake that must echo `bob-body/0`;
+- stable controller and command IDs (command results must repeat `command_id`);
 - command TTLs;
 - `status`, relative `move`, relative `turn`, preemptive `stop`, and `interact`;
 - newline-framed JSON encoding for the current native-local transport.

--- a/packages/gptme-body-protocol/README.md
+++ b/packages/gptme-body-protocol/README.md
@@ -2,11 +2,13 @@
 
 Small, transport-neutral wire models for a gptme Brain↔Body connection.
 
-`gptme-voice` and a body node need to agree on authenticated handshakes and
-bounded goal commands without importing one another's runtime. This package is
-that shared seam. The initial `bob-body/0` protocol supports:
+`gptme-voice` and a body node need to agree on controller-authenticated
+handshakes and bounded goal commands without importing one another's runtime.
+This package is that shared seam. The initial `bob-body/0` protocol supports:
 
-- an authenticated controller handshake that must echo `bob-body/0`;
+- a controller handshake: the client presents the bearer token, and the body
+  must echo `bob-body/0`. That authenticates the controller to the body, not
+  the body to the controller. Mutual proof is a later protocol.
 - stable controller and command IDs (command results must repeat `command_id`);
 - command TTLs;
 - `status`, relative `move`, relative `turn`, preemptive `stop`, and `interact`;

--- a/packages/gptme-body-protocol/pyproject.toml
+++ b/packages/gptme-body-protocol/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "gptme-body-protocol"
+version = "0.1.0"
+description = "Versioned, transport-neutral wire models for gptme body nodes"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_body_protocol"]

--- a/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
+++ b/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
@@ -65,7 +65,12 @@ def require_handshake_ok(response: dict[str, Any]) -> None:
 
 
 def require_command_result(response: dict[str, Any], command_id: str) -> None:
-    """Reject mismatched, delayed, or non-result command frames."""
+    """Reject mismatched, delayed, or non-result command frames.
+
+    Protocol version is gated at handshake_ok. Native body nodes omit
+    ``protocol`` on ``command_result``; ``decode_message`` still rejects a
+    foreign protocol when the field is present.
+    """
     if response.get("type") != "command_result":
         raise ValueError(f"unexpected body response type: {response.get('type')!r}")
     if response.get("command_id") != command_id:

--- a/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
+++ b/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
@@ -1,0 +1,60 @@
+"""Transport-neutral wire models for gptme body nodes.
+
+The protocol is intentionally small: one JSON object per framed transport
+message. Body nodes and clients share these DTOs without importing either the
+voice runtime or a body-specific driver.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+PROTOCOL_VERSION = "bob-body/0"
+
+
+@dataclass(frozen=True)
+class Handshake:
+    """Authenticate a controller and negotiate one body-node session."""
+
+    token: str
+    controller_id: str
+    protocol: str = PROTOCOL_VERSION
+    type: Literal["handshake"] = "handshake"
+
+
+@dataclass(frozen=True)
+class Command:
+    """A bounded, idempotent body goal."""
+
+    command_id: str
+    controller_id: str
+    command: Literal["status", "move", "turn", "stop", "interact"]
+    args: dict[str, Any] = field(default_factory=dict)
+    ttl_ms: int = 2_000
+    sent_at_ms: int = field(default_factory=lambda: int(time.time() * 1_000))
+    type: Literal["command"] = "command"
+
+
+def encode_message(message: Handshake | Command) -> bytes:
+    """Encode one newline-framed protocol message."""
+    return (json.dumps(asdict(message), separators=(",", ":")) + "\n").encode()
+
+
+def decode_message(line: bytes) -> dict[str, Any]:
+    """Decode one response, rejecting non-object JSON."""
+    value = json.loads(line)
+    if not isinstance(value, dict):
+        raise ValueError("body-node response must be a JSON object")
+    return value
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "Command",
+    "Handshake",
+    "decode_message",
+    "encode_message",
+]

--- a/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
+++ b/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
@@ -44,11 +44,32 @@ def encode_message(message: Handshake | Command) -> bytes:
 
 
 def decode_message(line: bytes) -> dict[str, Any]:
-    """Decode one response, rejecting non-object JSON."""
+    """Decode one response, rejecting non-object JSON and foreign protocols."""
     value = json.loads(line)
     if not isinstance(value, dict):
         raise ValueError("body-node response must be a JSON object")
+    protocol = value.get("protocol")
+    if protocol is not None and protocol != PROTOCOL_VERSION:
+        raise ValueError(f"incompatible body protocol: {protocol}")
     return value
+
+
+def require_handshake_ok(response: dict[str, Any]) -> None:
+    """Reject anything that is not a compatible handshake_ok."""
+    if response.get("type") != "handshake_ok":
+        raise PermissionError(
+            response.get("detail") or response.get("code", "body handshake rejected")
+        )
+    if response.get("protocol") != PROTOCOL_VERSION:
+        raise ValueError(f"incompatible body protocol: {response.get('protocol')!r}")
+
+
+def require_command_result(response: dict[str, Any], command_id: str) -> None:
+    """Reject mismatched, delayed, or non-result command frames."""
+    if response.get("type") != "command_result":
+        raise ValueError(f"unexpected body response type: {response.get('type')!r}")
+    if response.get("command_id") != command_id:
+        raise ValueError("body response command_id does not match")
 
 
 __all__ = [
@@ -57,4 +78,6 @@ __all__ = [
     "Handshake",
     "decode_message",
     "encode_message",
+    "require_command_result",
+    "require_handshake_ok",
 ]

--- a/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
+++ b/packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py
@@ -55,7 +55,13 @@ def decode_message(line: bytes) -> dict[str, Any]:
 
 
 def require_handshake_ok(response: dict[str, Any]) -> None:
-    """Reject anything that is not a compatible handshake_ok."""
+    """Reject anything that is not a compatible handshake_ok.
+
+    ``bob-body/0`` authenticates the controller: the client sends the bearer
+    token, and this check requires ``type=handshake_ok`` plus a protocol echo.
+    It is not a mutual proof that the peer holds the token. A later protocol
+    can add a challenge if body-to-controller authentication is required.
+    """
     if response.get("type") != "handshake_ok":
         raise PermissionError(
             response.get("detail") or response.get("code", "body handshake rejected")

--- a/packages/gptme-body-protocol/tests/test_protocol.py
+++ b/packages/gptme-body-protocol/tests/test_protocol.py
@@ -4,7 +4,14 @@ import json
 import time
 
 import pytest
-from gptme_body_protocol import Command, Handshake, decode_message, encode_message
+from gptme_body_protocol import (
+    Command,
+    Handshake,
+    decode_message,
+    encode_message,
+    require_command_result,
+    require_handshake_ok,
+)
 
 
 def test_protocol_frames_handshake_and_command() -> None:
@@ -36,3 +43,21 @@ def test_command_timestamp_is_current() -> None:
 def test_decode_rejects_non_object_json() -> None:
     with pytest.raises(ValueError, match="JSON object"):
         decode_message(b"[]\n")
+
+
+def test_decode_rejects_incompatible_protocol() -> None:
+    with pytest.raises(ValueError, match="incompatible body protocol"):
+        decode_message(b'{"type":"handshake_ok","protocol":"bob-body/1"}\n')
+
+
+def test_require_handshake_ok_rejects_missing_protocol() -> None:
+    with pytest.raises(ValueError, match="incompatible body protocol"):
+        require_handshake_ok({"type": "handshake_ok", "capabilities": ["status"]})
+
+
+def test_require_command_result_rejects_mismatched_id() -> None:
+    with pytest.raises(ValueError, match="command_id"):
+        require_command_result(
+            {"type": "command_result", "command_id": "other"},
+            "remote-0001",
+        )

--- a/packages/gptme-body-protocol/tests/test_protocol.py
+++ b/packages/gptme-body-protocol/tests/test_protocol.py
@@ -61,3 +61,11 @@ def test_require_command_result_rejects_mismatched_id() -> None:
             {"type": "command_result", "command_id": "other"},
             "remote-0001",
         )
+
+
+def test_require_command_result_allows_omitted_protocol() -> None:
+    """Handshake is the version gate; native nodes omit protocol on results."""
+    require_command_result(
+        {"type": "command_result", "command_id": "remote-0001"},
+        "remote-0001",
+    )

--- a/packages/gptme-body-protocol/tests/test_protocol.py
+++ b/packages/gptme-body-protocol/tests/test_protocol.py
@@ -55,6 +55,11 @@ def test_require_handshake_ok_rejects_missing_protocol() -> None:
         require_handshake_ok({"type": "handshake_ok", "capabilities": ["status"]})
 
 
+def test_require_handshake_ok_is_controller_auth_not_mutual() -> None:
+    """handshake_ok is type + protocol echo; no body-side token proof."""
+    require_handshake_ok({"type": "handshake_ok", "protocol": "bob-body/0"})
+
+
 def test_require_command_result_rejects_mismatched_id() -> None:
     with pytest.raises(ValueError, match="command_id"):
         require_command_result(

--- a/packages/gptme-body-protocol/tests/test_protocol.py
+++ b/packages/gptme-body-protocol/tests/test_protocol.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from gptme_body_protocol import Command, Handshake, decode_message, encode_message
+
+
+def test_protocol_frames_handshake_and_command() -> None:
+    handshake = json.loads(encode_message(Handshake("secret", "voice")))
+    assert handshake == {
+        "token": "secret",
+        "controller_id": "voice",
+        "protocol": "bob-body/0",
+        "type": "handshake",
+    }
+
+    command = Command(
+        command_id="move-1",
+        controller_id="voice",
+        command="move",
+        args={"forward_m": 1.5},
+        ttl_ms=250,
+        sent_at_ms=123,
+    )
+    assert encode_message(command).endswith(b"\n")
+    assert decode_message(encode_message(command))["command_id"] == "move-1"
+
+
+def test_command_timestamp_is_current() -> None:
+    command = Command("status-1", "voice", "status")
+    assert abs(command.sent_at_ms - int(time.time() * 1_000)) < 1_000
+
+
+def test_decode_rejects_non_object_json() -> None:
+    with pytest.raises(ValueError, match="JSON object"):
+        decode_message(b"[]\n")

--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -13,6 +13,9 @@ Voice interface for gptme agents using OpenAI or xAI Grok Realtime APIs.
 - **Local testing** with direct microphone/speaker I/O
 - **BobBrain camera tool** — the `/local` session exposes `look` and runs VLM
   inference only after the edge node returns an on-demand frame
+- **Goal-level body tools** — in-process MAVSDK or an authenticated remote
+  `bob-body/0` node can handle status, bounded movement, stop, turn, and local
+  interaction directly in the realtime tool bridge (never via a subagent)
 
 ## Installation
 
@@ -85,6 +88,22 @@ gptme-voice-call +46701234567
 ```
 
 Use `--dry-run` to print the generated TwiML without dialing.
+
+### Connect a remote body node
+
+Configure a private body endpoint and pass its token separately so credentials
+do not appear in URLs or logs:
+
+```bash
+GPTME_VOICE_BODY_URL=tcp://127.0.0.1:7777
+GPTME_VOICE_BODY_TOKEN=<body-node-token>
+GPTME_VOICE_BODY_CONTROLLER_ID=gptme-voice-local  # optional
+```
+
+The remote node negotiates its actual capabilities during the authenticated
+handshake. `gptme-voice` registers only the corresponding realtime tools. The
+body node remains responsible for controller leases, command TTLs, idempotency,
+deadman behavior, and collision/local safety.
 
 ### API keys
 

--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -100,14 +100,15 @@ GPTME_VOICE_BODY_TOKEN=<body-node-token>
 GPTME_VOICE_BODY_CONTROLLER_ID=gptme-voice-local  # optional
 ```
 
-Plaintext `tcp://` is loopback-only (`127.0.0.1`, `::1`, `localhost`). A
-non-loopback host is refused so the bearer token and physical commands never
-cross the network in the clear.
+Plaintext `tcp://` is loopback-only (`127.0.0.1` / `::1`; hostnames including
+`localhost` are refused). A non-loopback host is refused so the bearer token
+and physical commands never cross the network in the clear.
 
-The remote node negotiates its actual capabilities during the authenticated
-handshake. `gptme-voice` registers only the corresponding realtime tools. The
-body node remains responsible for controller leases, command TTLs, idempotency,
-deadman behavior, and collision/local safety.
+The remote node negotiates its actual capabilities during the
+controller-authenticated handshake. `gptme-voice` registers only the
+corresponding realtime tools. The body node remains responsible for controller
+leases, command TTLs, idempotency, deadman behavior, and collision/local
+safety.
 
 ### API keys
 

--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -100,6 +100,10 @@ GPTME_VOICE_BODY_TOKEN=<body-node-token>
 GPTME_VOICE_BODY_CONTROLLER_ID=gptme-voice-local  # optional
 ```
 
+Plaintext `tcp://` is loopback-only (`127.0.0.1`, `::1`, `localhost`). A
+non-loopback host is refused so the bearer token and physical commands never
+cross the network in the clear.
+
 The remote node negotiates its actual capabilities during the authenticated
 handshake. `gptme-voice` registers only the corresponding realtime tools. The
 body node remains responsible for controller leases, command TTLs, idempotency,

--- a/packages/gptme-voice/pyproject.toml
+++ b/packages/gptme-voice/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "twilio>=9.0.0",
     "audioop-lts>=0.2; python_version >= '3.13'",
     "gptme",
+    "gptme-body-protocol",
     "httpx>=0.27",
 ]
 

--- a/packages/gptme-voice/src/gptme_voice/body/__init__.py
+++ b/packages/gptme-voice/src/gptme_voice/body/__init__.py
@@ -7,6 +7,7 @@ the optional ``gptme-voice[body]`` extra.
 
 from .adapter import (
     CAP_ALTITUDE,
+    CAP_INTERACT,
     CAP_MOVE,
     CAP_ROTATE,
     BodyAdapter,
@@ -14,13 +15,16 @@ from .adapter import (
     body_adapter_from_env,
     body_tool_schemas,
 )
+from .remote_adapter import RemoteAdapter
 
 __all__ = [
     "CAP_ALTITUDE",
+    "CAP_INTERACT",
     "CAP_MOVE",
     "CAP_ROTATE",
     "BodyAdapter",
     "NullAdapter",
+    "RemoteAdapter",
     "body_adapter_from_env",
     "body_tool_schemas",
 ]

--- a/packages/gptme-voice/src/gptme_voice/body/adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/adapter.py
@@ -257,8 +257,10 @@ def body_tool_schemas(adapter: BodyAdapter | None) -> list[dict]:
                 "type": "function",
                 "name": "body_interact",
                 "description": (
-                    "Trigger the body's default interaction with the nearby "
-                    "object or landmark."
+                    "Use this when the caller wants you to engage whatever is "
+                    "immediately in front of the body: pick it up, press it, "
+                    "talk to it, or otherwise interact with that nearby object "
+                    "or landmark. Do not use it to walk, turn, or stop."
                 ),
                 "parameters": {"type": "object", "properties": {}},
             }
@@ -307,8 +309,10 @@ def body_adapter_from_env() -> BodyAdapter | None:
     - ``mavsdk://<system_address>`` -> MavsdkAdapter, e.g.
       ``mavsdk://udpin://0.0.0.0:14540`` (SITL) or
       ``mavsdk://serial:///dev/ttyUSB0:57600`` (SiK radio)
-    - ``tcp://<host>:<port>`` -> authenticated RemoteAdapter. The token comes
-      from ``GPTME_VOICE_BODY_TOKEN`` rather than the URL to avoid log leaks.
+    - ``tcp://<loopback>:<port>`` -> authenticated RemoteAdapter. Plaintext
+      TCP is loopback-only so the bearer token never leaves the machine.
+      The token comes from ``GPTME_VOICE_BODY_TOKEN`` rather than the URL
+      to avoid log leaks.
 
     Remote capabilities are discovered during the asynchronous handshake, so
     construction performs no I/O. The server connects remote adapters before
@@ -335,7 +339,15 @@ def body_adapter_from_env() -> BodyAdapter | None:
         ):
             logger.warning("Invalid remote body URL: %s (body disabled)", url)
             return None
-        from .remote_adapter import RemoteAdapter
+        from .remote_adapter import RemoteAdapter, is_loopback_host
+
+        if not is_loopback_host(parsed.hostname):
+            logger.warning(
+                "GPTME_VOICE_BODY_URL tcp:// host %s is not loopback "
+                "(plaintext remote bodies are disabled)",
+                parsed.hostname,
+            )
+            return None
 
         return RemoteAdapter(
             token,

--- a/packages/gptme-voice/src/gptme_voice/body/adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/adapter.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any, Protocol, runtime_checkable
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 CAP_MOVE = "move"  # horizontal translation (goto/move/return home)
 CAP_ROTATE = "rotate"  # yaw control
 CAP_ALTITUDE = "altitude"  # vertical control (takeoff/land/up-down)
+CAP_INTERACT = "interact"  # trigger the body's default local interaction
 
 
 @runtime_checkable
@@ -35,6 +37,7 @@ class BodyAdapter(Protocol):
 
     capabilities: set[str]
     name: str
+    requires_startup_connection: bool
 
     async def ensure_connected(self) -> None: ...
 
@@ -61,6 +64,8 @@ class BodyAdapter(Protocol):
 
     async def return_home(self) -> dict[str, Any]: ...
 
+    async def interact(self) -> dict[str, Any]: ...
+
     def telemetry(self) -> dict[str, Any]: ...
 
 
@@ -73,6 +78,7 @@ class NullAdapter:
 
     capabilities: set[str] = set()
     name = "null"
+    requires_startup_connection = False
 
     async def ensure_connected(self) -> None:
         return None
@@ -112,6 +118,9 @@ class NullAdapter:
         return await self._unsupported()
 
     async def return_home(self) -> dict[str, Any]:
+        return await self._unsupported()
+
+    async def interact(self) -> dict[str, Any]:
         return await self._unsupported()
 
 
@@ -242,6 +251,19 @@ def body_tool_schemas(adapter: BodyAdapter | None) -> list[dict]:
             }
         )
 
+    if CAP_INTERACT in caps:
+        tools.append(
+            {
+                "type": "function",
+                "name": "body_interact",
+                "description": (
+                    "Trigger the body's default interaction with the nearby "
+                    "object or landmark."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            }
+        )
+
     if CAP_ALTITUDE in caps:
         tools.append(
             {
@@ -285,12 +307,44 @@ def body_adapter_from_env() -> BodyAdapter | None:
     - ``mavsdk://<system_address>`` -> MavsdkAdapter, e.g.
       ``mavsdk://udpin://0.0.0.0:14540`` (SITL) or
       ``mavsdk://serial:///dev/ttyUSB0:57600`` (SiK radio)
+    - ``tcp://<host>:<port>`` -> authenticated RemoteAdapter. The token comes
+      from ``GPTME_VOICE_BODY_TOKEN`` rather than the URL to avoid log leaks.
+
+    Remote capabilities are discovered during the asynchronous handshake, so
+    construction performs no I/O. The server connects remote adapters before
+    building its realtime tool schema.
     """
     url = os.environ.get("GPTME_VOICE_BODY_URL", "").strip()
     if not url:
         return None
     if url == "null":
         return NullAdapter()
+    if url.startswith("tcp://"):
+        parsed = urlparse(url)
+        token = os.environ.get("GPTME_VOICE_BODY_TOKEN", "")
+        if not token:
+            logger.warning(
+                "GPTME_VOICE_BODY_URL uses tcp:// but GPTME_VOICE_BODY_TOKEN "
+                "is empty (body disabled)"
+            )
+            return None
+        if (
+            parsed.hostname is None
+            or parsed.port is None
+            or parsed.path not in {"", "/"}
+        ):
+            logger.warning("Invalid remote body URL: %s (body disabled)", url)
+            return None
+        from .remote_adapter import RemoteAdapter
+
+        return RemoteAdapter(
+            token,
+            host=parsed.hostname,
+            port=parsed.port,
+            controller_id=os.environ.get(
+                "GPTME_VOICE_BODY_CONTROLLER_ID", "gptme-voice-local"
+            ),
+        )
     if url.startswith("mavsdk://"):
         try:
             __import__("mavsdk")

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -51,6 +51,7 @@ class MavsdkAdapter:
 
     capabilities = {"move", "rotate", "altitude"}
     name = "mavsdk"
+    requires_startup_connection = False
 
     def __init__(
         self,
@@ -278,6 +279,9 @@ class MavsdkAdapter:
                 "status": "holding",
                 "message": "Motion stopped; holding position.",
             }
+
+    async def interact(self) -> dict[str, Any]:
+        return {"error": "MAVSDK bodies have no generic interaction capability."}
 
     async def return_home(self) -> dict[str, Any]:
         async with self._command_lock:

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -37,11 +37,13 @@ def is_loopback_host(host: str) -> bool:
 
 
 class RemoteAdapter:
-    """Translate model-facing body goals into authenticated body-node messages.
+    """Translate model-facing body goals into controller-authenticated messages.
 
     The body node owns controller leases, command deadlines, idempotency, and
     local safety. This adapter owns framing, handshake negotiation, and the
     translation from the stable voice tool contract to the neutral wire DTOs.
+    The handshake authenticates this controller to the body; it does not prove
+    the peer holds the token.
     """
 
     name = "remote"

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -25,13 +25,11 @@ _REQUIRED_WIRE_CAPABILITIES = {"status", "move", "turn", "stop"}
 
 
 def is_loopback_host(host: str) -> bool:
-    """True for literal loopback addresses and localhost.
+    """True only for literal loopback addresses.
 
-    Hostnames are not resolved. Plaintext body control is local-only, so a
-    DNS name other than localhost is treated as non-loopback.
+    Plaintext body control is local-only. Hostnames are deliberately rejected
+    because name resolution could select a non-loopback peer after this check.
     """
-    if host.lower().rstrip(".") == "localhost":
-        return True
     try:
         return ipaddress.ip_address(host).is_loopback
     except ValueError:

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -111,7 +111,7 @@ class RemoteAdapter:
                     for wire_capability, adapter_capability in _WIRE_TO_ADAPTER_CAPABILITY.items()
                     if wire_capability in wire_capabilities
                 }
-                self._telemetry = response.get("telemetry") or {}
+                self._telemetry = self._validated_telemetry(response)
             except BaseException:
                 await self.close()
                 raise
@@ -142,6 +142,13 @@ class RemoteAdapter:
 
     def telemetry(self) -> dict[str, Any]:
         return self._telemetry.copy()
+
+    @staticmethod
+    def _validated_telemetry(response: dict[str, Any]) -> dict[str, Any]:
+        telemetry = response.get("telemetry", {})
+        if not isinstance(telemetry, dict):
+            raise ValueError("body response telemetry must be a JSON object")
+        return telemetry
 
     async def takeoff(self, altitude_m: float) -> dict[str, Any]:
         return {"error": "This body has no takeoff capability."}
@@ -174,7 +181,7 @@ class RemoteAdapter:
             )
             response = await self._exchange(message)
             if "telemetry" in response:
-                self._telemetry = response["telemetry"]
+                self._telemetry = self._validated_telemetry(response)
             return response
 
     async def _exchange(self, message: Handshake | Command) -> dict[str, Any]:

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -148,6 +148,9 @@ class RemoteAdapter:
         telemetry = response.get("telemetry", {})
         if not isinstance(telemetry, dict):
             raise ValueError("body response telemetry must be a JSON object")
+        position = telemetry.get("position")
+        if position is not None and not isinstance(position, dict):
+            raise ValueError("body response telemetry position must be a JSON object")
         return telemetry
 
     async def takeoff(self, altitude_m: float) -> dict[str, Any]:

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -1,0 +1,158 @@
+"""Remote BodyAdapter over the versioned gptme body-node protocol."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from gptme_body_protocol import Command, Handshake, decode_message, encode_message
+
+# Body-node wire capabilities mapped to gptme-voice's model-facing capabilities.
+_WIRE_TO_ADAPTER_CAPABILITY = {
+    "move": "move",
+    "turn": "rotate",
+    "interact": "interact",
+}
+_REQUIRED_WIRE_CAPABILITIES = {"status", "move", "turn", "stop"}
+
+
+class RemoteAdapter:
+    """Translate model-facing body goals into authenticated body-node messages.
+
+    The body node owns controller leases, command deadlines, idempotency, and
+    local safety. This adapter owns framing, handshake negotiation, and the
+    translation from the stable voice tool contract to the neutral wire DTOs.
+    """
+
+    name = "remote"
+    requires_startup_connection = True
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 7777,
+        controller_id: str = "gptme-voice-local",
+        timeout_s: float = 2.0,
+    ) -> None:
+        if not token:
+            raise ValueError("a non-empty body token is required")
+        self.token = token
+        self.host = host
+        self.port = port
+        self.controller_id = controller_id
+        self.timeout_s = timeout_s
+        self.capabilities: set[str] = set()
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._sequence = 0
+        self._telemetry: dict[str, Any] = {}
+        self._command_lock = asyncio.Lock()
+        self._connection_lock = asyncio.Lock()
+
+    async def ensure_connected(self) -> None:
+        if self._writer is not None and not self._writer.is_closing():
+            return
+        async with self._connection_lock:
+            if self._writer is not None and not self._writer.is_closing():
+                return
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port), self.timeout_s
+            )
+            try:
+                response = await self._exchange(
+                    Handshake(token=self.token, controller_id=self.controller_id)
+                )
+                if response.get("type") != "handshake_ok":
+                    raise PermissionError(
+                        response.get("detail")
+                        or response.get("code", "body handshake rejected")
+                    )
+                wire_capabilities = set(response.get("capabilities") or ())
+                missing = _REQUIRED_WIRE_CAPABILITIES - wire_capabilities
+                if missing:
+                    raise ValueError(
+                        "body handshake missing required capabilities: "
+                        + ", ".join(sorted(missing))
+                    )
+                self.capabilities = {
+                    adapter_capability
+                    for wire_capability, adapter_capability in _WIRE_TO_ADAPTER_CAPABILITY.items()
+                    if wire_capability in wire_capabilities
+                }
+                self._telemetry = response.get("telemetry") or {}
+            except BaseException:
+                await self.close()
+                raise
+
+    async def close(self) -> None:
+        writer, self._writer = self._writer, None
+        self._reader = None
+        self.capabilities = set()
+        if writer is not None:
+            writer.close()
+            await writer.wait_closed()
+
+    async def move(
+        self, forward_m: float, right_m: float, up_m: float = 0.0
+    ) -> dict[str, Any]:
+        if up_m:
+            return {"error": "This body has no altitude capability."}
+        return await self._command("move", {"forward_m": forward_m, "right_m": right_m})
+
+    async def turn(self, yaw_deg: float) -> dict[str, Any]:
+        return await self._command("turn", {"yaw_deg": yaw_deg})
+
+    async def stop(self) -> dict[str, Any]:
+        return await self._command("stop")
+
+    async def interact(self) -> dict[str, Any]:
+        return await self._command("interact")
+
+    def telemetry(self) -> dict[str, Any]:
+        return self._telemetry.copy()
+
+    async def takeoff(self, altitude_m: float) -> dict[str, Any]:
+        return {"error": "This body has no takeoff capability."}
+
+    async def land(self) -> dict[str, Any]:
+        return {"error": "This body has no land capability."}
+
+    async def goto(
+        self,
+        latitude_deg: float,
+        longitude_deg: float,
+        altitude_m: float | None,
+    ) -> dict[str, Any]:
+        return {"error": "This body has no GPS capability."}
+
+    async def return_home(self) -> dict[str, Any]:
+        return {"error": "This body has no return-home capability."}
+
+    async def _command(
+        self, command: str, args: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        async with self._command_lock:
+            await self.ensure_connected()
+            self._sequence += 1
+            message = Command(
+                command_id=f"remote-{self._sequence:04d}",
+                controller_id=self.controller_id,
+                command=command,  # type: ignore[arg-type]
+                args=args or {},
+            )
+            response = await self._exchange(message)
+            if "telemetry" in response:
+                self._telemetry = response["telemetry"]
+            return response
+
+    async def _exchange(self, message: Handshake | Command) -> dict[str, Any]:
+        if self._reader is None or self._writer is None:
+            raise ConnectionError("body node is not connected")
+        self._writer.write(encode_message(message))
+        await self._writer.drain()
+        line = await asyncio.wait_for(self._reader.readline(), self.timeout_s)
+        if not line:
+            raise ConnectionError("body node closed the connection")
+        return decode_message(line)

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 from typing import Any
 
-from gptme_body_protocol import Command, Handshake, decode_message, encode_message
+from gptme_body_protocol import (
+    Command,
+    Handshake,
+    decode_message,
+    encode_message,
+    require_command_result,
+    require_handshake_ok,
+)
 
 # Body-node wire capabilities mapped to gptme-voice's model-facing capabilities.
 _WIRE_TO_ADAPTER_CAPABILITY = {
@@ -14,6 +22,20 @@ _WIRE_TO_ADAPTER_CAPABILITY = {
     "interact": "interact",
 }
 _REQUIRED_WIRE_CAPABILITIES = {"status", "move", "turn", "stop"}
+
+
+def is_loopback_host(host: str) -> bool:
+    """True for literal loopback addresses and localhost.
+
+    Hostnames are not resolved. Plaintext body control is local-only, so a
+    DNS name other than localhost is treated as non-loopback.
+    """
+    if host.lower().rstrip(".") == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 class RemoteAdapter:
@@ -38,6 +60,10 @@ class RemoteAdapter:
     ) -> None:
         if not token:
             raise ValueError("a non-empty body token is required")
+        if not is_loopback_host(host):
+            raise ValueError(
+                f"plaintext body transport is loopback-only, refused host {host!r}"
+            )
         self.token = token
         self.host = host
         self.port = port
@@ -51,12 +77,21 @@ class RemoteAdapter:
         self._command_lock = asyncio.Lock()
         self._connection_lock = asyncio.Lock()
 
+    def _is_connected(self) -> bool:
+        return (
+            self._reader is not None
+            and self._writer is not None
+            and not self._writer.is_closing()
+        )
+
     async def ensure_connected(self) -> None:
-        if self._writer is not None and not self._writer.is_closing():
+        if self._is_connected():
             return
         async with self._connection_lock:
-            if self._writer is not None and not self._writer.is_closing():
+            if self._is_connected():
                 return
+            if self._writer is not None:
+                await self.close()
             self._reader, self._writer = await asyncio.wait_for(
                 asyncio.open_connection(self.host, self.port), self.timeout_s
             )
@@ -64,11 +99,6 @@ class RemoteAdapter:
                 response = await self._exchange(
                     Handshake(token=self.token, controller_id=self.controller_id)
                 )
-                if response.get("type") != "handshake_ok":
-                    raise PermissionError(
-                        response.get("detail")
-                        or response.get("code", "body handshake rejected")
-                    )
                 wire_capabilities = set(response.get("capabilities") or ())
                 missing = _REQUIRED_WIRE_CAPABILITIES - wire_capabilities
                 if missing:
@@ -148,11 +178,21 @@ class RemoteAdapter:
             return response
 
     async def _exchange(self, message: Handshake | Command) -> dict[str, Any]:
-        if self._reader is None or self._writer is None:
+        reader, writer = self._reader, self._writer
+        if reader is None or writer is None:
             raise ConnectionError("body node is not connected")
-        self._writer.write(encode_message(message))
-        await self._writer.drain()
-        line = await asyncio.wait_for(self._reader.readline(), self.timeout_s)
-        if not line:
-            raise ConnectionError("body node closed the connection")
-        return decode_message(line)
+        try:
+            writer.write(encode_message(message))
+            await writer.drain()
+            line = await asyncio.wait_for(reader.readline(), self.timeout_s)
+            if not line:
+                raise ConnectionError("body node closed the connection")
+            response = decode_message(line)
+            if isinstance(message, Handshake):
+                require_handshake_ok(response)
+            else:
+                require_command_result(response, message.command_id)
+            return response
+        except BaseException:
+            await self.close()
+            raise

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -181,7 +181,11 @@ class RemoteAdapter:
             )
             response = await self._exchange(message)
             if "telemetry" in response:
-                self._telemetry = self._validated_telemetry(response)
+                try:
+                    self._telemetry = self._validated_telemetry(response)
+                except ValueError:
+                    await self.close()
+                    raise
             return response
 
     async def _exchange(self, message: Handshake | Command) -> dict[str, Any]:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -903,6 +903,25 @@ class VoiceServer:
     @contextlib.asynccontextmanager
     async def _lifespan(self, _app):
         try:
+            if (
+                self.body_adapter is not None
+                and self.body_adapter.requires_startup_connection
+            ):
+                try:
+                    await self.body_adapter.ensure_connected()
+                except Exception as error:  # noqa: BLE001 - keep voice available
+                    logger.error(
+                        "Body adapter startup connection failed; body tools disabled: %s",
+                        error,
+                    )
+                    await self.body_adapter.close()
+                    self.body_adapter = None
+                else:
+                    logger.info(
+                        "Body adapter ready: %s (capabilities: %s)",
+                        self.body_adapter.name,
+                        sorted(self.body_adapter.capabilities) or "none",
+                    )
             yield
         finally:
             await self._cancel_all_twilio_body_grant_idle_revokes()

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -1066,6 +1066,8 @@ class GptmeToolBridge:
             if name == "body_turn" and "rotate" in caps:
                 yaw = self._clamp(float(arguments.get("yaw_deg", 0.0)), 180.0)
                 return await _call(adapter.turn(yaw))
+            if name == "body_interact" and "interact" in caps:
+                return await _call(adapter.interact())
         except (KeyError, TypeError, ValueError) as e:
             return {"error": f"Invalid arguments for {name}: {e}"}
         except asyncio.TimeoutError:

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -1031,7 +1031,8 @@ class GptmeToolBridge:
                 up = self._clamp(
                     float(arguments.get("up_m", 0.0)), self.body_max_altitude_m
                 )
-                position = adapter.telemetry().get("position") or {}
+                raw_position = adapter.telemetry().get("position")
+                position = raw_position if isinstance(raw_position, dict) else {}
                 current_altitude = position.get("relative_altitude_m")
                 if current_altitude is None:
                     # Without a relative-altitude fix the absolute ceiling

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -18,6 +18,7 @@ class FakeAdapter:
     """Records calls; full capability set unless overridden."""
 
     name = "fake"
+    requires_startup_connection = False
 
     def __init__(
         self,

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -232,6 +232,23 @@ def test_bridge_move_allows_level_and_descent_without_altitude_telemetry(loop):
     assert adapter.calls[-1] == ("move", (0.0, 0.0, -3.0))
 
 
+def test_bridge_move_treats_non_object_position_as_missing_altitude(loop):
+    class Adapter(FakeAdapter):
+        def telemetry(self) -> dict[str, Any]:
+            return {"position": "unknown"}
+
+    adapter = Adapter()
+    bridge = GptmeToolBridge(body_adapter=adapter)
+
+    climb = _call(bridge, "body_move", {"up_m": 5.0})
+    assert "error" in climb
+    assert "altitude unknown" in climb["error"]
+    assert adapter.calls == []
+
+    _call(bridge, "body_move", {"forward_m": 1.0, "up_m": 0.0})
+    assert adapter.calls[-1] == ("move", (1.0, 0.0, 0.0))
+
+
 def test_bridge_capability_gate_blocks_uncapable_calls(loop):
     adapter = FakeAdapter({"move"})
     bridge = GptmeToolBridge(body_adapter=adapter)

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -1,0 +1,159 @@
+"""Tests for the remote body-node adapter and neutral wire protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from gptme_voice.body import RemoteAdapter, body_adapter_from_env, body_tool_schemas
+from gptme_voice.realtime.tool_bridge import GptmeToolBridge
+
+
+async def _body_node(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    requests: list[dict[str, Any]],
+) -> None:
+    while line := await reader.readline():
+        request = json.loads(line)
+        requests.append(request)
+        if request["type"] == "handshake":
+            response = {
+                "type": "handshake_ok",
+                "protocol": "bob-body/0",
+                "body_id": "bob-world-local",
+                "capabilities": ["status", "move", "turn", "stop", "interact"],
+                "telemetry": {"body_id": "bob-world-local"},
+            }
+        else:
+            response = {
+                "type": "command_result",
+                "command_id": request["command_id"],
+                "status": (
+                    "accepted"
+                    if request["command"] in {"move", "turn"}
+                    else "completed"
+                ),
+                "telemetry": {"motion": request["command"]},
+            }
+        writer.write((json.dumps(response) + "\n").encode())
+        await writer.drain()
+    writer.close()
+
+
+def test_remote_adapter_handshake_capabilities_and_goal_translation() -> None:
+    async def scenario() -> None:
+        requests: list[dict[str, Any]] = []
+        server = await asyncio.start_server(
+            lambda reader, writer: _body_node(reader, writer, requests),
+            "127.0.0.1",
+            0,
+        )
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port, controller_id="voice-test")
+        try:
+            await adapter.ensure_connected()
+            assert adapter.capabilities == {"move", "rotate", "interact"}
+            assert await adapter.move(2.0, -0.5, 0.0) == {
+                "type": "command_result",
+                "command_id": "remote-0001",
+                "status": "accepted",
+                "telemetry": {"motion": "move"},
+            }
+            await adapter.turn(45.0)
+            await adapter.interact()
+            await adapter.stop()
+            assert adapter.telemetry() == {"motion": "stop"}
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+        assert requests[0]["token"] == "secret"
+        assert [request["command"] for request in requests[1:]] == [
+            "move",
+            "turn",
+            "interact",
+            "stop",
+        ]
+        assert all(request["controller_id"] == "voice-test" for request in requests)
+
+    asyncio.run(scenario())
+
+
+def test_remote_adapter_rejects_unadvertised_required_capabilities() -> None:
+    async def scenario() -> None:
+        async def incompatible_node(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            writer.write(
+                (
+                    json.dumps({"type": "handshake_ok", "capabilities": ["status"]})
+                    + "\n"
+                ).encode()
+            )
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(incompatible_node, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port)
+        try:
+            with pytest.raises(ValueError, match="missing required capabilities"):
+                await adapter.ensure_connected()
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
+
+
+def test_remote_adapter_requires_token() -> None:
+    with pytest.raises(ValueError, match="token"):
+        RemoteAdapter("")
+
+
+def test_remote_adapter_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "tcp://127.0.0.1:7788")
+    monkeypatch.setenv("GPTME_VOICE_BODY_TOKEN", "secret")
+    monkeypatch.setenv("GPTME_VOICE_BODY_CONTROLLER_ID", "voice-env")
+    adapter = body_adapter_from_env()
+    assert isinstance(adapter, RemoteAdapter)
+    assert adapter.host == "127.0.0.1"
+    assert adapter.port == 7788
+    assert adapter.controller_id == "voice-env"
+
+
+def test_remote_adapter_from_env_requires_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "tcp://127.0.0.1:7788")
+    monkeypatch.delenv("GPTME_VOICE_BODY_TOKEN", raising=False)
+    assert body_adapter_from_env() is None
+
+
+def test_remote_capabilities_register_and_route_interaction() -> None:
+    class Adapter:
+        name = "remote"
+        capabilities = {"interact"}
+        requires_startup_connection = False
+
+        async def ensure_connected(self) -> None:
+            return None
+
+        async def interact(self) -> dict[str, Any]:
+            return {"status": "completed"}
+
+    adapter = Adapter()
+    names = {tool["name"] for tool in body_tool_schemas(adapter)}  # type: ignore[arg-type]
+    assert names == {"body_status", "body_interact"}
+    result = asyncio.run(
+        GptmeToolBridge(body_adapter=adapter).handle_function_call(  # type: ignore[arg-type]
+            "body_interact", {}
+        )
+    )
+    assert result == {"status": "completed"}

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -283,6 +283,35 @@ def test_remote_adapter_rejects_non_object_telemetry(response_type: str) -> None
     asyncio.run(scenario())
 
 
+def test_remote_adapter_rejects_non_object_position_telemetry() -> None:
+    async def scenario() -> None:
+        async def malformed_node(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            handshake = dict(_HANDSHAKE_OK)
+            handshake["telemetry"] = {"position": "unknown"}
+            writer.write((json.dumps(handshake) + "\n").encode())
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(malformed_node, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port)
+        try:
+            with pytest.raises(
+                ValueError, match="telemetry position must be a JSON object"
+            ):
+                await adapter.ensure_connected()
+            assert adapter._writer is None
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
+
+
 def test_remote_adapter_rejects_mismatched_command_id() -> None:
     async def scenario() -> None:
         async def mismatched_node(

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -274,6 +274,7 @@ def test_remote_adapter_rejects_non_object_telemetry(response_type: str) -> None
                 operation = adapter.stop()
             with pytest.raises(ValueError, match="telemetry must be a JSON object"):
                 await operation
+            assert adapter._writer is None
         finally:
             await adapter.close()
             server.close()

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -8,7 +8,16 @@ from typing import Any
 
 import pytest
 from gptme_voice.body import RemoteAdapter, body_adapter_from_env, body_tool_schemas
+from gptme_voice.body.remote_adapter import is_loopback_host
 from gptme_voice.realtime.tool_bridge import GptmeToolBridge
+
+_HANDSHAKE_OK = {
+    "type": "handshake_ok",
+    "protocol": "bob-body/0",
+    "body_id": "bob-world-local",
+    "capabilities": ["status", "move", "turn", "stop", "interact"],
+    "telemetry": {"body_id": "bob-world-local"},
+}
 
 
 async def _body_node(
@@ -20,13 +29,7 @@ async def _body_node(
         request = json.loads(line)
         requests.append(request)
         if request["type"] == "handshake":
-            response = {
-                "type": "handshake_ok",
-                "protocol": "bob-body/0",
-                "body_id": "bob-world-local",
-                "capabilities": ["status", "move", "turn", "stop", "interact"],
-                "telemetry": {"body_id": "bob-world-local"},
-            }
+            response = dict(_HANDSHAKE_OK)
         else:
             response = {
                 "type": "command_result",
@@ -91,7 +94,13 @@ def test_remote_adapter_rejects_unadvertised_required_capabilities() -> None:
             await reader.readline()
             writer.write(
                 (
-                    json.dumps({"type": "handshake_ok", "capabilities": ["status"]})
+                    json.dumps(
+                        {
+                            "type": "handshake_ok",
+                            "protocol": "bob-body/0",
+                            "capabilities": ["status"],
+                        }
+                    )
                     + "\n"
                 ).encode()
             )
@@ -115,6 +124,27 @@ def test_remote_adapter_rejects_unadvertised_required_capabilities() -> None:
 def test_remote_adapter_requires_token() -> None:
     with pytest.raises(ValueError, match="token"):
         RemoteAdapter("")
+
+
+def test_is_loopback_host() -> None:
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("::1")
+    assert is_loopback_host("localhost")
+    assert not is_loopback_host("10.0.0.4")
+    assert not is_loopback_host("body.example")
+
+
+def test_remote_adapter_rejects_non_loopback_host() -> None:
+    with pytest.raises(ValueError, match="loopback-only"):
+        RemoteAdapter("secret", host="10.0.0.4")
+
+
+def test_remote_adapter_from_env_rejects_non_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_BODY_URL", "tcp://10.0.0.4:7788")
+    monkeypatch.setenv("GPTME_VOICE_BODY_TOKEN", "secret")
+    assert body_adapter_from_env() is None
 
 
 def test_remote_adapter_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -149,11 +179,132 @@ def test_remote_capabilities_register_and_route_interaction() -> None:
             return {"status": "completed"}
 
     adapter = Adapter()
-    names = {tool["name"] for tool in body_tool_schemas(adapter)}  # type: ignore[arg-type]
+    tools = body_tool_schemas(adapter)  # type: ignore[arg-type]
+    names = {tool["name"] for tool in tools}
     assert names == {"body_status", "body_interact"}
+    interact = next(tool for tool in tools if tool["name"] == "body_interact")
+    assert "when the caller wants you to engage" in interact["description"]
     result = asyncio.run(
         GptmeToolBridge(body_adapter=adapter).handle_function_call(  # type: ignore[arg-type]
             "body_interact", {}
         )
     )
     assert result == {"status": "completed"}
+
+
+def test_remote_adapter_rejects_incompatible_protocol() -> None:
+    async def scenario() -> None:
+        async def incompatible_node(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "type": "handshake_ok",
+                            "protocol": "bob-body/1",
+                            "capabilities": [
+                                "status",
+                                "move",
+                                "turn",
+                                "stop",
+                            ],
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(incompatible_node, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port)
+        try:
+            with pytest.raises(ValueError, match="incompatible body protocol"):
+                await adapter.ensure_connected()
+            assert adapter._writer is None
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
+
+
+def test_remote_adapter_rejects_mismatched_command_id() -> None:
+    async def scenario() -> None:
+        async def mismatched_node(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            writer.write((json.dumps(_HANDSHAKE_OK) + "\n").encode())
+            await writer.drain()
+            await reader.readline()
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "type": "command_result",
+                            "command_id": "stale-from-earlier",
+                            "status": "completed",
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(mismatched_node, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port)
+        try:
+            await adapter.ensure_connected()
+            with pytest.raises(ValueError, match="command_id"):
+                await adapter.move(1.0, 0.0)
+            assert adapter._writer is None
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
+
+
+def test_remote_adapter_reconnects_after_timeout() -> None:
+    async def scenario() -> None:
+        connections = {"n": 0}
+
+        async def flaky_node(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            connections["n"] += 1
+            if connections["n"] == 1:
+                await reader.readline()
+                writer.write((json.dumps(_HANDSHAKE_OK) + "\n").encode())
+                await writer.drain()
+                await reader.readline()
+                await reader.read()
+                writer.close()
+                return
+            await _body_node(reader, writer, [])
+
+        server = await asyncio.start_server(flaky_node, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port, timeout_s=0.2)
+        try:
+            await adapter.ensure_connected()
+            with pytest.raises(asyncio.TimeoutError):
+                await adapter.move(1.0, 0.0)
+            assert adapter._writer is None
+            result = await adapter.move(1.0, 0.0)
+            assert result["command_id"] == "remote-0002"
+            assert result["status"] == "accepted"
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -234,6 +234,54 @@ def test_remote_adapter_rejects_incompatible_protocol() -> None:
     asyncio.run(scenario())
 
 
+@pytest.mark.parametrize("response_type", ["handshake_ok", "command_result"])
+def test_remote_adapter_rejects_non_object_telemetry(response_type: str) -> None:
+    async def scenario() -> None:
+        async def malformed_node(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            handshake = dict(_HANDSHAKE_OK)
+            if response_type == "handshake_ok":
+                handshake["telemetry"] = []
+            writer.write((json.dumps(handshake) + "\n").encode())
+            await writer.drain()
+            if response_type == "command_result":
+                request = json.loads(await reader.readline())
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "command_result",
+                                "command_id": request["command_id"],
+                                "telemetry": [],
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(malformed_node, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        adapter = RemoteAdapter("secret", port=port)
+        try:
+            if response_type == "handshake_ok":
+                operation = adapter.ensure_connected()
+            else:
+                await adapter.ensure_connected()
+                operation = adapter.stop()
+            with pytest.raises(ValueError, match="telemetry must be a JSON object"):
+                await operation
+        finally:
+            await adapter.close()
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(scenario())
+
+
 def test_remote_adapter_rejects_mismatched_command_id() -> None:
     async def scenario() -> None:
         async def mismatched_node(

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -129,14 +129,15 @@ def test_remote_adapter_requires_token() -> None:
 def test_is_loopback_host() -> None:
     assert is_loopback_host("127.0.0.1")
     assert is_loopback_host("::1")
-    assert is_loopback_host("localhost")
+    assert not is_loopback_host("localhost")
     assert not is_loopback_host("10.0.0.4")
     assert not is_loopback_host("body.example")
 
 
-def test_remote_adapter_rejects_non_loopback_host() -> None:
+@pytest.mark.parametrize("host", ["localhost", "localhost.", "10.0.0.4"])
+def test_remote_adapter_rejects_non_literal_loopback_host(host: str) -> None:
     with pytest.raises(ValueError, match="loopback-only"):
-        RemoteAdapter("secret", host="10.0.0.4")
+        RemoteAdapter("secret", host=host)
 
 
 def test_remote_adapter_from_env_rejects_non_loopback(

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -920,13 +920,19 @@ def test_untrusted_sessions_do_not_advertise_body_tools(monkeypatch) -> None:
     assert [tool["name"] for tool in allowed.extra_tools] == ["body_status"]
 
 
-def test_server_lifespan_closes_body_adapter(monkeypatch) -> None:
+def test_server_lifespan_connects_and_closes_remote_body_adapter(monkeypatch) -> None:
     class Adapter:
         name = "fake"
-        capabilities: set[str] = set()
+        requires_startup_connection = True
 
         def __init__(self) -> None:
+            self.capabilities: set[str] = set()
+            self.connected = False
             self.closed = False
+
+        async def ensure_connected(self) -> None:
+            self.connected = True
+            self.capabilities = {"move"}
 
         async def close(self) -> None:
             self.closed = True
@@ -942,7 +948,32 @@ def test_server_lifespan_closes_body_adapter(monkeypatch) -> None:
             pass
 
     asyncio.run(run_lifespan())
+    assert adapter.connected is True
     assert adapter.closed is True
+
+
+def test_server_lifespan_disables_unreachable_remote_body(monkeypatch) -> None:
+    class Adapter:
+        name = "fake"
+        capabilities: set[str] = set()
+        requires_startup_connection = True
+
+        async def ensure_connected(self) -> None:
+            raise ConnectionError("offline")
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server.body_adapter_from_env", lambda: Adapter()
+    )
+    server = VoiceServer()
+
+    async def run_lifespan() -> None:
+        async with server._lifespan(server.app):
+            assert server.body_adapter is None
+
+    asyncio.run(run_lifespan())
 
 
 def test_build_caller_instructions_no_number() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ torch = { index = "pytorch-cpu" }
 # but noisy across machines. See alice journal 2026-08-18.
 numpy = { index = "pypi" }
 gptme = { git = "https://github.com/gptme/gptme.git", branch = "master" }
+gptme-body-protocol = { workspace = true }
 gptme-vision-node = { workspace = true }
 gptme-sessions = { workspace = true }
 gptme-usage = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ members = [
     "gptme-attention-tracker",
     "gptme-backoff",
     "gptme-bob-status",
+    "gptme-body-protocol",
     "gptme-browser-semantic",
     "gptme-cc-memory",
     "gptme-claude-code",
@@ -1788,6 +1789,20 @@ requires-dist = [
 provides-extras = ["test"]
 
 [[package]]
+name = "gptme-body-protocol"
+version = "0.1.0"
+source = { editable = "packages/gptme-body-protocol" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" }]
+provides-extras = ["test"]
+
+[[package]]
 name = "gptme-browser-semantic"
 version = "0.1.0"
 source = { editable = "packages/gptme-browser-semantic" }
@@ -2621,6 +2636,7 @@ dependencies = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "click" },
     { name = "gptme" },
+    { name = "gptme-body-protocol" },
     { name = "httpx" },
     { name = "openai" },
     { name = "starlette" },
@@ -2645,6 +2661,7 @@ requires-dist = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2" },
     { name = "click", specifier = ">=8.0" },
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "gptme-body-protocol", editable = "packages/gptme-body-protocol" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mavsdk", marker = "extra == 'body'", specifier = ">=2.0" },
     { name = "openai", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

- add a tiny transport-neutral `gptme-body-protocol` package for the versioned `bob-body/0` handshake and bounded command DTOs
- add an authenticated TCP `RemoteAdapter` selected by `GPTME_VOICE_BODY_URL`, with capabilities negotiated before realtime session schemas are built
- route `body_status`, `body_move`, `body_turn`, `body_stop`, and `body_interact` directly through the realtime tool bridge without subagent dispatch

## Safety boundaries

- the bearer token stays in `GPTME_VOICE_BODY_TOKEN`, not the URL
- incompatible handshakes fail closed and unreachable nodes disable body tools while leaving voice available
- body-node leases, TTL/idempotency, deadman behavior, collision handling, and local safety remain body-local

## Verification

- `uv run --package gptme-voice pytest packages/gptme-body-protocol/tests/test_protocol.py packages/gptme-voice/tests/test_remote_adapter.py packages/gptme-voice/tests/test_body_tools.py packages/gptme-voice/tests/test_tool_bridge.py packages/gptme-voice/tests/test_server.py -q` (242 passed, 1 skipped)
- `uv run mypy packages/gptme-body-protocol/src packages/gptme-voice/src/gptme_voice/body/adapter.py packages/gptme-voice/src/gptme_voice/body/remote_adapter.py packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py`
- scoped `prek run --files ...`

This upstreams the already-proven native-local Bob World protocol spike; it deliberately does not add a generic body-node runtime or browser/public transport.
