### PR TITLE
test(gptme-sessions): combined exec→wait→patch regression fixture + monitoring (#1567)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -609,11 +609,29 @@ def post_session(
                 # Trajectory explicitly says this was noop — caller SHAs are
                 # from concurrent sessions.
                 if caller_deliverables:
-                    logger.warning(
-                        "Dropping %d git-range commit(s): trajectory determined "
-                        "noop with no deliverables (SHAs from concurrent session)",
-                        len(caller_deliverables),
-                    )
+                    _traj_tool_calls = (signals or {}).get("tool_calls") or {}
+                    if _traj_tool_calls:
+                        # Extractor recognized the format (non-empty tool_calls) but
+                        # found no commits/writes. This is the "no-deliverables-with-commits"
+                        # pattern: trajectory tool-call shape is known yet deliverables are
+                        # empty while caller has git-range evidence. Sustained occurrences
+                        # (especially with positive judge scores) indicate an extraction gap
+                        # for a new or changed tool-call shape — check for new Codex shapes.
+                        logger.warning(
+                            "no-deliverables-with-commits: trajectory recognized %d tool "
+                            "call type(s) (%s) but found no deliverables; dropping %d "
+                            "caller commit(s) as concurrent-session SHAs. Sustained "
+                            "recurrence suggests a signal-extraction gap.",
+                            len(_traj_tool_calls),
+                            ", ".join(sorted(_traj_tool_calls)[:5]),
+                            len(caller_deliverables),
+                        )
+                    else:
+                        logger.warning(
+                            "Dropping %d git-range commit(s): trajectory determined "
+                            "noop with no deliverables (SHAs from concurrent session)",
+                            len(caller_deliverables),
+                        )
                 deliverables = []
             else:
                 # Either the trajectory didn't rule out work, or it is

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -938,11 +938,18 @@ def test_post_session_format_blind_trajectory_keeps_caller_deliverables(tmp_path
     assert result.record.outcome_flip_reason == "format_blind_trajectory_caller_deliverables"
 
 
-def test_post_session_nonzero_tool_calls_still_drops_caller_deliverables(tmp_path: Path):
+def test_post_session_nonzero_tool_calls_still_drops_caller_deliverables(tmp_path: Path, caplog):
     """Inverse of the format-blind guard: when the trajectory DID parse tool
     calls (non-empty tool_calls) and says noop, it remains an authoritative
     noop — caller git-range commits (likely from a concurrent session) are
-    still dropped."""
+    still dropped.
+
+    Also locks the operator-facing ``no-deliverables-with-commits`` marker so
+    the diagnostic payload cannot silently regress to the generic concurrent-
+    commit drop warning.
+    """
+    import logging
+
     store = SessionStore(sessions_dir=tmp_path)
     fake_traj = tmp_path / "trajectory.jsonl"
     fake_traj.write_text("")
@@ -955,17 +962,25 @@ def test_post_session_nonzero_tool_calls_still_drops_caller_deliverables(tmp_pat
     }
     concurrent_sha = "deadbeef" + "01234567" * 4
     with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
-        result = post_session(
-            store=store,
-            harness="codex",
-            model="gpt-5.6-sol",
-            duration_seconds=620,
-            trajectory_path=fake_traj,
-            deliverables=[concurrent_sha],
-        )
+        with caplog.at_level(logging.WARNING, logger="gptme_sessions.post_session"):
+            result = post_session(
+                store=store,
+                harness="codex",
+                model="gpt-5.6-sol",
+                duration_seconds=620,
+                trajectory_path=fake_traj,
+                deliverables=[concurrent_sha],
+            )
 
     assert result.record.outcome == "noop"
     assert result.record.deliverables == []
+    named = [r.message for r in caplog.records if "no-deliverables-with-commits" in r.message]
+    assert named, "extraction-gap warning marker must stay in operator logs"
+    assert "exec_command" in named[0]
+    assert "signal-extraction gap" in named[0]
+    assert not any(
+        "Dropping" in r.message and "concurrent session" in r.message for r in caplog.records
+    )
 
 
 def test_post_session_trajectory_empty_deliverables_keeps_caller_when_productive(

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4542,6 +4542,105 @@ def test_extract_signals_codex_patch_apply_end_file_writes():
     assert is_productive(signals) is True
 
 
+def test_extract_signals_codex_wait_and_patch_combined():
+    """Combined regression fixture: exec → cell ID → wait → block-list commit + patch_apply_end.
+
+    Covers the exact pattern from the 2026-08-24..30 false-noop cluster (issue #1567):
+    - exec custom_tool_call returns only a cell ID (async dispatch)
+    - wait function_call block-list output carries the actual commit line(s)
+    - event_msg patch_apply_end records file changes alongside the commit
+
+    All three signals must appear in the extracted result and is_productive must be True.
+    """
+    msgs = [
+        {
+            "timestamp": "2026-08-25T14:00:00Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        # exec dispatches async shell; output is only the cell ID placeholder
+        {
+            "timestamp": "2026-08-25T14:00:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec_combined",
+                "name": "exec",
+                "input": (
+                    'const r = await tools.exec_command({"cmd":'
+                    '"git add -A && git commit -m \\"fix: combined\\"",'
+                    '"workdir":"/workspace"});\ntext(r.output);\n'
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-08-25T14:00:11Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_combined",
+                "output": "Script running with cell ID abc456\nWall time 0.0 seconds\nOutput:\n",
+            },
+        },
+        # wait continuation returns actual commit in a block-list
+        {
+            "timestamp": "2026-08-25T14:00:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "wait",
+                "call_id": "call_wait_combined",
+                "arguments": '{"cell_id":"abc456","yield_time_ms":30000}',
+            },
+        },
+        {
+            "timestamp": "2026-08-25T14:00:20Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_wait_combined",
+                "output": [
+                    {
+                        "type": "input_text",
+                        "text": "Script completed\nWall time 8.3 seconds\nOutput:\n",
+                    },
+                    {
+                        "type": "input_text",
+                        "text": (
+                            '{"exit_code":0,"output":"[master cafe5678] fix: combined\\n'
+                            ' 2 files changed, 10 insertions(+)\\n"}'
+                        ),
+                    },
+                ],
+            },
+        },
+        # patch_apply_end records the file-level changes from the nested apply_patch
+        {
+            "timestamp": "2026-08-25T14:00:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "call_id": "call_exec_combined",
+                "success": True,
+                "changes": {
+                    "/workspace/src/fix.py": {"type": "update"},
+                    "/workspace/src/new_helper.py": {"type": "add"},
+                },
+            },
+        },
+    ]
+
+    signals = extract_signals_codex(msgs)
+
+    assert signals["tool_calls"].get("exec") == 1
+    assert signals["tool_calls"].get("wait") == 1
+    assert signals["tool_calls"].get("apply_patch") == 1
+    assert signals["git_commits"] == ["fix: combined (cafe5678)"]
+    assert "/workspace/src/fix.py" in signals["file_writes"]
+    assert "/workspace/src/new_helper.py" in signals["file_writes"]
+    assert is_productive(signals) is True
+
+
 def test_extract_usage_codex():
     """Extract model, token, and rate-limit info from Codex trajectory."""
     msgs = [
@@ -4887,6 +4986,96 @@ def test_extract_from_path_codex(tmp_path: Path):
     assert result["tool_calls"]["exec_command"] == 1
     assert "usage" in result
     assert result["usage"]["model"] == "gpt-5.3-codex"
+
+
+def test_extract_from_path_codex_wait_patch_combined(tmp_path: Path):
+    """extract_from_path correctly handles exec → wait → patch_apply_end in one pass.
+
+    Regression coverage for issue #1567: the combined exec/wait/patch_apply_end
+    shape caused false NOOPs because extract_from_path returned empty git_commits
+    and productive=False even when the session had real commits.
+    """
+    from gptme_sessions.signals import extract_from_path
+
+    trajectory_file = tmp_path / "rollout.jsonl"
+    msgs = [
+        {
+            "timestamp": "2026-08-25T14:00:00Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-08-25T14:00:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec_fp",
+                "name": "exec",
+                "input": 'const r = await tools.exec_command({"cmd":"git commit -m \\"fix: fp\\""});\ntext(r.output);\n',
+            },
+        },
+        {
+            "timestamp": "2026-08-25T14:00:11Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_fp",
+                "output": "Script running with cell ID fp123\nWall time 0.0 seconds\nOutput:\n",
+            },
+        },
+        {
+            "timestamp": "2026-08-25T14:00:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "wait",
+                "call_id": "call_wait_fp",
+                "arguments": '{"cell_id":"fp123","yield_time_ms":30000}',
+            },
+        },
+        {
+            "timestamp": "2026-08-25T14:00:25Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_wait_fp",
+                "output": [
+                    {
+                        "type": "input_text",
+                        "text": "Script completed\nWall time 14.1 seconds\nOutput:\n",
+                    },
+                    {
+                        "type": "input_text",
+                        "text": '{"exit_code":0,"output":"[master dead1234] fix: fp\\n 1 file changed\\n"}',
+                    },
+                ],
+            },
+        },
+        {
+            "timestamp": "2026-08-25T14:00:26Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "call_id": "call_exec_fp",
+                "success": True,
+                "changes": {
+                    "/workspace/src/fix.py": {"type": "update"},
+                },
+            },
+        },
+    ]
+    with open(trajectory_file, "w") as f:
+        for msg in msgs:
+            f.write(json.dumps(msg) + "\n")
+
+    result = extract_from_path(trajectory_file)
+    assert result["format"] == "codex"
+    assert result["productive"] is True
+    assert result["git_commits"] == ["fix: fp (dead1234)"]
+    assert "/workspace/src/fix.py" in result["file_writes"]
+    assert result["tool_calls"].get("exec") == 1
+    assert result["tool_calls"].get("wait") == 1
+    assert result["tool_calls"].get("apply_patch") == 1
 
 
 def test_extract_from_path_copilot(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes remaining acceptance criteria from #1567 after #1575 shipped the core wait-continuation parse fix.

- **Combined regression fixture** (`test_extract_signals_codex_wait_and_patch_combined`): single test covering the exact false-noop pattern — `exec` custom_tool_call returns only a cell ID, `wait` function_call block-list output carries commit lines, and `event_msg.patch_apply_end` records file changes. All three signals must appear together and `is_productive()` must return `True`.
- **`extract_from_path()` integration test** (`test_extract_from_path_codex_wait_patch_combined`): writes a temp JSONL file with the combined fixture and calls `extract_from_path()`, verifying `productive=True`, `git_commits`, `file_writes`, and all three tool_call types end-to-end.
- **`no-deliverables-with-commits` monitoring** in `post_session.py`: when a trajectory recognizes tool_call types (non-empty `tool_calls` dict) but finds no deliverables despite caller having git-range evidence, emit a named warning. This surfaces sustained recurrence in operator logs so new Codex tool-call shape regressions are detected early.

## Acceptance criteria status

- [x] Normalize string and content-block-list output — done in existing code + #1575
- [x] Associate `wait` continuation output with async exec — done in #1575
- [x] Recognize nested `tools.apply_patch` / `patch_apply_end` — done in existing code + #1575
- [x] Add combined regression fixture (exec → cell ID → wait → block-list commit + nested patch) — **this PR**
- [x] Ensure `extract_from_path()` reports commits/files/productive for that fixture — **this PR**
- [x] Add monitoring for sustained `no-deliverables-with-commits` — **this PR**
- [ ] Regrade affected records from 2026-08-24 onward — operational step, separate from code

## Test plan

- [x] `test_extract_signals_codex_wait_and_patch_combined` passes
- [x] `test_extract_from_path_codex_wait_patch_combined` passes
- [x] Full `gptme-sessions` suite: 1318 passed, 0 failed

<!-- gptme-id:v1:gai_sYW20nFRK9d0G9v58iKAXTAHclQADrdOObaD1uW0jjW -->