### PR TITLE
feat(gptme-sessions): regrade command for post-fix false-noop recovery (#1567)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2575,6 +2575,135 @@ def sync(
         click.echo(", ".join(parts))
 
 
+@cli.command("regrade")
+@click.option("--harness", default=None, help="Restrict to a specific harness (e.g. codex)")
+@click.option(
+    "--outcome",
+    default="noop",
+    type=click.Choice(["productive", "noop", "failed", "unknown", "violated_policy", "all"]),
+    show_default=True,
+    help="Only regrade records whose current outcome matches this value ('all' = no filter)",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Only regrade records newer than this window (e.g. 10d, 2026-08-24)",
+)
+@click.option("--dry-run", is_flag=True, help="Show what would change without rewriting the store")
+@click.pass_context
+def regrade(
+    ctx: click.Context,
+    harness: str | None,
+    outcome: str,
+    since: str | None,
+    dry_run: bool,
+) -> None:
+    """Re-extract trajectory signals for existing session records.
+
+    Useful after a signal-extractor bug fix to backfill sessions that were
+    incorrectly graded (e.g., productive runs classified as noop because the
+    extractor missed a new tool-call shape).
+
+    Unlike ``sync --signals``, this command forces re-extraction even when
+    ``outcome`` is already set (not just ``unknown``), as long as the field
+    has not been manually annotated.  Annotated fields are preserved.
+
+    After running this command, the store is updated in place.  Bandit
+    posteriors are caller-side; recompute them separately from the corrected
+    records (e.g. ``gptme-sessions export --harness codex --since 10d``).
+
+    Example — fix false-noops from the Codex wait-continuation bug (#1567):
+
+        gptme-sessions regrade --harness codex --since 10d --dry-run
+        gptme-sessions regrade --harness codex --since 10d
+    """
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    since_days = _parse_since(since) if since else None
+    effective_outcome = None if outcome == "all" else outcome
+
+    candidates = store.query(
+        harness=harness,
+        outcome=effective_outcome,
+        since_days=since_days,
+    )
+
+    if not candidates:
+        click.echo("No matching records found.")
+        return
+
+    regraded = 0
+    no_trajectory = 0
+    unchanged = 0
+    errors = 0
+
+    for rec in candidates:
+        traj = Path(rec.trajectory_path) if rec.trajectory_path else None
+        if traj is None or not traj.is_file():
+            no_trajectory += 1
+            if dry_run:
+                click.echo(
+                    f"  no-trajectory: {rec.session_id}  "
+                    f"outcome={rec.outcome}  (would reset to unknown)"
+                )
+            else:
+                if "outcome" not in rec.annotated_fields:
+                    rec.outcome = "unknown"
+                    regraded += 1
+            continue
+
+        try:
+            result = extract_from_path(traj)
+        except Exception as exc:
+            click.echo(
+                f"  error: extraction failed for {rec.session_id}: {exc}",
+                err=True,
+            )
+            errors += 1
+            continue
+
+        new_outcome = "productive" if result.get("productive") else "noop"
+        outcome_changed = False
+
+        if "outcome" not in rec.annotated_fields and rec.outcome != new_outcome:
+            if dry_run:
+                click.echo(
+                    f"  would regrade: {rec.session_id}  "
+                    f"{rec.outcome} → {new_outcome}  "
+                    f"commits={len(result.get('git_commits', []))}  "
+                    f"files={len(result.get('file_writes', []))}"
+                )
+            else:
+                rec.outcome = new_outcome
+                outcome_changed = True
+
+        if not dry_run:
+            # Backfill deliverables/duration that the old extractor missed.
+            # _apply_extract_result_to_record skips outcome when != "unknown",
+            # so it is safe to call after we've already set the new outcome.
+            _apply_extract_result_to_record(rec, result)
+
+        if outcome_changed:
+            regraded += 1
+        elif not dry_run:
+            unchanged += 1
+
+    if not dry_run and candidates:
+        # rewrite() has upsert semantics: mutated candidates take precedence
+        # over existing records; all other records are preserved.
+        store.rewrite(candidates)
+
+    parts = []
+    verb = "Would regrade" if dry_run else "Regraded"
+    parts.append(f"{verb} {regraded} record(s)")
+    if no_trajectory:
+        parts.append(f"{no_trajectory} missing trajectory (reset to unknown)")
+    if unchanged:
+        parts.append(f"{unchanged} already correct")
+    if errors:
+        parts.append(f"{errors} extraction error(s)")
+    click.echo(", ".join(parts) + ".")
+
+
 @cli.command("repair-grades")
 @click.option("--dry-run", is_flag=True, help="Show what would change without rewriting the store")
 @click.pass_context

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2575,6 +2575,24 @@ def sync(
         click.echo(", ".join(parts))
 
 
+# Process-level outcomes that trajectory extraction cannot reconstruct.
+# post_session() sets these from exit_code / policy checks, which outrank
+# the extractor's binary productive/noop mapping.
+_PROCESS_OUTCOMES = frozenset({"failed", "violated_policy"})
+
+
+def _regrade_outcome(current: str, productive: bool) -> str:
+    """Map extractor productivity onto a stored outcome without erasing failures.
+
+    ``extract_from_path`` only reports productive vs not. ``failed`` and
+    ``violated_policy`` come from process exit / policy and must be preserved
+    — a nonproductive trajectory must not collapse them to ``noop``.
+    """
+    if current in _PROCESS_OUTCOMES:
+        return current
+    return "productive" if productive else "noop"
+
+
 @cli.command("regrade")
 @click.option("--harness", default=None, help="Restrict to a specific harness (e.g. codex)")
 @click.option(
@@ -2608,6 +2626,9 @@ def regrade(
     ``outcome`` is already set (not just ``unknown``), as long as the field
     has not been manually annotated.  Annotated fields are preserved.
 
+    Process-level outcomes (``failed``, ``violated_policy``) are never
+    overwritten — the extractor cannot reconstruct them from a trajectory.
+
     After running this command, the store is updated in place.  Bandit
     posteriors are caller-side; recompute them separately from the corrected
     records (e.g. ``gptme-sessions export --harness codex --since 10d``).
@@ -2631,6 +2652,12 @@ def regrade(
         click.echo("No matching records found.")
         return
 
+    # Snapshot before mutation so a locked three-way merge can keep concurrent
+    # field updates. Extraction is slow, so it stays outside the store lock
+    # (same pattern as sync).
+    original_records = {rec.session_id: rec.to_dict() for rec in candidates}
+    mutated: list[SessionRecord] = []
+
     regraded = 0
     no_trajectory = 0
     unchanged = 0
@@ -2639,6 +2666,10 @@ def regrade(
     for rec in candidates:
         traj = Path(rec.trajectory_path) if rec.trajectory_path else None
         if traj is None or not traj.is_file():
+            if rec.outcome in _PROCESS_OUTCOMES or "outcome" in rec.annotated_fields:
+                if not dry_run:
+                    unchanged += 1
+                continue
             no_trajectory += 1
             if dry_run:
                 click.echo(
@@ -2646,9 +2677,9 @@ def regrade(
                     f"outcome={rec.outcome}  (would reset to unknown)"
                 )
             else:
-                if "outcome" not in rec.annotated_fields:
-                    rec.outcome = "unknown"
-                    regraded += 1
+                rec.outcome = "unknown"
+                mutated.append(rec)
+                regraded += 1
             continue
 
         try:
@@ -2661,8 +2692,9 @@ def regrade(
             errors += 1
             continue
 
-        new_outcome = "productive" if result.get("productive") else "noop"
+        new_outcome = _regrade_outcome(rec.outcome, bool(result.get("productive")))
         outcome_changed = False
+        record_changed = False
 
         if "outcome" not in rec.annotated_fields and rec.outcome != new_outcome:
             if dry_run:
@@ -2675,22 +2707,30 @@ def regrade(
             else:
                 rec.outcome = new_outcome
                 outcome_changed = True
+                record_changed = True
 
         if not dry_run:
             # Backfill deliverables/duration that the old extractor missed.
             # _apply_extract_result_to_record skips outcome when != "unknown",
             # so it is safe to call after we've already set the new outcome.
-            _apply_extract_result_to_record(rec, result)
+            if _apply_extract_result_to_record(rec, result):
+                record_changed = True
+            if record_changed:
+                mutated.append(rec)
 
         if outcome_changed:
             regraded += 1
         elif not dry_run:
             unchanged += 1
 
-    if not dry_run and candidates:
-        # rewrite() has upsert semantics: mutated candidates take precedence
-        # over existing records; all other records are preserved.
-        store.rewrite(candidates)
+    if not dry_run and mutated:
+        # Extraction happens outside the lock; three-way merge a final
+        # locked re-read so no concurrent record mutation is lost.
+        # rewrite() has upsert semantics: only mutated candidates are
+        # supplied, so untouched records are not rewritten from a stale copy.
+        with store.lock():
+            _merge_concurrent_record_updates(mutated, store.load_all(), original_records)
+            store.rewrite(mutated)
 
     parts = []
     verb = "Would regrade" if dry_run else "Regraded"

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2581,14 +2581,22 @@ def sync(
 _PROCESS_OUTCOMES = frozenset({"failed", "violated_policy"})
 
 
-def _regrade_outcome(current: str, productive: bool) -> str:
+def _regrade_outcome(
+    current: str,
+    productive: bool,
+    *,
+    annotated: bool = False,
+) -> str:
     """Map extractor productivity onto a stored outcome without erasing failures.
 
     ``extract_from_path`` only reports productive vs not. ``failed`` and
     ``violated_policy`` come from process exit / policy and must be preserved
     — a nonproductive trajectory must not collapse them to ``noop``.
+    Operator-annotated outcomes are frozen the same way: the helper itself
+    returns ``current``, so a caller cannot overwrite them by forgetting a
+    separate guard.
     """
-    if current in _PROCESS_OUTCOMES:
+    if annotated or current in _PROCESS_OUTCOMES:
         return current
     return "productive" if productive else "noop"
 
@@ -2667,8 +2675,7 @@ def regrade(
         traj = Path(rec.trajectory_path) if rec.trajectory_path else None
         if traj is None or not traj.is_file():
             if rec.outcome in _PROCESS_OUTCOMES or "outcome" in rec.annotated_fields:
-                if not dry_run:
-                    unchanged += 1
+                unchanged += 1
                 continue
             no_trajectory += 1
             if dry_run:
@@ -2679,7 +2686,7 @@ def regrade(
             else:
                 rec.outcome = "unknown"
                 mutated.append(rec)
-                regraded += 1
+            regraded += 1
             continue
 
         try:
@@ -2692,11 +2699,14 @@ def regrade(
             errors += 1
             continue
 
-        new_outcome = _regrade_outcome(rec.outcome, bool(result.get("productive")))
-        outcome_changed = False
+        new_outcome = _regrade_outcome(
+            rec.outcome,
+            bool(result.get("productive")),
+            annotated="outcome" in rec.annotated_fields,
+        )
         record_changed = False
 
-        if "outcome" not in rec.annotated_fields and rec.outcome != new_outcome:
+        if rec.outcome != new_outcome:
             if dry_run:
                 click.echo(
                     f"  would regrade: {rec.session_id}  "
@@ -2706,8 +2716,10 @@ def regrade(
                 )
             else:
                 rec.outcome = new_outcome
-                outcome_changed = True
                 record_changed = True
+            regraded += 1
+        else:
+            unchanged += 1
 
         if not dry_run:
             # Backfill deliverables/duration that the old extractor missed.
@@ -2717,11 +2729,6 @@ def regrade(
                 record_changed = True
             if record_changed:
                 mutated.append(rec)
-
-        if outcome_changed:
-            regraded += 1
-        elif not dry_run:
-            unchanged += 1
 
     if not dry_run and mutated:
         # Extraction happens outside the lock; three-way merge a final

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -2045,3 +2045,154 @@ class TestRegradeCommand:
         records = {r.session_id: r for r in store.load_all()}
         assert records["codex-noop"].outcome == "productive"
         assert records["cc-noop"].outcome == "noop"
+
+    def test_regrade_preserves_failed_on_nonproductive_extract(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Failed is process-derived; a nonproductive trajectory must not collapse it to noop."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="failed-crash",
+                harness="codex",
+                outcome="failed",
+                exit_code=1,
+                trajectory_path=str(traj),
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": False,
+                "git_commits": [],
+                "file_writes": [],
+                "deliverables": [],
+                "deliverable_details": [],
+                "session_duration_s": 12,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--outcome", "failed"], tmp_path)
+
+        assert rc == 0, out
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "failed"
+        assert "→ noop" not in out
+
+    def test_regrade_all_does_not_erase_failed(self, tmp_path: Path, monkeypatch) -> None:
+        """--outcome all flips false-noops but leaves failed records intact."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="false-noop",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="still-failed",
+                harness="codex",
+                outcome="failed",
+                exit_code=1,
+                trajectory_path=str(traj),
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="policy-hit",
+                harness="codex",
+                outcome="violated_policy",
+                trajectory_path=str(traj),
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": True,
+                "git_commits": ["fix: x (eee5555)"],
+                "file_writes": [],
+                "deliverables": ["fix: x (eee5555)"],
+                "deliverable_details": [],
+                "session_duration_s": 90,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--outcome", "all"], tmp_path)
+
+        assert rc == 0, out
+        records = {r.session_id: r for r in store.load_all()}
+        assert records["false-noop"].outcome == "productive"
+        assert records["still-failed"].outcome == "failed"
+        assert records["policy-hit"].outcome == "violated_policy"
+
+    def test_regrade_missing_trajectory_preserves_failed(self, tmp_path: Path) -> None:
+        """A missing trajectory must not reset process-derived failed to unknown."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="failed-missing-traj",
+                harness="codex",
+                outcome="failed",
+                exit_code=1,
+                trajectory_path=str(tmp_path / "nonexistent.jsonl"),
+            )
+        )
+
+        rc, out = _invoke(["regrade", "--outcome", "failed"], tmp_path)
+
+        assert rc == 0, out
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "failed"
+        assert "reset to unknown" not in out
+
+    def test_regrade_preserves_concurrent_record_updates(self, tmp_path: Path, monkeypatch) -> None:
+        """A concurrent annotation during extraction must survive rewrite."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="race-1",
+                harness="codex",
+                model="old-model",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+
+        def _extract(_path: Path) -> dict:
+            with store.lock():
+                records = store.load_all()
+                records[0].model = "concurrent-model"
+                if "model" not in records[0].annotated_fields:
+                    records[0].annotated_fields.append("model")
+                store.rewrite(records)
+            return {
+                "productive": True,
+                "git_commits": ["fix: race (fff6666)"],
+                "file_writes": [],
+                "deliverables": ["fix: race (fff6666)"],
+                "deliverable_details": [],
+                "session_duration_s": 80,
+                "inferred_category": None,
+                "usage": None,
+            }
+
+        monkeypatch.setattr("gptme_sessions.cli.extract_from_path", _extract)
+
+        rc, out = _invoke(["regrade", "--harness", "codex"], tmp_path)
+
+        assert rc == 0, out
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "productive"
+        assert persisted.model == "concurrent-model"
+        assert "model" in persisted.annotated_fields

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1822,3 +1822,226 @@ class TestSyncRouteBackfill:
         records = store.load_all()
         assert len(records) == 1
         assert records[0].trajectory_revision == trajectory_revision_for(fake_file)
+
+
+class TestRegradeCommand:
+    """Tests for the ``regrade`` command."""
+
+    def _make_codex_traj(self, tmp_path: Path, name: str = "traj.jsonl") -> Path:
+        """Write a minimal Codex JSONL trajectory to tmp_path."""
+        traj = tmp_path / name
+        traj.write_text("{}\n", encoding="utf-8")
+        return traj
+
+    def test_regrade_flips_false_noop_to_productive(self, tmp_path: Path, monkeypatch) -> None:
+        """A noop record re-extracts as productive when the trajectory has commits."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="false-noop-1",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+                deliverables=[],
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": True,
+                "git_commits": ["fix: something (abc1234)"],
+                "file_writes": ["src/foo.py"],
+                "deliverables": ["fix: something (abc1234)"],
+                "deliverable_details": [],
+                "session_duration_s": 300,
+                "inferred_category": "code",
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--harness", "codex"], tmp_path)
+
+        assert rc == 0, out
+        assert "Regraded 1 record(s)" in out
+
+        records = store.load_all()
+        assert len(records) == 1
+        assert records[0].outcome == "productive"
+        assert records[0].deliverables == ["fix: something (abc1234)"]
+
+    def test_regrade_dry_run_does_not_persist(self, tmp_path: Path, monkeypatch) -> None:
+        """--dry-run reports what would change without touching the store."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="dry-run-noop",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": True,
+                "git_commits": ["feat: x (bbb2222)"],
+                "file_writes": [],
+                "deliverables": ["feat: x (bbb2222)"],
+                "deliverable_details": [],
+                "session_duration_s": 120,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--dry-run"], tmp_path)
+
+        assert rc == 0, out
+        assert "would regrade" in out.lower() or "Would regrade" in out
+
+        # Store must be unchanged.
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "noop"
+
+    def test_regrade_leaves_genuine_noops_unchanged(self, tmp_path: Path, monkeypatch) -> None:
+        """A noop that truly has no commits stays noop."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="genuine-noop",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": False,
+                "git_commits": [],
+                "file_writes": [],
+                "deliverables": [],
+                "deliverable_details": [],
+                "session_duration_s": 60,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--harness", "codex"], tmp_path)
+
+        assert rc == 0, out
+        assert "Regraded 0 record(s)" in out
+
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "noop"
+
+    def test_regrade_respects_annotated_outcome(self, tmp_path: Path, monkeypatch) -> None:
+        """Manually annotated outcomes are not overridden."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        rec = SessionRecord(
+            session_id="annotated-noop",
+            harness="codex",
+            outcome="noop",
+            trajectory_path=str(traj),
+            annotated_fields=["outcome"],
+        )
+        store.append(rec)
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": True,
+                "git_commits": ["fix: something (ccc3333)"],
+                "file_writes": [],
+                "deliverables": ["fix: something (ccc3333)"],
+                "deliverable_details": [],
+                "session_duration_s": 200,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--harness", "codex"], tmp_path)
+
+        assert rc == 0, out
+        persisted = store.load_all()[0]
+        # Annotated outcome must not change.
+        assert persisted.outcome == "noop"
+
+    def test_regrade_no_trajectory_resets_to_unknown(self, tmp_path: Path) -> None:
+        """Records with missing trajectory files are reset to outcome=unknown."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="missing-traj",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(tmp_path / "nonexistent.jsonl"),
+            )
+        )
+
+        rc, out = _invoke(["regrade", "--outcome", "noop"], tmp_path)
+
+        assert rc == 0, out
+        assert "Regraded 1 record(s)" in out
+
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "unknown"
+
+    def test_regrade_harness_filter_skips_other_harnesses(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """--harness restricts regrading to matching records only."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="codex-noop",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="cc-noop",
+                harness="claude-code",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+
+        calls = []
+
+        def _mock_extract(path):
+            calls.append(path)
+            return {
+                "productive": True,
+                "git_commits": ["fix: x (ddd4444)"],
+                "file_writes": [],
+                "deliverables": ["fix: x (ddd4444)"],
+                "deliverable_details": [],
+                "session_duration_s": 100,
+                "inferred_category": None,
+                "usage": None,
+            }
+
+        monkeypatch.setattr("gptme_sessions.cli.extract_from_path", _mock_extract)
+
+        rc, out = _invoke(["regrade", "--harness", "codex"], tmp_path)
+
+        assert rc == 0, out
+        # Only one extraction call (for the codex record).
+        assert len(calls) == 1
+
+        records = {r.session_id: r for r in store.load_all()}
+        assert records["codex-noop"].outcome == "productive"
+        assert records["cc-noop"].outcome == "noop"

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -13,7 +13,7 @@ import pytest
 
 from click.testing import CliRunner
 
-from gptme_sessions.cli import cli
+from gptme_sessions.cli import _regrade_outcome, cli
 from gptme_sessions.record import SessionRecord
 from gptme_sessions.store import SessionStore
 
@@ -1824,6 +1824,28 @@ class TestSyncRouteBackfill:
         assert records[0].trajectory_revision == trajectory_revision_for(fake_file)
 
 
+class TestRegradeOutcomeHelper:
+    """Unit tests for ``_regrade_outcome`` — the mapping must freeze
+    process-derived and operator-annotated outcomes itself, not rely on
+    a caller-side guard.
+    """
+
+    def test_maps_productive_and_noop(self) -> None:
+        assert _regrade_outcome("noop", True) == "productive"
+        assert _regrade_outcome("unknown", False) == "noop"
+        assert _regrade_outcome("productive", False) == "noop"
+
+    def test_preserves_process_outcomes(self) -> None:
+        assert _regrade_outcome("failed", False) == "failed"
+        assert _regrade_outcome("failed", True) == "failed"
+        assert _regrade_outcome("violated_policy", True) == "violated_policy"
+
+    def test_preserves_annotated_outcomes(self) -> None:
+        assert _regrade_outcome("noop", True, annotated=True) == "noop"
+        assert _regrade_outcome("productive", False, annotated=True) == "productive"
+        assert _regrade_outcome("failed", False, annotated=True) == "failed"
+
+
 class TestRegradeCommand:
     """Tests for the ``regrade`` command."""
 
@@ -1901,7 +1923,8 @@ class TestRegradeCommand:
         rc, out = _invoke(["regrade", "--dry-run"], tmp_path)
 
         assert rc == 0, out
-        assert "would regrade" in out.lower() or "Would regrade" in out
+        assert "would regrade" in out.lower()
+        assert "Would regrade 1 record(s)" in out
 
         # Store must be unchanged.
         persisted = store.load_all()[0]
@@ -1975,6 +1998,106 @@ class TestRegradeCommand:
         persisted = store.load_all()[0]
         # Annotated outcome must not change.
         assert persisted.outcome == "noop"
+        assert "→ productive" not in out
+        assert "Regraded 0 record(s)" in out
+
+    def test_regrade_dry_run_preserves_annotated_outcome(self, tmp_path: Path, monkeypatch) -> None:
+        """Dry-run must not report an annotated outcome as a would-regrade."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="annotated-dry-run",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+                annotated_fields=["outcome"],
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": True,
+                "git_commits": ["fix: something (ccc3333)"],
+                "file_writes": [],
+                "deliverables": ["fix: something (ccc3333)"],
+                "deliverable_details": [],
+                "session_duration_s": 200,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--dry-run"], tmp_path)
+
+        assert rc == 0, out
+        assert "would regrade:" not in out.lower()
+        assert "Would regrade 0 record(s)" in out
+        assert store.load_all()[0].outcome == "noop"
+
+    def test_regrade_all_preserves_annotated_outcome(self, tmp_path: Path, monkeypatch) -> None:
+        """--outcome all still freezes operator-annotated outcomes."""
+        store = SessionStore(sessions_dir=tmp_path)
+        traj = self._make_codex_traj(tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="annotated-all",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+                annotated_fields=["outcome"],
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="false-noop",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(traj),
+            )
+        )
+
+        monkeypatch.setattr(
+            "gptme_sessions.cli.extract_from_path",
+            lambda _: {
+                "productive": True,
+                "git_commits": ["fix: x (eee5555)"],
+                "file_writes": [],
+                "deliverables": ["fix: x (eee5555)"],
+                "deliverable_details": [],
+                "session_duration_s": 90,
+                "inferred_category": None,
+                "usage": None,
+            },
+        )
+
+        rc, out = _invoke(["regrade", "--outcome", "all"], tmp_path)
+
+        assert rc == 0, out
+        records = {r.session_id: r for r in store.load_all()}
+        assert records["annotated-all"].outcome == "noop"
+        assert records["false-noop"].outcome == "productive"
+
+    def test_regrade_missing_trajectory_preserves_annotated(self, tmp_path: Path) -> None:
+        """A missing trajectory must not reset an annotated outcome to unknown."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="annotated-missing-traj",
+                harness="codex",
+                outcome="noop",
+                trajectory_path=str(tmp_path / "nonexistent.jsonl"),
+                annotated_fields=["outcome"],
+            )
+        )
+
+        rc, out = _invoke(["regrade", "--outcome", "noop"], tmp_path)
+
+        assert rc == 0, out
+        persisted = store.load_all()[0]
+        assert persisted.outcome == "noop"
+        assert "reset to unknown" not in out
 
     def test_regrade_no_trajectory_resets_to_unknown(self, tmp_path: Path) -> None:
         """Records with missing trajectory files are reset to outcome=unknown."""


### PR DESCRIPTION
## Summary

- Adds `gptme-sessions regrade` CLI command that re-extracts trajectory signals for existing records, fixing outcomes set wrong due to extractor bugs
- Unlike `sync --signals` (which only processes `outcome=unknown` records), `regrade` re-runs extraction even on settled `outcome=noop` records and updates them if the extractor now disagrees
- Supports `--harness`, `--outcome`, `--since` filters and `--dry-run` mode
- Manually annotated (`annotated_fields`) outcomes are preserved and never overwritten
- 6 new tests covering: false-noop flip, dry-run safety, genuine-noop unchanged, annotated-field preservation, missing-trajectory reset, harness filter isolation

## Closes remaining acceptance criterion from #1567

After #1575 (core wait-continuation parse fix) and #1578 (tests + monitoring), the last open criterion was:
> Regrade affected records from 2026-08-24 onward and recompute affected harness/category bandit posteriors.

This PR delivers the tooling. Operational steps:

```bash
# Preview what would change
gptme-sessions regrade --harness codex --since 10d --dry-run

# Apply corrections
gptme-sessions regrade --harness codex --since 10d

# Export corrected records for bandit recomputation
gptme-sessions export --harness codex --since 10d --format json > /tmp/corrected.json
```

## Test plan

- [x] 6 `TestRegradeCommand` tests: false-noop flip, dry-run, genuine noop unchanged, annotated fields preserved, missing trajectory, harness filter
- [x] Full `gptme-sessions` suite: 1324 passed, 0 failed