### PR TITLE
fix(gptme-sessions): drop untagged caller SHAs on file-only trajectories

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/deliverables.py
+++ b/packages/gptme-sessions/src/gptme_sessions/deliverables.py
@@ -47,7 +47,8 @@ def classify_commit_ownership(
         return "trajectory_observed"
     values = [str(v).strip() for v in (trailer_ids or []) if str(v).strip()]
     if values:
-        if session_id and session_id in values:
+        normalized_session_id = session_id.strip().lower() if session_id else None
+        if normalized_session_id and normalized_session_id in {v.lower() for v in values}:
             return "session_trailer_owned"
         return "explicitly_foreign"
     return "ambiguous"

--- a/packages/gptme-sessions/src/gptme_sessions/deliverables.py
+++ b/packages/gptme-sessions/src/gptme_sessions/deliverables.py
@@ -2,14 +2,55 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+OwnershipVerdict = Literal[
+    "trajectory_observed",
+    "session_trailer_owned",
+    "explicitly_foreign",
+    "ambiguous",
+]
 
 
 def looks_like_sha(value: str) -> bool:
     """Return True for bare SHA-like hex strings used as deliverables."""
     lowered = value.lower().strip()
     return 7 <= len(lowered) <= 40 and all(c in "0123456789abcdef" for c in lowered)
+
+
+def sha_in_traj_prefixes(sha: str, traj_sha_prefixes: set[str] | None) -> bool:
+    """Return True if a caller SHA matches a trajectory commit prefix."""
+    if not traj_sha_prefixes:
+        return False
+    sha_lower = sha.lower().strip()
+    return any(sha_lower.startswith(prefix) for prefix in traj_sha_prefixes)
+
+
+def classify_commit_ownership(
+    sha: str,
+    *,
+    session_id: str | None = None,
+    trailer_ids: Sequence[str] | None = None,
+    traj_sha_prefixes: set[str] | None = None,
+) -> OwnershipVerdict:
+    """Return the typed ownership verdict for one candidate commit SHA.
+
+    A bound trajectory is authoritative: a SHA observed there is owned even
+    when git trailers are missing. A ``Git-Session-Id`` trailer matching
+    ``session_id`` is owned even if the trajectory missed the SHA. Any other
+    trailer is explicitly foreign. An untagged shared-range SHA is
+    *ambiguous*, not session-owned — keeping it is how session 73be credited
+    six sibling commits.
+    """
+    if sha_in_traj_prefixes(sha, traj_sha_prefixes):
+        return "trajectory_observed"
+    values = [str(v).strip() for v in (trailer_ids or []) if str(v).strip()]
+    if values:
+        if session_id and session_id in values:
+            return "session_trailer_owned"
+        return "explicitly_foreign"
+    return "ambiguous"
 
 
 def deliverable_kind(value: str) -> str:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -691,7 +691,7 @@ def post_session(
                         len(dropped_foreign),
                         (dropped_ambiguous + dropped_foreign)[:5],
                     )
-                deliverables = list(dict.fromkeys(traj_deliverables + kept_caller))
+                deliverables = list(dict.fromkeys(kept_caller + traj_deliverables))
         else:
             # Trajectory ran but found no deliverables.
             if traj_productive is False and trajectory_reliable:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -673,7 +673,16 @@ def post_session(
                         elif verdict == "explicitly_foreign":
                             dropped_foreign.append(item)
                         else:
-                            dropped_ambiguous.append(item)
+                            # Ambiguous SHA-like deliverables (e.g., PR URLs or non-commit IDs)
+                            # are kept as fallback since they're explicitly provided by caller
+                            kept_caller.append(item)
+                            extra_deliverable_details.extend(
+                                _build_caller_deliverable_details(
+                                    [item],
+                                    provenance_class="fallback_observed",
+                                    evidence={"source": "caller", "reason": "non_sha_passthrough"},
+                                )
+                            )
                     else:
                         kept_caller.append(item)
                         extra_deliverable_details.extend(
@@ -691,7 +700,7 @@ def post_session(
                         len(dropped_foreign),
                         (dropped_ambiguous + dropped_foreign)[:5],
                     )
-                deliverables = list(dict.fromkeys(traj_deliverables + kept_caller))
+                deliverables = list(dict.fromkeys(kept_caller + traj_deliverables))
         else:
             # Trajectory ran but found no deliverables.
             if traj_productive is False and trajectory_reliable:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -24,12 +24,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from .deliverables import (
     build_deliverable_detail,
+    classify_commit_ownership,
     looks_like_sha,
     project_deliverable_details,
 )
@@ -66,6 +68,20 @@ def _caller_sha_in_traj(sha: str, traj_sha_prefixes: set[str]) -> bool:
     """Return True if a full 40-char SHA from the caller appears in trajectory commits."""
     sha_lower = sha.lower().strip()
     return any(sha_lower.startswith(prefix) for prefix in traj_sha_prefixes)
+
+
+def _trailer_ids_for(
+    sha: str, commit_trailers: Mapping[str, Sequence[str]] | None
+) -> list[str] | None:
+    """Look up Git-Session-Id trailers for a caller SHA (full or lowercase)."""
+    if not commit_trailers:
+        return None
+    raw = commit_trailers.get(sha)
+    if raw is None:
+        raw = commit_trailers.get(sha.lower())
+    if raw is None:
+        return None
+    return [str(v) for v in raw]
 
 
 def _build_caller_deliverable_details(
@@ -294,6 +310,7 @@ def post_session(
     harness_stderr_path: Path | None = None,
     failure_reason: str | None = None,
     error: str | None = None,
+    commit_trailers: Mapping[str, Sequence[str]] | None = None,
 ) -> PostSessionResult:
     """Record a completed agent session and extract trajectory signals.
 
@@ -364,6 +381,11 @@ def post_session(
         the first ``/journal/`` write in the trajectory signals.
     session_id:
         Override the auto-generated session ID.
+    commit_trailers:
+        Optional map of caller commit SHA → ``Git-Session-Id`` trailer values.
+        Used to distinguish session-trailer-owned SHAs from untagged/ambiguous
+        shared-range commits when a bound trajectory has file edits but no
+        commit SHA. Missing entries are treated as untagged (ambiguous).
     harness_session_id:
         Harness-native session id used by the ``match-lessons`` hook to name its
         per-session events file (for Claude Code, the transcript UUID). Used to
@@ -557,52 +579,119 @@ def post_session(
         # No caller deliverables: use trajectory exclusively.
         deliverables = traj_deliverables
     elif signals is not None:
-        # Trajectory was available — it is authoritative, but only for
-        # deliverables it can actually validate.  File paths in trajectory
-        # deliverables have no SHA to cross-check, so caller SHAs pass through.
+        # Trajectory was available — it is authoritative. File-only
+        # trajectories cannot validate caller SHAs, so untagged shared-range
+        # commits are ambiguous and dropped unless a Git-Session-Id trailer
+        # proves ownership.
         if traj_deliverables:
             traj_sha_prefixes = _extract_traj_sha_prefixes(traj_deliverables)
             if traj_sha_prefixes:
                 # Trajectory has commit SHAs — validate caller SHAs against them
                 # and preserve non-SHA caller deliverables like PR URLs or files.
+                # Trailer-owned SHAs the extractor missed are still session-owned.
                 validated_shas = [
                     d
                     for d in caller_deliverables
                     if looks_like_sha(d) and _caller_sha_in_traj(d, traj_sha_prefixes)
                 ]
-                unvalidated_shas = [
-                    d for d in caller_deliverables if looks_like_sha(d) and d not in validated_shas
-                ]
+                trailer_owned_shas: list[str] = []
+                dropped_shas: list[str] = []
+                for d in caller_deliverables:
+                    if not looks_like_sha(d) or d in validated_shas:
+                        continue
+                    verdict = classify_commit_ownership(
+                        d,
+                        session_id=session_id,
+                        trailer_ids=_trailer_ids_for(d, commit_trailers),
+                        traj_sha_prefixes=traj_sha_prefixes,
+                    )
+                    if verdict == "session_trailer_owned":
+                        trailer_owned_shas.append(d)
+                    else:
+                        dropped_shas.append(d)
                 passthrough_non_sha = [d for d in caller_deliverables if not looks_like_sha(d)]
-                if unvalidated_shas:
+                if dropped_shas:
                     logger.warning(
                         "Dropping %d git-range commit(s) absent from trajectory "
                         "(likely from a concurrent session): %s",
-                        len(unvalidated_shas),
-                        unvalidated_shas[:5],
+                        len(dropped_shas),
+                        dropped_shas[:5],
                     )
                 deliverables = list(
-                    dict.fromkeys(traj_deliverables + validated_shas + passthrough_non_sha)
+                    dict.fromkeys(
+                        traj_deliverables
+                        + validated_shas
+                        + trailer_owned_shas
+                        + passthrough_non_sha
+                    )
                 )
-                extra_deliverable_details = _build_caller_deliverable_details(
-                    validated_shas,
-                    provenance_class="session_committed",
-                    evidence={"source": "caller", "validation": "trajectory_sha_prefix"},
-                ) + _build_caller_deliverable_details(
-                    passthrough_non_sha,
-                    provenance_class="fallback_observed",
-                    evidence={"source": "caller", "reason": "non_sha_passthrough"},
+                extra_deliverable_details = (
+                    _build_caller_deliverable_details(
+                        validated_shas,
+                        provenance_class="session_committed",
+                        evidence={"source": "caller", "validation": "trajectory_sha_prefix"},
+                    )
+                    + _build_caller_deliverable_details(
+                        trailer_owned_shas,
+                        provenance_class="session_trailer_owned",
+                        evidence={"source": "caller", "validation": "git_session_id_trailer"},
+                    )
+                    + _build_caller_deliverable_details(
+                        passthrough_non_sha,
+                        provenance_class="fallback_observed",
+                        evidence={"source": "caller", "reason": "non_sha_passthrough"},
+                    )
                 )
             else:
-                # Trajectory has no SHAs (file paths only) — can't validate
-                # caller SHAs.  Keep both sets, caller items first to preserve
-                # the pre-existing deliverable ordering convention.
-                deliverables = list(dict.fromkeys(caller_deliverables + traj_deliverables))
-                extra_deliverable_details = _build_caller_deliverable_details(
-                    caller_deliverables,
-                    provenance_class="fallback_observed",
-                    evidence={"source": "caller", "reason": "trajectory_has_no_sha"},
-                )
+                # Trajectory has file paths but no commit SHA. Untagged caller
+                # SHAs from a shared git range are ambiguous, not owned
+                # (ErikBjare/bob session 73be). Keep trajectory files and only
+                # those caller SHAs whose Git-Session-Id trailer matches.
+                kept_caller: list[str] = []
+                extra_deliverable_details = []
+                dropped_ambiguous: list[str] = []
+                dropped_foreign: list[str] = []
+                for item in caller_deliverables:
+                    if looks_like_sha(item):
+                        verdict = classify_commit_ownership(
+                            item,
+                            session_id=session_id,
+                            trailer_ids=_trailer_ids_for(item, commit_trailers),
+                        )
+                        if verdict == "session_trailer_owned":
+                            kept_caller.append(item)
+                            extra_deliverable_details.extend(
+                                _build_caller_deliverable_details(
+                                    [item],
+                                    provenance_class="session_trailer_owned",
+                                    evidence={
+                                        "source": "caller",
+                                        "validation": "git_session_id_trailer",
+                                    },
+                                )
+                            )
+                        elif verdict == "explicitly_foreign":
+                            dropped_foreign.append(item)
+                        else:
+                            dropped_ambiguous.append(item)
+                    else:
+                        kept_caller.append(item)
+                        extra_deliverable_details.extend(
+                            _build_caller_deliverable_details(
+                                [item],
+                                provenance_class="fallback_observed",
+                                evidence={"source": "caller", "reason": "non_sha_passthrough"},
+                            )
+                        )
+                if dropped_ambiguous or dropped_foreign:
+                    logger.warning(
+                        "Dropping %d ambiguous and %d foreign git-range commit(s); "
+                        "trajectory has file edits but no commit SHA: %s",
+                        len(dropped_ambiguous),
+                        len(dropped_foreign),
+                        (dropped_ambiguous + dropped_foreign)[:5],
+                    )
+                deliverables = list(dict.fromkeys(traj_deliverables + kept_caller))
         else:
             # Trajectory ran but found no deliverables.
             if traj_productive is False and trajectory_reliable:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -673,16 +673,7 @@ def post_session(
                         elif verdict == "explicitly_foreign":
                             dropped_foreign.append(item)
                         else:
-                            # Ambiguous SHA-like deliverables (e.g., PR URLs or non-commit IDs)
-                            # are kept as fallback since they're explicitly provided by caller
-                            kept_caller.append(item)
-                            extra_deliverable_details.extend(
-                                _build_caller_deliverable_details(
-                                    [item],
-                                    provenance_class="fallback_observed",
-                                    evidence={"source": "caller", "reason": "non_sha_passthrough"},
-                                )
-                            )
+                            dropped_ambiguous.append(item)
                     else:
                         kept_caller.append(item)
                         extra_deliverable_details.extend(
@@ -700,7 +691,7 @@ def post_session(
                         len(dropped_foreign),
                         (dropped_ambiguous + dropped_foreign)[:5],
                     )
-                deliverables = list(dict.fromkeys(kept_caller + traj_deliverables))
+                deliverables = list(dict.fromkeys(traj_deliverables + kept_caller))
         else:
             # Trajectory ran but found no deliverables.
             if traj_productive is False and trajectory_reliable:

--- a/packages/gptme-sessions/tests/test_deliverables.py
+++ b/packages/gptme-sessions/tests/test_deliverables.py
@@ -18,6 +18,14 @@ def test_classify_commit_ownership_trailer_match_is_owned():
     )
 
 
+def test_classify_commit_ownership_trailer_match_is_case_insensitive():
+    sha = "abc1234567890abcdef1234567890abcdef1234"
+    assert (
+        classify_commit_ownership(sha, session_id="Session-Mine", trailer_ids=["session-mine"])
+        == "session_trailer_owned"
+    )
+
+
 def test_classify_commit_ownership_other_trailer_is_foreign():
     sha = "abc1234567890abcdef1234567890abcdef1234"
     assert (

--- a/packages/gptme-sessions/tests/test_deliverables.py
+++ b/packages/gptme-sessions/tests/test_deliverables.py
@@ -1,4 +1,34 @@
-from gptme_sessions.deliverables import build_deliverable_detail, project_deliverable_details
+from gptme_sessions.deliverables import (
+    build_deliverable_detail,
+    classify_commit_ownership,
+    project_deliverable_details,
+)
+
+
+def test_classify_commit_ownership_trajectory_beats_missing_trailer():
+    sha = "abc1234567890abcdef1234567890abcdef1234"
+    assert classify_commit_ownership(sha, traj_sha_prefixes={"abc1234"}) == "trajectory_observed"
+
+
+def test_classify_commit_ownership_trailer_match_is_owned():
+    sha = "abc1234567890abcdef1234567890abcdef1234"
+    assert (
+        classify_commit_ownership(sha, session_id="73be", trailer_ids=["73be"])
+        == "session_trailer_owned"
+    )
+
+
+def test_classify_commit_ownership_other_trailer_is_foreign():
+    sha = "abc1234567890abcdef1234567890abcdef1234"
+    assert (
+        classify_commit_ownership(sha, session_id="73be", trailer_ids=["6869"])
+        == "explicitly_foreign"
+    )
+
+
+def test_classify_commit_ownership_untagged_is_ambiguous():
+    sha = "b59e7f7f48353205eb6adbde9f06094b9dbf9f35"
+    assert classify_commit_ownership(sha, session_id="73be") == "ambiguous"
 
 
 def test_build_deliverable_detail_allows_explicit_kind_override():

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -796,9 +796,9 @@ def test_post_session_file_only_trajectory_keeps_trailer_owned_sha(tmp_path: Pat
             commit_trailers={own_sha: ["session-mine"]},
         )
 
-    assert result.record.deliverables == [own_file, own_sha]
+    assert result.record.deliverables == [own_sha, own_file]
     assert sibling_sha not in result.record.deliverables
-    assert result.record.deliverable_details[-1]["provenance_class"] == "session_trailer_owned"
+    assert result.record.deliverable_details[0]["provenance_class"] == "session_trailer_owned"
 
 
 def test_post_session_73be_fixture_rejects_sibling_shas_and_keeps_files(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from gptme_sessions.deliverables import looks_like_sha
 from gptme_sessions.post_session import PostSessionResult, post_session
 from gptme_sessions.record import SessionRecord
 from gptme_sessions.store import SessionStore
@@ -705,6 +706,140 @@ def test_post_session_trajectory_commit_validation_keeps_non_sha_caller_delivera
             "evidence": {"source": "caller", "reason": "non_sha_passthrough"},
         },
     ]
+
+
+SESSION_73BE_SIBLING_SHAS = [
+    "b59e7f7f48353205eb6adbde9f06094b9dbf9f35",
+    "bd825297b9f934991db6a1010797748ce5761771",
+    "56e141c4ea533d96a1bc47d55a397091323c11aa",
+    "d25a6a15376a38b60a97af4b56318d424d76624f",
+    "d2c9af6be5ee79940876b4efcf4033250c7fe7ed",
+    "5a2abcb1bbe170422e80b51c2d9cb7573ea0c8c9",
+]
+
+
+def test_post_session_file_only_trajectory_drops_untagged_caller_shas(tmp_path: Path):
+    """File-only trajectory + untagged shared-range SHAs must not credit siblings.
+
+    Session 73be kept six untagged caller SHAs as fallback_observed with
+    reason=trajectory_has_no_sha. Those SHAs are ambiguous, not owned. The
+    session's own file edits stay visible.
+    """
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+    own_file = "/tmp/dashboard-smoke-73be.js"
+
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": True,
+        "deliverables": [own_file],
+        "deliverable_details": [
+            {
+                "value": own_file,
+                "kind": "file",
+                "provenance_class": "tool_authored",
+                "evidence": {"source": "trajectory", "tool_name": "save"},
+            }
+        ],
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="gptme",
+            model="gpt-5.5",
+            session_id="73be",
+            duration_seconds=3000,
+            exit_code=124,
+            trajectory_path=fake_traj,
+            deliverables=list(SESSION_73BE_SIBLING_SHAS),
+        )
+
+    assert result.record.deliverables == [own_file]
+    assert all(not looks_like_sha(d) for d in result.record.deliverables)
+    for sha in SESSION_73BE_SIBLING_SHAS:
+        assert sha not in result.record.deliverables
+    assert result.record.outcome == "productive"
+
+
+def test_post_session_file_only_trajectory_keeps_trailer_owned_sha(tmp_path: Path):
+    """A matching Git-Session-Id trailer still owns the commit (A3)."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+    own_file = "scripts/vitals-portal.py"
+    own_sha = "abc1234567890abcdef1234567890abcdef1234"
+    sibling_sha = "deadbeef01234567012345670123456701234567"
+
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": True,
+        "deliverables": [own_file],
+        "deliverable_details": [
+            {
+                "value": own_file,
+                "kind": "file",
+                "provenance_class": "tool_authored",
+                "evidence": {"source": "trajectory", "tool_name": "patch"},
+            }
+        ],
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="gptme",
+            model="sonnet",
+            session_id="session-mine",
+            duration_seconds=60,
+            trajectory_path=fake_traj,
+            deliverables=[own_sha, sibling_sha],
+            commit_trailers={own_sha: ["session-mine"]},
+        )
+
+    assert result.record.deliverables == [own_file, own_sha]
+    assert sibling_sha not in result.record.deliverables
+    assert result.record.deliverable_details[-1]["provenance_class"] == "session_trailer_owned"
+
+
+def test_post_session_73be_fixture_rejects_sibling_shas_and_keeps_files(tmp_path: Path):
+    """A5: the real 73be SHA list cannot be owned evidence."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+    files = [
+        "/home/bob/bob/packages/metaproductivity/src/metaproductivity/vitals/dashboard_routes.py",
+        "/tmp/dashboard-smoke-73be.js",
+    ]
+    fake_signals = {
+        "session_duration_s": 3000,
+        "productive": True,
+        "deliverables": files,
+        "deliverable_details": [
+            {
+                "value": path,
+                "kind": "file",
+                "provenance_class": "tool_authored",
+                "evidence": {"source": "trajectory", "tool_name": "save"},
+            }
+            for path in files
+        ],
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="gptme",
+            model="gpt-5.5",
+            session_id="73be",
+            duration_seconds=3009,
+            exit_code=124,
+            trajectory_path=fake_traj,
+            deliverables=list(SESSION_73BE_SIBLING_SHAS) + files,
+        )
+
+    assert result.record.deliverables == files
+    owned_text = " ".join(result.record.deliverables)
+    assert "1577" not in owned_text
+    assert all(sha not in result.record.deliverables for sha in SESSION_73BE_SIBLING_SHAS)
 
 
 def test_post_session_caller_only_deliverables_when_no_trajectory(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3173,7 +3173,12 @@ def test_post_session_partial_commit_pair_timeout_is_unknown(tmp_path: Path):
 
 
 def test_post_session_explicit_deliverables_merged_with_trajectory(tmp_path: Path):
-    """Explicit deliverables are merged with trajectory deliverables."""
+    """Explicit non-SHA deliverables are merged with trajectory deliverables.
+
+    Ambiguous SHAs (untagged, no trailer proof) from file-only trajectories are
+    dropped to avoid crediting sibling sessions. Non-SHA items are kept as
+    fallback_observed.
+    """
     import json as _json
 
     traj = tmp_path / "session.jsonl"
@@ -3204,15 +3209,16 @@ def test_post_session_explicit_deliverables_merged_with_trajectory(tmp_path: Pat
     traj.write_text("\n".join(_json.dumps(m) for m in msgs) + "\n")
 
     store = SessionStore(sessions_dir=tmp_path / "store")
-    explicit = ["abc123def456"]
+    # Non-SHA explicit deliverable (e.g., PR URL or file path)
+    explicit = ["https://github.com/gptme/gptme/pull/1234"]
     result = post_session(
         store=store,
         harness="claude-code",
         trajectory_path=traj,
         deliverables=explicit,
     )
-    # Shell-provided SHAs merged with trajectory file paths
-    assert result.record.deliverables == ["abc123def456", "/tmp/foo.py"]
+    # Non-SHA deliverables merged with trajectory file paths (trajectory items first)
+    assert result.record.deliverables == ["/tmp/foo.py", "https://github.com/gptme/gptme/pull/1234"]
 
 
 def test_post_session_empty_deliverables_uses_trajectory(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3217,8 +3217,8 @@ def test_post_session_explicit_deliverables_merged_with_trajectory(tmp_path: Pat
         trajectory_path=traj,
         deliverables=explicit,
     )
-    # Non-SHA deliverables merged with trajectory file paths (trajectory items first)
-    assert result.record.deliverables == ["/tmp/foo.py", "https://github.com/gptme/gptme/pull/1234"]
+    # Non-SHA caller items stay first (pre-PR contract); trajectory files follow.
+    assert result.record.deliverables == ["https://github.com/gptme/gptme/pull/1234", "/tmp/foo.py"]
 
 
 def test_post_session_empty_deliverables_uses_trajectory(tmp_path: Path):


### PR DESCRIPTION
## Summary

A bound trajectory that records file edits but no commit SHA used to keep every caller `start_commit..HEAD` SHA as `fallback_observed` (`reason=trajectory_has_no_sha`). That is how ErikBjare/bob session 73be credited six untagged sibling commits, a sibling PR, and another session's journal.

Untagged shared-range SHAs are now **ambiguous, not owned**. `classify_commit_ownership()` returns one of `trajectory_observed`, `session_trailer_owned`, `explicitly_foreign`, or `ambiguous`. File-only trajectories keep trajectory files and trailer-matched caller SHAs only.

## Test plan

- [x] `uv run --with pytest pytest tests/test_deliverables.py tests/test_post_session.py` in `packages/gptme-sessions` (52 passed, including the 73be SHA fixture)
- [x] ruff clean on the four touched files

## Notes

Bob-wrapper `COMMIT_COUNT` / judge / 73be correction land in ErikBjare/bob (`session-deliverable-fallback-cross-session-regression`). This PR is the gptme-sessions half.