### PR TITLE
fix(gptme-sessions): classify CC weekly-limit stream-json as rate_limit

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -15,7 +15,7 @@ FAILURE_REASON_RATE_LIMIT = "rate_limit"
 FAILURE_REASON_TIMEOUT = "timeout"
 
 _ERROR_LINE_RE = re.compile(
-    r"(?i)(error|exception|traceback|failed|rate.?limit|401|403|429|authentication)"
+    r"(?i)(error|exception|traceback|failed|rate.?limit|weekly.?limit|401|403|429|authentication)"
 )
 _ASSISTANT_ROLES = frozenset({"assistant"})
 
@@ -100,6 +100,36 @@ def _trajectory_has_assistant(trajectory_path: Path | None) -> bool:
     return False
 
 
+def _structured_error_signals(rec: dict) -> list[str]:
+    """Pull CC stream-json error fields that never appear in assistant text.
+
+    Claude Code weekly-limit deaths look like a synthetic assistant turn whose
+    visible copy is ``You've hit your weekly limit``. The actual classifier
+    signals live on sibling fields: ``type=rate_limit_event``,
+    ``error=rate_limit``, ``api_error_status=429``. Scanning only
+    ``message.content`` misses all three, so the session records as
+    ``nonzero_exit_unclassified``.
+    """
+    signals: list[str] = []
+    rec_type = rec.get("type")
+    if rec_type == "rate_limit_event":
+        info = rec.get("rate_limit_info")
+        info_dict = info if isinstance(info, dict) else {}
+        status = info_dict.get("status")
+        limit_type = info_dict.get("rateLimitType")
+        signals.append(f"rate_limit_event status={status} type={limit_type}")
+    err = rec.get("error")
+    if isinstance(err, str) and err.strip():
+        signals.append(err.strip())
+    status = rec.get("api_error_status")
+    if status is not None:
+        signals.append(f"api_error_status:{status}")
+    result = rec.get("result")
+    if rec.get("is_error") and isinstance(result, str) and result.strip():
+        signals.append(result.strip()[:500])
+    return signals
+
+
 def _extract_trajectory_error_line(trajectory_path: Path | None) -> str | None:
     if trajectory_path is None or not trajectory_path.is_file():
         return None
@@ -114,11 +144,11 @@ def _extract_trajectory_error_line(trajectory_path: Path | None) -> str | None:
                     rec = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                candidates: list[str] = list(_structured_error_signals(rec))
                 content = _record_content_text(rec)
-                if not content:
-                    continue
-                for part in content.splitlines():
-                    part = part.strip()
+                if content:
+                    candidates.extend(part.strip() for part in content.splitlines() if part.strip())
+                for part in candidates:
                     if part and _ERROR_LINE_RE.search(part):
                         last_match = part[:500]
     except OSError:
@@ -138,7 +168,7 @@ def classify_failure_reason(
         return FAILURE_REASON_TIMEOUT
     if error_text:
         lower = error_text.lower()
-        if ("rate" in lower and "limit" in lower) or "429" in error_text:
+        if ("rate" in lower and "limit" in lower) or "429" in error_text or "weekly limit" in lower:
             return FAILURE_REASON_RATE_LIMIT
         # Check invalid_request_error BEFORE auth: a 400 bad-request from a
         # provider (e.g. deepseek rejecting tool_calls format) is NOT an auth

--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -116,8 +116,11 @@ def _structured_error_signals(rec: dict) -> list[str]:
         info = rec.get("rate_limit_info")
         info_dict = info if isinstance(info, dict) else {}
         status = info_dict.get("status")
-        limit_type = info_dict.get("rateLimitType")
-        signals.append(f"rate_limit_event status={status} type={limit_type}")
+        # Informational "allowed" windows must not stamp a later unrelated
+        # nonzero exit as rate_limit (Greptile P1 on gptme-contrib#1582).
+        if status == "rejected":
+            limit_type = info_dict.get("rateLimitType")
+            signals.append(f"rate_limit_event status={status} type={limit_type}")
     err = rec.get("error")
     if isinstance(err, str) and err.strip():
         signals.append(err.strip())

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -340,3 +340,36 @@ def test_capture_cc_weekly_limit_stream_json(tmp_path: Path):
     assert reason == FAILURE_REASON_RATE_LIMIT
     assert err is not None
     assert "429" in err or "rate_limit" in err or "weekly limit" in err.lower()
+
+
+def test_capture_allowed_rate_limit_event_not_rate_limit(tmp_path: Path):
+    """An informational allowed rate_limit_event must not classify a later exit."""
+    traj = tmp_path / "conversation.jsonl"
+    records = [
+        {
+            "type": "rate_limit_event",
+            "rate_limit_info": {
+                "status": "allowed",
+                "rateLimitType": "five_hour",
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Sure, I can do that."}],
+            },
+        },
+    ]
+    traj.write_text(
+        "".join(json.dumps(rec) + "\n" for rec in records),
+        encoding="utf-8",
+    )
+    reason, _ = capture_session_failure(
+        exit_code=1,
+        duration_seconds=45,
+        input_tokens=0,
+        trajectory_path=traj,
+        harness_stderr_path=None,
+    )
+    assert reason == FAILURE_REASON_NONZERO

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -270,3 +270,73 @@ def test_capture_cc_session_with_assistant_not_pre_response(tmp_path: Path):
         harness_stderr_path=None,
     )
     assert reason == FAILURE_REASON_NONZERO
+
+
+def test_classify_cc_weekly_limit_copy():
+    """CC user-facing weekly-limit copy has 'limit' but not 'rate'."""
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=53,
+        input_tokens=0,
+        has_assistant_turn=True,
+        error_text="You've hit your weekly limit · resets Sep 1, 6pm (UTC)",
+    )
+    assert result == FAILURE_REASON_RATE_LIMIT
+
+
+def test_capture_cc_weekly_limit_stream_json(tmp_path: Path):
+    """CC seven_day weekly-limit stream-json must classify as rate_limit.
+
+    Live 2026-08-31 email-run storm (13/13 surviving logs): synthetic assistant
+    turn + rate_limit_event + api_error_status=429. Content-only extraction
+    previously returned nonzero_exit_unclassified because has_assistant_turn
+    blocked the pre_response fallback and the visible copy never said 'rate'.
+    """
+    traj = tmp_path / "conversation.jsonl"
+    records = [
+        {
+            "type": "rate_limit_event",
+            "rate_limit_info": {
+                "status": "rejected",
+                "rateLimitType": "seven_day",
+                "overageStatus": "rejected",
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "model": "<synthetic>",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "You've hit your weekly limit · resets Sep 1, 6pm (UTC)",
+                    }
+                ],
+            },
+            "error": "rate_limit",
+            "is_api_error_message": True,
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": True,
+            "api_error_status": 429,
+            "result": "You've hit your weekly limit · resets Sep 1, 6pm (UTC)",
+            "num_turns": 1,
+        },
+    ]
+    traj.write_text(
+        "".join(json.dumps(rec) + "\n" for rec in records),
+        encoding="utf-8",
+    )
+    reason, err = capture_session_failure(
+        exit_code=1,
+        duration_seconds=53,
+        input_tokens=0,
+        trajectory_path=traj,
+        harness_stderr_path=None,
+    )
+    assert reason == FAILURE_REASON_RATE_LIMIT
+    assert err is not None
+    assert "429" in err or "rate_limit" in err or "weekly limit" in err.lower()


### PR DESCRIPTION
## Summary

Claude Code seven-day weekly-limit deaths were recording as `failure_reason=nonzero_exit_unclassified`.

Live 2026-08-31 email-run storm (13/13 surviving `/tmp/cc-session-*.log` files): CC emits a synthetic assistant turn whose visible copy is `You've hit your weekly limit`, plus sibling fields `type=rate_limit_event`, `error=rate_limit`, and `api_error_status=429`. The extractor only scanned `message.content`, so `error_text` stayed empty. The synthetic assistant turn also blocked the `pre_response_api_failure` fallback (`has_assistant_turn=True`).

## Fix

- Read structured CC stream-json error fields (`rate_limit_event`, `error`, `api_error_status`, `is_error` result).
- Treat `weekly limit` copy as `rate_limit` (the user-facing string has `limit` but not `rate`).

Replay of the live `gpoSoS` shape now returns `failure_reason=rate_limit`.

Research: `knowledge/research/2026-09-01-email-run-unclassified-exits.md` (Bob workspace). Idea #1198.

## Test plan

- [x] `uv run pytest packages/gptme-sessions/tests/test_failure_capture.py` — 18 passed
- [x] Live `/tmp/cc-session-gpoSoS.log` and the 157s `pq59gu` log both classify as `rate_limit`
- [ ] CI `gptme-sessions` tests on this PR