### PR TITLE
fix(self-merge): policy-drop null scores are not abstentions

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -942,6 +942,12 @@ def fetch_greptile_status(
 # additive `submodule_only` bit is the pointer-bump signal; explicit false
 # means "reviewed, no in-scope score". Older markers omit the key and must
 # fail closed (the #850 shape).
+#
+# Policy-drop is not a merge credential. `ai_review_abstained` returning False
+# only lifts the abstention block; `evaluate_pr` still requires a parseable
+# current-head Greptile score at or above the floor. A Greptile presence-only
+# record (has_review, score unparseable) plus a policy-drop marker must not
+# self-merge — that combination used to be blocked by the abstention itself.
 AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
 AI_REVIEW_MARKER_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
 
@@ -1043,6 +1049,38 @@ def ai_review_abstained(
     # Markers written before score provenance was added are not abstentions:
     # the old reviewer had no explicit structured abstention state.
     return False
+
+
+def _is_policy_drop_null_marker(
+    marker: dict[str, Any] | None | _MarkerLookupFailed | _MarkerUnset,
+    *,
+    head_sha: str = "",
+) -> bool:
+    """True when the latest AI-review marker is an explicit policy-drop null.
+
+    ``score: null`` + ``submodule_only: false`` means the reviewer looked at
+    real source and dropped every in-scope finding — not an abstention, and
+    not a scored verdict. Callers that lift the abstention block on this
+    shape must still require independent scored evidence (a parseable
+    current-head Greptile score).
+
+    A marker written for an older head is ignored, matching
+    ``ai_review_abstained``: it is not a verdict on the current diff and
+    must not tighten the general score-floor fail-open.
+    """
+    if not isinstance(marker, dict):
+        return False
+    if not (
+        "score" in marker
+        and marker["score"] is None
+        and marker.get("submodule_only") is False
+    ):
+        return False
+    if head_sha:
+        marker_sha = str(marker.get("sha") or "")
+        if marker_sha and not _sha_matches_head(marker_sha, head_sha):
+            return False
+    return True
 
 
 # Known bot logins (exact match, case-insensitive) to exclude when counting
@@ -2685,8 +2723,12 @@ def evaluate_pr(
     # (default 5/5, override via SELF_MERGE_MIN_GREPTILE_SCORE). Without this, resolving
     # threads alone could let a low-score PR self-merge — the alice#61 (4/5) and #63 (3/5)
     # incidents where buggy control-path code shipped. Reuses the shared greptile-merge-signal
-    # evaluator (upstreamed from Bob). Parse failure (score None) does NOT block — the
-    # thread/category gates still apply; this only catches a clear sub-floor score.
+    # evaluator (upstreamed from Bob). Parse failure (score None) does NOT block in
+    # the general case — the thread/category gates still apply; this only catches
+    # a clear sub-floor score. Exception: a policy-drop AI marker (score null,
+    # submodule_only false) used to be blocked by the abstention itself. Lifting
+    # that block without a parseable Greptile score would self-merge on presence
+    # alone, so parse failure fails closed on that shape.
     if greptile["has_review"]:
         min_score = _parse_self_merge_min_greptile_score()
         score = greptile_summary_score(repo, number)
@@ -2706,6 +2748,13 @@ def evaluate_pr(
                     f"{reviewed[:12]}, head is {result.head_sha[:12]}) — "
                     "re-review of head required"
                 )
+        elif score is None and _is_policy_drop_null_marker(
+            shared_marker, head_sha=result.head_sha
+        ):
+            result.reasons.append(
+                "AI review is policy-drop (score null) and Greptile score is "
+                "unparseable — requiring a qualifying current-head Greptile score"
+            )
 
     # An explicit abstention blocks in its own right. If the structured review
     # state cannot be read, fail closed rather than silently removing the gate.

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -918,7 +918,7 @@ def fetch_greptile_status(
 # --- Our own AI reviewer's explicit abstention -------------------------------
 #
 # The self-hosted reviewer (ErikBjare/bob#1122) can decline to review at all.
-# Today that happens on submodule-pointer bumps, where the diff is a SHA and no
+# That happens on submodule-pointer bumps, where the diff is a SHA and no
 # source, so there is nothing in it to assess. It says so verbatim:
 #
 #     ℹ️ **Submodule pointer change only — not reviewed.**
@@ -934,8 +934,14 @@ def fetch_greptile_status(
 # staleness, consensus and identity requirements. Reaching this function's
 # `False` return means only "the reviewer did not decline"; it grants nothing.
 #
-# The reviewer encodes abstention as `score: null` in its structured marker.
-# Reading that field avoids coupling this safety gate to human-facing prose.
+# `score: null` is necessary but not sufficient. The reviewer also serialises
+# null when every in-scope finding was dropped by policy (out-of-scope /
+# informational-only) so that those reviews cannot mint a 5/5. That is still a
+# review of real source — treating it as "not reviewed" deadlocked contrib#1579
+# and #1580 (Greptile 5/5 at head, operator had to merge). The marker's
+# additive `submodule_only` bit is the pointer-bump signal; explicit false
+# means "reviewed, no in-scope score". Older markers omit the key and must
+# fail closed (the #850 shape).
 AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
 AI_REVIEW_MARKER_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
 
@@ -1022,6 +1028,13 @@ def ai_review_abstained(
     if "score" in marker:
         score = marker["score"]
         if score is None:
+            # Null score is an abstention only for a gitlink-only pointer bump
+            # (the #850 hole). Policy-drop reviews also serialise score as null
+            # so they cannot mint a 5/5, but they ARE reviews of real source.
+            # `submodule_only is False` is the new explicit "reviewed, no
+            # in-scope score". Omission (legacy markers) fails closed.
+            if marker.get("submodule_only") is False:
+                return False
             return True
         if isinstance(score, int) and not isinstance(score, bool) and 1 <= score <= 5:
             return False

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -219,8 +219,19 @@ def test_fetch_is_author_scoped_and_paginated() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _evaluate(*comment_bodies: str) -> Any:
-    """Run evaluate_pr on a PR that passes every other gate."""
+def _evaluate(
+    *comment_bodies: str,
+    greptile_score: int | None = None,
+    greptile_reviewed: str | None = None,
+    greptile_has_review: bool = True,
+) -> Any:
+    """Run evaluate_pr on a PR that passes every other gate.
+
+    ``greptile_score`` defaults to None (unparseable), which is the historical
+    fail-open for the score floor. Policy-drop markers must not inherit that
+    fail-open — tests that assert eligibility on a policy-drop body have to
+    pass a qualifying score explicitly.
+    """
     pr_data: dict[str, object] = {
         "number": 999,
         "author": {"login": "TimeToBuildBob"},
@@ -238,19 +249,31 @@ def _evaluate(*comment_bodies: str) -> Any:
         "mergeStateStatus": "CLEAN",
         "labels": [],
     }
+    greptile_status = (
+        {"has_review": True, "unresolved": 0, "total": 1}
+        if greptile_has_review
+        else {"has_review": False, "unresolved": 0, "total": 0}
+    )
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
         patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
         patch.object(self_merge_check, "merge_permission", return_value=True),
         patch.object(
-            self_merge_check, "_fetch_greptile_review_data", return_value=None
+            self_merge_check, "_fetch_greptile_review_data", return_value=([], [])
         ),
         patch.object(
             self_merge_check,
             "fetch_greptile_status",
-            return_value={"has_review": True, "unresolved": 0, "total": 1},
+            return_value=greptile_status,
         ),
-        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check, "greptile_summary_score", return_value=greptile_score
+        ),
+        patch.object(
+            self_merge_check,
+            "greptile_summary_reviewed_commit",
+            return_value=greptile_reviewed,
+        ),
         patch.object(
             self_merge_check,
             "fetch_unresolved_human_threads",
@@ -463,20 +486,74 @@ def test_legacy_null_score_without_submodule_key_still_abstains() -> None:
 
 def test_evaluate_pr_allows_informational_only_when_greptile_cleared_head() -> None:
     """The #1580 deadlock: Greptile 5/5, AI review posted, score null, source PR."""
-    result = _evaluate(INFORMATIONAL_ONLY_BODY)
+    result = _evaluate(
+        INFORMATIONAL_ONLY_BODY,
+        greptile_score=5,
+        greptile_reviewed="c096e25e50f8",
+    )
     assert not any(ABSTENTION_REASON in r for r in result.reasons)
     assert result.eligible
 
 
 def test_evaluate_pr_allows_degraded_zero_findings_when_greptile_cleared_head() -> None:
     """The #1579 deadlock: Greptile 5/5, native 0-findings review, 1/3 consensus."""
-    result = _evaluate(DEGRADED_CLEAN_BODY)
+    result = _evaluate(
+        DEGRADED_CLEAN_BODY,
+        greptile_score=5,
+        greptile_reviewed="c096e25e50f8",
+    )
     assert not any(ABSTENTION_REASON in r for r in result.reasons)
     assert result.eligible
 
 
 def test_evaluate_pr_still_blocks_explicit_submodule_abstention() -> None:
     """Greptile 5/5 must not rescue a gitlink-only unreviewed bump (#850)."""
-    result = _evaluate(SUBMODULE_ONLY_BODY)
+    result = _evaluate(
+        SUBMODULE_ONLY_BODY,
+        greptile_score=5,
+        greptile_reviewed="c096e25e50f8",
+    )
     assert not result.eligible
     assert ABSTENTION_REASON in result.reasons
+
+
+POLICY_DROP_UNPARSEABLE_REASON = (
+    "AI review is policy-drop (score null) and Greptile score is unparseable"
+)
+
+
+def test_evaluate_pr_blocks_policy_drop_when_greptile_score_unparseable() -> None:
+    """Presence-only Greptile plus a policy-drop marker is not scored evidence.
+
+    The score floor fails open on parse failure in the general case. That was
+    safe while a null-score marker still blocked as an abstention. Lifting the
+    abstention without a parseable Greptile score would self-merge with no
+    scored review of the current head.
+    """
+    result = _evaluate(INFORMATIONAL_ONLY_BODY)
+    assert not result.eligible
+    assert any(POLICY_DROP_UNPARSEABLE_REASON in r for r in result.reasons)
+    assert not any(ABSTENTION_REASON in r for r in result.reasons)
+
+
+def test_evaluate_pr_blocks_policy_drop_when_greptile_is_absent() -> None:
+    """A policy-drop null is not a Greptile substitute.
+
+    The positive AI-fallback path still refuses a null score. Without Greptile,
+    the PR has no scored review at all.
+    """
+    result = _evaluate(INFORMATIONAL_ONLY_BODY, greptile_has_review=False)
+    assert not result.eligible
+    assert not any(ABSTENTION_REASON in r for r in result.reasons)
+
+
+def test_stale_policy_drop_does_not_tighten_the_score_floor() -> None:
+    """A policy-drop written for an older head is not a verdict on this one.
+
+    The extra fail-closed (unparseable Greptile score) only applies to a
+    current-head marker. A stale one is ignored, same as a stale abstention.
+    """
+    stale = INFORMATIONAL_ONLY_BODY.replace("c096e25e50f8", "aaaaaaaaaaaa")
+    result = _evaluate(stale)
+    assert not any(POLICY_DROP_UNPARSEABLE_REASON in r for r in result.reasons)
+    assert result.eligible

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -392,3 +392,91 @@ def test_abstention_for_the_current_head_still_blocks() -> None:
             head_sha="c096e25e50f8aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
     assert current is True
+
+
+# ---------------------------------------------------------------------------
+# Policy-drop null scores are reviews, not abstentions (contrib#1579 / #1580)
+# ---------------------------------------------------------------------------
+
+# Explicit gitlink-only marker (the #850 shape, now labelled).
+SUBMODULE_ONLY_BODY = """## 🤖 AI code review
+
+### Confidence Score: N/A
+
+Not scored — this diff moves a submodule pointer and contains no source to
+assess. Treat it as *not reviewed*, not as approved.
+
+<!-- bob-ai-review {"sha": "c096e25e50f8", "score": null, "engine": "llm", "submodule_only": true, "history": []} -->
+"""
+
+# Out-of-scope P2s, empty in-scope findings, score null. Real source.
+INFORMATIONAL_ONLY_BODY = """## 🤖 AI code review
+
+### Confidence Score: N/A
+
+Not scored — every finding was dropped by policy.
+
+<!-- bob-ai-review {"sha": "c096e25e50f8", "score": null, "engine": "llm", "submodule_only": false, "history": []} -->
+"""
+
+# 0 in-scope findings, degraded consensus (1/3 passes). Still a review.
+DEGRADED_CLEAN_BODY = """## 🤖 AI code review
+
+### Confidence Score: 5/5 — No findings on this head
+
+<sub>ℹ️ Consensus was degraded on this run: 1 of 3 passes answered, so findings were filtered at 1-of-1 agreement rather than 2-of-3 — less filtered than usual.</sub>
+
+✅ **No findings.** The diff looks correct to me on this pass.
+
+<!-- bob-ai-review {"sha": "c096e25e50f8", "score": 5, "engine": "llm", "submodule_only": false, "consensus": {"requested": 3, "answered": 1, "jobs_requested": 9, "jobs_answered": 3, "min_agreement": 1, "min_agreement_requested": 2, "rejected": 0, "failures": []}, "history": []} -->
+"""
+
+
+def test_informational_only_null_score_is_not_an_abstention() -> None:
+    """contrib#1580: out-of-scope-only reviews serialise score null.
+
+    They cannot mint a 5/5, but they are reviews of real source. The gate must
+    not refuse them as "not reviewed" when Greptile has independently cleared
+    the head.
+    """
+    assert _abstained(INFORMATIONAL_ONLY_BODY) is False
+
+
+def test_degraded_consensus_zero_findings_is_not_an_abstention() -> None:
+    """contrib#1579: a posted 0-finding review at the head, 1/3 passes answered.
+
+    Degraded consensus is a recall warning on the *positive* AI-fallback path,
+    not an abstention. Greptile 5/5 at the same head still counts.
+    """
+    assert _abstained(DEGRADED_CLEAN_BODY) is False
+
+
+def test_explicit_submodule_only_null_score_is_still_an_abstention() -> None:
+    """The #850 hole stays closed when the marker names a pointer bump."""
+    assert _abstained(SUBMODULE_ONLY_BODY) is True
+
+
+def test_legacy_null_score_without_submodule_key_still_abstains() -> None:
+    """Older markers omit `submodule_only`. Omission must fail closed."""
+    assert _abstained(ABSTENTION_BODY) is True
+
+
+def test_evaluate_pr_allows_informational_only_when_greptile_cleared_head() -> None:
+    """The #1580 deadlock: Greptile 5/5, AI review posted, score null, source PR."""
+    result = _evaluate(INFORMATIONAL_ONLY_BODY)
+    assert not any(ABSTENTION_REASON in r for r in result.reasons)
+    assert result.eligible
+
+
+def test_evaluate_pr_allows_degraded_zero_findings_when_greptile_cleared_head() -> None:
+    """The #1579 deadlock: Greptile 5/5, native 0-findings review, 1/3 consensus."""
+    result = _evaluate(DEGRADED_CLEAN_BODY)
+    assert not any(ABSTENTION_REASON in r for r in result.reasons)
+    assert result.eligible
+
+
+def test_evaluate_pr_still_blocks_explicit_submodule_abstention() -> None:
+    """Greptile 5/5 must not rescue a gitlink-only unreviewed bump (#850)."""
+    result = _evaluate(SUBMODULE_ONLY_BODY)
+    assert not result.eligible
+    assert ABSTENTION_REASON in result.reasons


### PR DESCRIPTION
## Why

The self-merge gate treats `score: null` as an abstention. That was the right
fail-closed for gitlink-only pointer bumps (gptme-cloud#850). It is the wrong
signal for a review of *real source* whose in-scope findings were empty or
dropped by policy.

Live tonight:

- gptme/gptme-contrib#1579 — real source, native 0-findings review at head,
  degraded consensus (1/3). Gate: `AI review abstained — not reviewed`.
  Operator had to merge.
- gptme/gptme-contrib#1580 — real `gptme-sessions` source, Greptile 5/5 at
  head, 4 out-of-scope P2s, empty in-scope list. `confidence_score()` returns
  `None` when `informational and not findings`. Gate refused again.

The reviewer *must* still serialise those policy-drop reviews as `score: null`
so they cannot mint a 5/5. The gate must not then pretend nobody reviewed.

## What

`ai_review_abstained()` now reads the additive `submodule_only` marker bit:

- `submodule_only: true` + `score: null` → abstention (the #850 hole stays closed)
- `submodule_only: false` + `score: null` → not an abstention (reviewed, no in-scope score)
- key omitted (legacy markers) → fail closed

The AI-fallback *positive* path (`fetch_ai_review_status`) still refuses a
null score. Greptile 5/5 at the current head remains the score floor.

Companion change on the reviewer (ErikBjare/bob, this session):
`confidence_rationale` only prints the submodule-pointer sentence when the
diff actually is gitlink-only, and `build_marker_state` stamps `submodule_only`.

## Tests

- informational-only `score: null` is not an abstention
- degraded-consensus 0-findings `score: 5` is not an abstention
- explicit `submodule_only: true` still abstains, including when Greptile is 5/5
- legacy null markers without the key still fail closed
- `evaluate_pr` allows the two incident shapes when other gates pass

32 tests in `tests/test_self_merge_ai_review_abstention.py` pass.