### PR TITLE
feat(gptme-sessions): handle file:// URIs in Pi sessionDir paths

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -18,6 +18,7 @@ import os
 from datetime import date, datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from .pi import (
     PiSessionFormatError,
@@ -81,14 +82,24 @@ def _expand_pi_path(value: str) -> Path:
     Pi 0.84.4+ in ``sessionDir``), and plain filesystem paths.  Non-``file``
     URI schemes and malformed ``file://`` values (empty path component) fail
     closed with :exc:`ValueError`.
+
+    URI parsing runs only when the value is actually a URI (``file:`` prefix
+    or ``://``).  ``urlparse`` treats a Windows drive letter as a scheme
+    (``C:\\Users`` → scheme ``c``), so feeding every string through it would
+    reject ordinary Windows absolute paths.
     """
-    parsed = urlparse(value)
-    if parsed.scheme == "file":
-        if not parsed.path:
-            raise ValueError(f"Malformed file:// URI — no path component: {value!r}")
-        return Path(parsed.path)
-    if parsed.scheme and parsed.scheme not in ("", "~"):
-        raise ValueError(f"Unsupported URI scheme in Pi session dir: {parsed.scheme!r}")
+    # Gate on URI shape, not on urlparse().scheme — see docstring.
+    if value.startswith("file:") or "://" in value:
+        parsed = urlparse(value)
+        if parsed.scheme == "file":
+            # url2pathname unquotes percent-escapes and, on Windows, converts
+            # file:///C:/... to a drive-letter path.
+            path_str = url2pathname(parsed.path)
+            if not path_str:
+                raise ValueError(f"Malformed file:// URI — no path component: {value!r}")
+            return Path(path_str)
+        if parsed.scheme:
+            raise ValueError(f"Unsupported URI scheme in Pi session dir: {parsed.scheme!r}")
     # Plain path — preserve Pi's tilde expansion without Python's user lookup.
     if value == "~":
         return Path.home()

--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -17,6 +17,7 @@ import logging
 import os
 from datetime import date, datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .pi import (
     PiSessionFormatError,
@@ -74,7 +75,21 @@ def _get_copilot_state_dir() -> Path:
 
 
 def _expand_pi_path(value: str) -> Path:
-    """Expand Pi's supported ``~`` spellings without Python's user lookup."""
+    """Expand a Pi session directory string to a filesystem :class:`Path`.
+
+    Handles Pi's supported ``~`` spellings, ``file://`` URIs (as accepted by
+    Pi 0.84.4+ in ``sessionDir``), and plain filesystem paths.  Non-``file``
+    URI schemes and malformed ``file://`` values (empty path component) fail
+    closed with :exc:`ValueError`.
+    """
+    parsed = urlparse(value)
+    if parsed.scheme == "file":
+        if not parsed.path:
+            raise ValueError(f"Malformed file:// URI — no path component: {value!r}")
+        return Path(parsed.path)
+    if parsed.scheme and parsed.scheme not in ("", "~"):
+        raise ValueError(f"Unsupported URI scheme in Pi session dir: {parsed.scheme!r}")
+    # Plain path — preserve Pi's tilde expansion without Python's user lookup.
     if value == "~":
         return Path.home()
     if value.startswith("~/") or (os.name == "nt" and value.startswith("~\\")):

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from gptme_sessions.discovery import (
+    _expand_pi_path,
     _first_event_cwd,
     _quick_date_from_jsonl,
     _quick_datetime_from_jsonl,
@@ -1603,3 +1604,52 @@ class TestExtractProject:
             "pi-project",
         )
         assert extract_project("pi", session) == "/workspace/pi-project"
+
+
+# --- _expand_pi_path (file:// URI handling) ---
+
+
+def test_expand_pi_path_plain_path(tmp_path: Path) -> None:
+    """Plain paths pass through unchanged."""
+    assert _expand_pi_path(str(tmp_path)) == tmp_path
+
+
+def test_expand_pi_path_tilde_home() -> None:
+    """Tilde-only resolves to home directory."""
+    assert _expand_pi_path("~") == Path.home()
+
+
+def test_expand_pi_path_tilde_subdir() -> None:
+    """~/subdir resolves relative to home."""
+    assert _expand_pi_path("~/pi-sessions") == Path.home() / "pi-sessions"
+
+
+def test_expand_pi_path_file_uri_absolute(tmp_path: Path) -> None:
+    """file:///absolute/path resolves to the filesystem path."""
+    uri = f"file://{tmp_path}"
+    assert _expand_pi_path(uri) == tmp_path
+
+
+def test_expand_pi_path_file_uri_empty_path_fails_closed() -> None:
+    """Malformed file:// URI with no path component raises ValueError."""
+    with pytest.raises(ValueError, match="Malformed"):
+        _expand_pi_path("file://")
+
+
+def test_expand_pi_path_non_file_scheme_fails_closed() -> None:
+    """Non-file URI schemes (http, https, etc.) raise ValueError."""
+    with pytest.raises(ValueError, match="Unsupported"):
+        _expand_pi_path("http://example.com/sessions")
+
+
+def test_discover_pi_sessions_file_uri_session_dir_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PI_CODING_AGENT_SESSION_DIR=file:///... resolves and discovers sessions."""
+    session = _make_pi_session(tmp_path, "session.jsonl", "2026-03-05T10:00:00Z", "pi-uri")
+    monkeypatch.setenv("PI_CODING_AGENT_SESSION_DIR", f"file://{tmp_path}")
+    monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+
+    result = discover_pi_sessions(date(2026, 3, 5), date(2026, 3, 5))
+
+    assert result == [session.resolve()]

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -1630,6 +1630,21 @@ def test_expand_pi_path_file_uri_absolute(tmp_path: Path) -> None:
     assert _expand_pi_path(uri) == tmp_path
 
 
+def test_expand_pi_path_file_uri_percent_encoded() -> None:
+    """Percent-escaped file URI paths are decoded before use."""
+    assert _expand_pi_path("file:///tmp/my%20sessions") == Path("/tmp/my sessions")
+
+
+def test_expand_pi_path_windows_drive_letter_is_not_a_scheme() -> None:
+    """Windows absolute paths must not be rejected as URI schemes.
+
+    urlparse("C:\\\\Users\\\\me") reports scheme "c"; gating URI parsing on
+    "://" / "file:" keeps these as ordinary filesystem paths.
+    """
+    assert _expand_pi_path(r"C:\Users\me\sessions") == Path(r"C:\Users\me\sessions")
+    assert _expand_pi_path("C:/Users/me/sessions") == Path("C:/Users/me/sessions")
+
+
 def test_expand_pi_path_file_uri_empty_path_fails_closed() -> None:
     """Malformed file:// URI with no path component raises ValueError."""
     with pytest.raises(ValueError, match="Malformed"):


### PR DESCRIPTION
## Summary

Pi 0.84.4+ accepts `file://` URIs in `sessionDir` / `PI_CODING_AGENT_SESSION_DIR`. The existing `_expand_pi_path` only handled `~` spellings; this extends it to also resolve `file:///absolute/path` URIs correctly.

**Changes:**
- Extend `_expand_pi_path` in `discovery.py` to parse `file://` URIs via `urllib.parse.urlparse`
- Non-`file` URI schemes (http, https, etc.) fail closed with `ValueError`
- Malformed `file://` (empty path component) fails closed with `ValueError`
- Tilde handling is preserved unchanged

## Test plan

- [x] `test_expand_pi_path_plain_path` — plain paths pass through unchanged
- [x] `test_expand_pi_path_tilde_home` — `~` resolves to home
- [x] `test_expand_pi_path_tilde_subdir` — `~/subdir` resolves correctly
- [x] `test_expand_pi_path_file_uri_absolute` — `file:///path` resolves to filesystem path
- [x] `test_expand_pi_path_file_uri_empty_path_fails_closed` — raises `ValueError`
- [x] `test_expand_pi_path_non_file_scheme_fails_closed` — raises `ValueError`
- [x] `test_discover_pi_sessions_file_uri_session_dir_env` — end-to-end: `file://` env var discovers real sessions

Split from `gptme-sessions-pi-parser` task after gptme-contrib#1577.