### PR TITLE
fix(gptme-dashboard): use relative URLs for static data.json fetch and search links

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1806,7 +1806,7 @@ function closeSearch() {
   document.getElementById('search-result-count').textContent = '';
 }
 
-function safeUrl(u) { const s = String(u || ''); if (/^https?:\/\//i.test(s) || /^\/[^/]/.test(s)) return s; if (s && s[0] !== '/' && !/[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(s)) return s; return '#'; }
+function safeUrl(u) { const s = String(u || '').replace(/^[\u0000-\u0020]+/, ''); if (/^https?:\/\//i.test(s) || /^\/[^/]/.test(s)) return s; if (s && s[0] !== '/' && s[0] !== '\\' && !/[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(s)) return s; return '#'; }
 
 /** Build a flat search index from data.json for client-side search on static sites. */
 function _buildClientIndex(data) {

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1806,12 +1806,12 @@ function closeSearch() {
   document.getElementById('search-result-count').textContent = '';
 }
 
-function safeUrl(u) { const s = String(u || ''); if (/^https?:\/\//i.test(s) || /^\/[^/]/.test(s)) return s; if (s && !/[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(s)) return s; return '#'; }
+function safeUrl(u) { const s = String(u || ''); if (/^https?:\/\//i.test(s) || /^\/[^/]/.test(s)) return s; if (s && s[0] !== '/' && !/[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(s)) return s; return '#'; }
 
 /** Build a flat search index from data.json for client-side search on static sites. */
 function _buildClientIndex(data) {
   const items = [];
-  // Returns '/path' when page_url or path is present; null when both absent (avoids broken links)
+  // Returns a relative path when page_url or path is present; null when both absent (avoids broken links)
   const pageUrl = (x) => (x.page_url || x.path) ? (x.page_url || x.path) : null;
   const addItem = (type, title, category, source, keywords, excerpt, url) => {
     if (url) items.push({ type, title: title || '', category: category || '',

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1806,13 +1806,13 @@ function closeSearch() {
   document.getElementById('search-result-count').textContent = '';
 }
 
-function safeUrl(u) { const s = String(u || ''); return (/^https?:\/\//i.test(s) || /^\/[^/]/.test(s)) ? s : '#'; }
+function safeUrl(u) { const s = String(u || ''); if (/^https?:\/\//i.test(s) || /^\/[^/]/.test(s)) return s; if (s && !/[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(s)) return s; return '#'; }
 
 /** Build a flat search index from data.json for client-side search on static sites. */
 function _buildClientIndex(data) {
   const items = [];
   // Returns '/path' when page_url or path is present; null when both absent (avoids broken links)
-  const pageUrl = (x) => (x.page_url || x.path) ? '/' + (x.page_url || x.path) : null;
+  const pageUrl = (x) => (x.page_url || x.path) ? (x.page_url || x.path) : null;
   const addItem = (type, title, category, source, keywords, excerpt, url) => {
     if (url) items.push({ type, title: title || '', category: category || '',
       source: source || '', keywords: keywords || [], excerpt: excerpt || '', url });
@@ -1863,7 +1863,7 @@ function _clientSearch(q, typeFilter, limit) {
 async function _loadStaticSearchIndex() {
   if (_staticSearchIndex !== null) return;  // already loaded (or failed)
   try {
-    const resp = await fetch('/data.json');
+    const resp = await fetch('./data.json');
     if (!resp.ok) {
       console.warn('gptme-dashboard: /data.json fetch failed (' + resp.status + ') — static search unavailable');
       _staticSearchIndex = false;

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4271,6 +4271,8 @@ def test_static_safeurl_rejects_protocol_relative(workspace: Path, tmp_path: Pat
     Allowing ``lessons/foo`` is required for subpath deploys, but ``//evil.com``
     is a different origin (browsers resolve it against the current scheme).
     The relative branch must reject any string that starts with ``/``.
+    Leading C0/space is trimmed first so ``  //evil.com`` cannot skip that
+    check, and a leading backslash is rejected (``\\evil.com``).
     """
     import shutil
     import subprocess
@@ -4284,6 +4286,13 @@ def test_static_safeurl_rejects_protocol_relative(workspace: Path, tmp_path: Pat
         "safeUrl relative-path fallback must reject strings starting with '/' "
         "so protocol-relative '//host' cannot bypass the sanitizer"
     )
+    assert "\\u0000-\\u0020" in snippet, (
+        "safeUrl must trim leading C0 controls and space before the first-char "
+        "check so padded protocol-relative URLs cannot bypass it"
+    )
+    assert (
+        "s[0] !== '\\\\'" in snippet
+    ), "safeUrl relative-path fallback must reject a leading backslash"
 
     node = shutil.which("node")
     if node is None:
@@ -4296,6 +4305,9 @@ def test_static_safeurl_rejects_protocol_relative(workspace: Path, tmp_path: Pat
         "../x": "../x",
         "//evil.com": "#",
         "//evil.com/phish": "#",
+        "  //evil.com": "#",
+        "\\evil.com": "#",
+        "  lessons/foo": "lessons/foo",
         "javascript:alert(1)": "#",
         "data:text/html,x": "#",
         "": "#",

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4220,3 +4220,46 @@ def test_generate_json_has_page_field(workspace: Path):
         assert isinstance(
             plugin["has_page"], bool
         ), f"has_page must be a bool, got {type(plugin['has_page'])}"
+
+
+def test_static_data_json_fetch_is_relative(workspace: Path, tmp_path: Path):
+    """The data.json fetch in static mode must use a relative URL ('./data.json').
+
+    When the dashboard is deployed under a subpath (e.g. /dashboard/), an
+    absolute '/data.json' fetch hits the wrong path and returns 404 — breaking
+    static search entirely. The fetch must be page-relative so it resolves to
+    '/dashboard/data.json' when served under /dashboard/.
+    """
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    # Must use page-relative fetch, not root-absolute
+    assert "fetch('./data.json')" in html, (
+        "Static data.json fetch must use './data.json' (page-relative) not '/data.json' "
+        "to work when the dashboard is deployed under a subpath like /dashboard/"
+    )
+    assert (
+        "fetch('/data.json')" not in html
+    ), "Root-absolute '/data.json' fetch breaks when served under a subpath"
+
+
+def test_static_search_urls_are_relative(workspace: Path, tmp_path: Path):
+    """Search result URLs built by _buildClientIndex must be page-relative.
+
+    When the dashboard is at /dashboard/index.html, search result links like
+    '/lessons/…' navigate to the root instead of '/dashboard/lessons/…'.
+    The pageUrl() helper must return relative paths (no leading '/') so that
+    clicking a result navigates correctly within the deployed subpath.
+    """
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    # pageUrl must not prepend '/' — should be e.g. 'lessons/…', not '/lessons/…'
+    build_idx = html.index("_buildClientIndex")
+    page_url_idx = html.index("pageUrl", build_idx)
+    # The definition: look for the pattern with or without leading slash
+    snippet = html[page_url_idx : page_url_idx + 120]
+    assert "'/' +" not in snippet, (
+        "pageUrl() must not prepend '/' to page_url — it produces root-absolute URLs "
+        "that break navigation when the dashboard is served under a subpath"
+    )

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4263,3 +4263,56 @@ def test_static_search_urls_are_relative(workspace: Path, tmp_path: Path):
         "pageUrl() must not prepend '/' to page_url — it produces root-absolute URLs "
         "that break navigation when the dashboard is served under a subpath"
     )
+
+
+def test_static_safeurl_rejects_protocol_relative(workspace: Path, tmp_path: Path):
+    """safeUrl relative-path fallback must not admit protocol-relative URLs.
+
+    Allowing ``lessons/foo`` is required for subpath deploys, but ``//evil.com``
+    is a different origin (browsers resolve it against the current scheme).
+    The relative branch must reject any string that starts with ``/``.
+    """
+    import shutil
+    import subprocess
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    start = html.index("function safeUrl")
+    snippet = html[start : html.index("\n", start)]
+    assert "s[0] !== '/'" in snippet, (
+        "safeUrl relative-path fallback must reject strings starting with '/' "
+        "so protocol-relative '//host' cannot bypass the sanitizer"
+    )
+
+    node = shutil.which("node")
+    if node is None:
+        return
+    cases = {
+        "https://ok.example/a": "https://ok.example/a",
+        "/lessons/foo": "/lessons/foo",
+        "lessons/foo": "lessons/foo",
+        "./data.json": "./data.json",
+        "../x": "../x",
+        "//evil.com": "#",
+        "//evil.com/phish": "#",
+        "javascript:alert(1)": "#",
+        "data:text/html,x": "#",
+        "": "#",
+    }
+    script = (
+        snippet
+        + "\nconst cases = "
+        + json.dumps(cases)
+        + (
+            ";\nfor (const [input, expected] of Object.entries(cases)) {\n"
+            "  const got = safeUrl(input);\n"
+            "  if (got !== expected) {\n"
+            "    console.error(JSON.stringify({input, expected, got}));\n"
+            "    process.exit(1);\n"
+            "  }\n"
+            "}\n"
+        )
+    )
+    result = subprocess.run([node, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Problem

When the dashboard is deployed under a subpath (e.g. `/dashboard/`), two bugs break static search:

1. **`fetch('/data.json')` is root-absolute** — under `/dashboard/`, the browser fetches `/data.json` (root) which 404s. Data lives at `/dashboard/data.json`. Static search is completely broken.

2. **`pageUrl()` in `_buildClientIndex` prepends `'/'`** — search result URLs become root-absolute (`/lessons/…`), so clicking navigates away from `/dashboard/` to the root.

## Fix

- `fetch('./data.json')` — page-relative, resolves correctly under any deployment subpath
- `pageUrl`: drop the `'/' +` prefix, return bare relative paths (`tasks/…`, `lessons/…`)
- `safeUrl`: extend to accept relative paths in addition to `https?://` and `/…`

392 tests pass. Two regression tests added to prevent recurrence.

## Related

- Fixes the core static search breakage from task `gptme-dashboard-subpath-static-search-and-responsive-layout` (subtasks 1.2/1.3)
- Follow-on: payload bounding (1.5), responsive layout (1.4), broken nested link repair (1.6)