### PR TITLE
fix(gptme-sessions): extract stop_reason from CC trajectories

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1490,6 +1490,7 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
     sys_prompt_tokens: int | None = None
     context_peak_tokens: int | None = None
     result_usage: dict | None = None
+    stop_reason: str | None = None
 
     for record in msgs:
         rec_type = record.get("type")
@@ -1517,6 +1518,11 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
                 )
             if msg.get("model"):
                 model = msg["model"]
+            # Track final stop reason — updated on every assistant turn so the
+            # last assistant message's reason is the session's terminal signal.
+            _sr = msg.get("stop_reason")
+            if isinstance(_sr, str) and _sr:
+                stop_reason = _sr
 
         elif rec_type == "result":
             # Stream-json format: result record has correct cumulative totals.
@@ -1558,7 +1564,7 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
     total_tokens = input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens
     if total_tokens == 0 and model is None:
         return {}
-    return {
+    result: dict = {
         "model": model,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
@@ -1568,6 +1574,9 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
         "sys_prompt_tokens": sys_prompt_tokens,
         "context_peak_tokens": context_peak_tokens,
     }
+    if stop_reason is not None:
+        result["stop_reason"] = stop_reason
+    return result
 
 
 def extract_signals_codex(msgs: list[dict]) -> dict:

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -1825,6 +1825,56 @@ def test_extract_usage_cc_partial_result_falls_back_per_field():
     assert usage["cache_read_tokens"] == 300
 
 
+def test_extract_usage_cc_stop_reason_final_wins():
+    """stop_reason reflects the last assistant message's stop_reason."""
+    msgs = [
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "tool_use",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+    ]
+    usage = extract_usage_cc(msgs)
+    assert usage["stop_reason"] == "end_turn"
+
+
+def test_extract_usage_cc_stop_reason_absent_when_not_set():
+    """stop_reason is absent from returned dict when no assistant has one."""
+    msgs = [_make_cc_assistant_usage(10, 5)]
+    usage = extract_usage_cc(msgs)
+    assert "stop_reason" not in usage
+
+
+def test_extract_usage_cc_stop_sequence_captured():
+    """stop_sequence reason (e.g. from /end skill) is captured."""
+    msgs = [
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "stop_sequence",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+    ]
+    usage = extract_usage_cc(msgs)
+    assert usage["stop_reason"] == "stop_sequence"
+
+
 def test_detect_format_cc_with_preamble():
     """CC trajectories starting with non-standard record types are still detected correctly.
 


### PR DESCRIPTION
## Summary

- `extract_usage_cc` was silently dropping `message.stop_reason` from Claude Code trajectories despite it being present in every assistant record
- This left `stop_reason: null` across all 16k session records even though the field is wired in the schema and `post_session` logic
- Fix: track the last assistant message's stop_reason and include it in the returned usage dict (absent when not set — consistent with Pi extractor behaviour)

### Distribution across 100 recent CC trajectories
| stop_reason | count |
|---|---|
| `end_turn` | 54 |
| `stop_sequence` | 17 (e.g. from `/end` skill) |
| `tool_use` | 4 (session cut short before final text turn) |

## Test plan

- [x] `test_extract_usage_cc_stop_reason_final_wins` — last assistant reason wins over earlier turns
- [x] `test_extract_usage_cc_stop_reason_absent_when_not_set` — key absent when no assistant has stop_reason
- [x] `test_extract_usage_cc_stop_sequence_captured` — stop_sequence captured correctly
- [x] All 12 existing `extract_usage_cc` tests still pass