### PR TITLE
fix(gptme-sessions): persist Grok Build end-record stopReason

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -103,12 +103,15 @@ def _usage_backfill_fields(harness: str | None) -> tuple[str, ...]:
     Copilot trajectories never contain token-count fields — only byte metrics
     and model name are extractable. Pi uses ``trajectory_revision`` as its
     enrichment marker because several valid route/context fields can be absent;
-    missing-field checks would reparse unchanged history forever.
+    missing-field checks would reparse unchanged history forever. Grok Build
+    end records carry a terminal ``stopReason`` that older records omitted.
     """
     if harness == "copilot-cli":
         return _COPILOT_BACKFILL_FIELDS
     if harness == "pi":
         return ()
+    if harness == "grok-build":
+        return (*_DEFAULT_BACKFILL_FIELDS, "stop_reason")
     return _DEFAULT_BACKFILL_FIELDS
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2943,13 +2943,13 @@ def extract_usage_grok(msgs: list[dict]) -> dict:
 
     Reads from the final 'end' record which has cumulative session totals.
     Model name comes from the modelUsage dict (keyed by model id).
+    Terminal ``stopReason`` (e.g. ``end_turn``) is copied onto ``stop_reason``
+    so post_session / sync can persist the harness-native stop signal.
     """
     for record in reversed(msgs):
         if record.get("type") != "end":
             continue
         usage_data = record.get("usage") or {}
-        if not usage_data:
-            continue
         result: dict = {}
         input_tokens = usage_data.get("input_tokens")
         output_tokens = usage_data.get("output_tokens")
@@ -2965,7 +2965,11 @@ def extract_usage_grok(msgs: list[dict]) -> dict:
             model_name = next(iter(model_usage), None)
             if model_name:
                 result["model"] = model_name
-        return result
+        raw_stop = record.get("stopReason")
+        if isinstance(raw_stop, str) and raw_stop:
+            result["stop_reason"] = raw_stop
+        if result:
+            return result
     return {}
 
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1684,6 +1684,11 @@ class TestSyncRouteBackfill:
         assert "provider" not in gptme_fields
         assert "cost_usd" not in gptme_fields
         assert "token_count" in gptme_fields
+        assert "stop_reason" not in gptme_fields
+
+        grok_fields = _usage_backfill_fields("grok-build")
+        assert "stop_reason" in grok_fields
+        assert "token_count" in grok_fields
 
     def test_sync_signals_backfills_pi_route_metadata_for_existing_known_record(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -66,9 +66,12 @@ def _text(content: str = "Done.") -> dict:
 
 
 def _end_record(
-    input_tokens: int = 100, output_tokens: int = 50, model: str = "grok-4.5-build"
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    model: str = "grok-4.5-build",
+    stop_reason: str | None = "end_turn",
 ) -> dict:
-    return {
+    record = {
         "type": "end",
         "usage": {
             "input_tokens": input_tokens,
@@ -77,6 +80,9 @@ def _end_record(
         },
         "modelUsage": {model: {"input_tokens": input_tokens, "output_tokens": output_tokens}},
     }
+    if stop_reason is not None:
+        record["stopReason"] = stop_reason
+    return record
 
 
 # ─── _detect_format ──────────────────────────────────────────────────────────
@@ -289,6 +295,25 @@ def test_extract_usage_grok_reads_from_end_record():
     assert usage["input_tokens"] == 7170
     assert usage["output_tokens"] == 114
     assert usage["model"] == "grok-4.5-build"
+    assert usage["stop_reason"] == "end_turn"
+
+
+def test_extract_usage_grok_stop_reason_without_usage():
+    msgs = [
+        _available_commands(),
+        {"type": "end", "stopReason": "error"},
+    ]
+    usage = extract_usage_grok(msgs)
+    assert usage == {"stop_reason": "error"}
+
+
+def test_extract_usage_grok_omits_stop_reason_when_absent():
+    msgs = [
+        _available_commands(),
+        _end_record(stop_reason=None),
+    ]
+    usage = extract_usage_grok(msgs)
+    assert "stop_reason" not in usage
 
 
 def test_extract_usage_grok_empty_trajectory():


### PR DESCRIPTION
## Summary

- #1586 wired `stop_reason` for Claude Code, but 24h volume is dominated by Grok Build (~188/349 records) whose `end` records already carry `stopReason` (typically `end_turn`)
- `extract_usage_grok` read tokens/model from that `end` record and dropped the stop signal, so `stop_reason` stayed null on every grok-build session record
- Copy `stopReason` onto `usage.stop_reason` and include it in grok-build `sync --signals` backfill

## Test plan

- [x] `test_extract_usage_grok_reads_from_end_record` asserts `stop_reason == end_turn`
- [x] `test_extract_usage_grok_stop_reason_without_usage` — end record with only `stopReason`
- [x] `test_extract_usage_grok_omits_stop_reason_when_absent`
- [x] grok-build backfill fields include `stop_reason`
- [x] 34 `test_signals_grok` tests passed