### PR TITLE
feat(match-lessons): class-aware lesson dropout (Phase 1 differential epsilon)

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -1377,10 +1377,13 @@ def _get_dropout_epsilon_for_class(policy_class: str, global_epsilon: float) -> 
     """Return the effective dropout probability for a given policy class.
 
     - exempt: always 0.0 (never withheld, regardless of global_epsilon)
-    - validated_core: LESSON_DROPOUT_EPSILON_VALIDATED_CORE (default 0.05)
+    - validated_core: LESSON_DROPOUT_EPSILON_VALIDATED_CORE (default 0.05),
+      but only once the global switch (LESSON_DROPOUT_EPSILON) is > 0
     - holdout / unknown: global_epsilon (LESSON_DROPOUT_EPSILON)
     """
     if policy_class == "exempt":
+        return 0.0
+    if global_epsilon <= 0.0:
         return 0.0
     if policy_class == "validated_core":
         return _get_dropout_epsilon_validated_core()

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -1377,8 +1377,10 @@ def _get_dropout_epsilon_for_class(policy_class: str, global_epsilon: float) -> 
     """Return the effective dropout probability for a given policy class.
 
     - exempt: always 0.0 (never withheld, regardless of global_epsilon)
-    - validated_core: LESSON_DROPOUT_EPSILON_VALIDATED_CORE (default 0.05),
-      but only once the global switch (LESSON_DROPOUT_EPSILON) is > 0
+    - validated_core: min(global_epsilon, LESSON_DROPOUT_EPSILON_VALIDATED_CORE)
+      (default 0.05), but only once the global switch (LESSON_DROPOUT_EPSILON) is > 0.
+      Bounded by global_epsilon so the per-class differential can only reduce
+      dropout relative to the global setting, never exceed it.
     - holdout / unknown: global_epsilon (LESSON_DROPOUT_EPSILON)
     """
     if policy_class == "exempt":
@@ -1386,7 +1388,7 @@ def _get_dropout_epsilon_for_class(policy_class: str, global_epsilon: float) -> 
     if global_epsilon <= 0.0:
         return 0.0
     if policy_class == "validated_core":
-        return _get_dropout_epsilon_validated_core()
+        return min(global_epsilon, _get_dropout_epsilon_validated_core())
     return global_epsilon
 
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -1347,7 +1347,10 @@ def _get_dropout_epsilon() -> float:
         epsilon = float(raw)
     except ValueError:
         return 0.0
-    if math.isnan(epsilon) or epsilon <= 0.0:
+    # Treat non-finite values (inf, -inf, nan) as unset — matching
+    # _get_dropout_epsilon_validated_core's handling so that a mis-set env var
+    # (e.g. LESSON_DROPOUT_EPSILON=inf) does not silently enable 100% dropout.
+    if not math.isfinite(epsilon) or epsilon <= 0.0:
         return 0.0
     return min(epsilon, 1.0)
 
@@ -1452,6 +1455,14 @@ def _apply_lesson_dropout(
     if epsilon <= 0.0 or not lessons:
         return lessons
 
+    # When the manifest is unavailable (the "*" sentinel is active), classification
+    # is unreliable — lessons that would be "exempt" in a real manifest are
+    # indistinguishable from "holdout" and could be dropped. Skip dropout entirely
+    # to preserve the PR's guarantee that exempt lessons are never withheld.
+    manifest = _load_policy_manifest()
+    if "*" in manifest.get("holdout_population", []):
+        return lessons
+
     kept: list[dict] = []
     for lesson in lessons:
         policy_class, _ = _classify_lesson(lesson.get("path", ""))
@@ -1487,6 +1498,14 @@ def _apply_lesson_dropout_multi(
     # lesson-loo-analysis.py can distinguish treatment-group sessions
     # (epsilon>0, possibly 0 withheld) from control-group sessions (epsilon=0).
     if epsilon <= 0.0:
+        return matches, predicted
+
+    # When the manifest is unavailable (the "*" sentinel is active), classification
+    # is unreliable — lessons that would be "exempt" in a real manifest are
+    # indistinguishable from "holdout" and could be dropped. Skip dropout entirely
+    # to preserve the guarantee that exempt lessons are never withheld.
+    manifest = _load_policy_manifest()
+    if "*" in manifest.get("holdout_population", []):
         return matches, predicted
 
     withheld: list[dict] = []

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -1366,9 +1366,9 @@ def _get_dropout_epsilon_validated_core() -> float:
         epsilon = float(raw)
     except ValueError:
         return 0.05
-    # float("nan") succeeds; min/max retain NaN and later `eff_epsilon > 0`
-    # silently disables validated-core sampling. Treat non-finite as unset.
-    if math.isnan(epsilon):
+    # float() accepts NaN and infinities, but neither is a probability.
+    # Treat non-finite values as unset instead of clamping infinity to 1.0.
+    if not math.isfinite(epsilon):
         return 0.05
     return min(max(epsilon, 0.0), 1.0)
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -1347,7 +1347,7 @@ def _get_dropout_epsilon() -> float:
         epsilon = float(raw)
     except ValueError:
         return 0.0
-    if epsilon <= 0.0:
+    if math.isnan(epsilon) or epsilon <= 0.0:
         return 0.0
     return min(epsilon, 1.0)
 
@@ -1365,6 +1365,10 @@ def _get_dropout_epsilon_validated_core() -> float:
     try:
         epsilon = float(raw)
     except ValueError:
+        return 0.05
+    # float("nan") succeeds; min/max retain NaN and later `eff_epsilon > 0`
+    # silently disables validated-core sampling. Treat non-finite as unset.
+    if math.isnan(epsilon):
         return 0.05
     return min(max(epsilon, 0.0), 1.0)
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -1352,6 +1352,37 @@ def _get_dropout_epsilon() -> float:
     return min(epsilon, 1.0)
 
 
+def _get_dropout_epsilon_validated_core() -> float:
+    """Get dropout epsilon for validated_core lessons (default 0.05).
+
+    Only meaningful when global LESSON_DROPOUT_EPSILON > 0 (the global switch activates
+    the dropout system; this controls how aggressively validated_core lessons are sampled).
+    Override with LESSON_DROPOUT_EPSILON_VALIDATED_CORE env var.
+    """
+    raw = os.environ.get("LESSON_DROPOUT_EPSILON_VALIDATED_CORE")
+    if raw is None:
+        return 0.05
+    try:
+        epsilon = float(raw)
+    except ValueError:
+        return 0.05
+    return min(max(epsilon, 0.0), 1.0)
+
+
+def _get_dropout_epsilon_for_class(policy_class: str, global_epsilon: float) -> float:
+    """Return the effective dropout probability for a given policy class.
+
+    - exempt: always 0.0 (never withheld, regardless of global_epsilon)
+    - validated_core: LESSON_DROPOUT_EPSILON_VALIDATED_CORE (default 0.05)
+    - holdout / unknown: global_epsilon (LESSON_DROPOUT_EPSILON)
+    """
+    if policy_class == "exempt":
+        return 0.0
+    if policy_class == "validated_core":
+        return _get_dropout_epsilon_validated_core()
+    return global_epsilon
+
+
 def _get_dropout_log_dir(workspace: Path) -> Path:
     """Dropout log directory (LESSON_DROPOUT_LOG_DIR or workspace/state/lesson-dropout)."""
     raw = os.environ.get("LESSON_DROPOUT_LOG_DIR")
@@ -1402,6 +1433,9 @@ def _apply_lesson_dropout(
     """Randomly withhold lessons for causal leave-one-out analysis.
 
     Controlled by LESSON_DROPOUT_EPSILON (float [0,1]). Default 0 = no-op.
+    Uses class-aware epsilon: validated_core uses LESSON_DROPOUT_EPSILON_VALIDATED_CORE
+    (default 0.05), exempt is never withheld.
+
     Does NOT log — logging is done by _apply_lesson_dropout_multi which
     collects withheld lessons from both pools into one unified record.
     """
@@ -1411,9 +1445,10 @@ def _apply_lesson_dropout(
 
     kept: list[dict] = []
     for lesson in lessons:
-        if random.random() < epsilon:
-            # Withheld — skip
-            pass
+        policy_class, _ = _classify_lesson(lesson.get("path", ""))
+        eff_epsilon = _get_dropout_epsilon_for_class(policy_class, epsilon)
+        if eff_epsilon > 0.0 and random.random() < eff_epsilon:
+            pass  # Withheld — skip
         else:
             kept.append(lesson)
 
@@ -1426,11 +1461,16 @@ def _apply_lesson_dropout_multi(
     session_id: str,
     workspace: Path,
 ) -> tuple[list[dict], list[dict]]:
-    """Apply dropout to both matches and predicted, logging ONE unified record.
+    """Apply class-aware dropout to both matches and predicted, logging ONE unified record.
 
     Processes both pools together so that the analysis script receives a
     single JSONL record per hook invocation containing all withheld lessons,
     not two split records with partial withheld lists.
+
+    Class-aware epsilons (all require global LESSON_DROPOUT_EPSILON > 0 to activate):
+    - exempt: 0.0 (never withheld regardless of global epsilon)
+    - validated_core: LESSON_DROPOUT_EPSILON_VALIDATED_CORE (default 0.05)
+    - holdout / unknown: LESSON_DROPOUT_EPSILON (global epsilon)
     """
     epsilon = _get_dropout_epsilon()
 
@@ -1445,9 +1485,15 @@ def _apply_lesson_dropout_multi(
     def _do_dropout(lessons: list[dict]) -> list[dict]:
         kept: list[dict] = []
         for lesson in lessons:
-            if random.random() < epsilon:
+            policy_class, _ = _classify_lesson(lesson.get("path", ""))
+            eff_epsilon = _get_dropout_epsilon_for_class(policy_class, epsilon)
+            if eff_epsilon > 0.0 and random.random() < eff_epsilon:
                 withheld.append(
-                    {"path": lesson["path"], "title": lesson.get("title", "")}
+                    {
+                        "path": lesson["path"],
+                        "title": lesson.get("title", ""),
+                        "effective_epsilon": eff_epsilon,
+                    }
                 )
             else:
                 kept.append(lesson)

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1244,10 +1244,9 @@ def test_cc_dropout_epsilon_validated_core_env_override(hook, monkeypatch):
     assert hook._get_dropout_epsilon_validated_core() == 1.0
     monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "not-a-float")
     assert hook._get_dropout_epsilon_validated_core() == 0.05  # fallback to default
-    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "nan")
-    assert (
-        hook._get_dropout_epsilon_validated_core() == 0.05
-    )  # NaN is not a probability
+    for non_finite in ("nan", "inf", "-inf"):
+        monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", non_finite)
+        assert hook._get_dropout_epsilon_validated_core() == 0.05
 
 
 def test_cc_dropout_epsilon_for_class(hook, monkeypatch):

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1225,3 +1225,91 @@ def test_extract_frontmatter_regex_fallback_quoted_active_not_dropped(
     assert (
         hook.effective_status(fm2) == "active"
     ), "metadata.status: 'active' (single-quoted) must not be silently dropped"
+
+
+# --- Class-aware dropout: differential epsilon (Phase 1) ---
+
+
+def test_cc_dropout_epsilon_validated_core_default(hook, monkeypatch):
+    monkeypatch.delenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", raising=False)
+    assert hook._get_dropout_epsilon_validated_core() == 0.05
+
+
+def test_cc_dropout_epsilon_validated_core_env_override(hook, monkeypatch):
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "0.10")
+    assert hook._get_dropout_epsilon_validated_core() == 0.10
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "0.0")
+    assert hook._get_dropout_epsilon_validated_core() == 0.0
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "2.5")
+    assert hook._get_dropout_epsilon_validated_core() == 1.0
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "not-a-float")
+    assert hook._get_dropout_epsilon_validated_core() == 0.05  # fallback to default
+
+
+def test_cc_dropout_epsilon_for_class(hook, monkeypatch):
+    monkeypatch.delenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", raising=False)
+    # exempt is always 0
+    assert hook._get_dropout_epsilon_for_class("exempt", 0.20) == 0.0
+    assert hook._get_dropout_epsilon_for_class("exempt", 1.0) == 0.0
+    # validated_core uses lower env-controlled epsilon (default 0.05)
+    eff = hook._get_dropout_epsilon_for_class("validated_core", 0.20)
+    assert eff == 0.05
+    assert eff < 0.20
+    # holdout/unknown use global epsilon
+    assert hook._get_dropout_epsilon_for_class("holdout", 0.20) == 0.20
+    assert hook._get_dropout_epsilon_for_class("unknown", 0.15) == 0.15
+
+
+def test_cc_dropout_exempt_lesson_never_withheld(hook, monkeypatch, tmp_path):
+    """An exempt lesson must never be withheld even at epsilon=1.0 in the CC hook."""
+    import random as _random
+
+    log_dir = tmp_path / "drop"
+    exempt_path = "lessons/exempt/my-exempt-lesson.md"
+
+    # Inject a manifest that classifies this lesson as exempt (no root, uses lessons/ heuristic)
+    hook._policy_manifest_cache = {
+        "version": 1,
+        "validated_core": [],
+        "exempt": ["exempt/my-exempt-lesson"],
+        "holdout_population": [],
+    }
+    try:
+        monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "1.0")
+        monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+        monkeypatch.setenv("GPTME_SESSION_ID", "sess-cc-exempt")
+
+        _random.seed(42)
+        matches = [{"path": exempt_path, "title": "Exempt Lesson"}]
+        predicted: list = []
+        kept_m, kept_p = hook._apply_lesson_dropout_multi(
+            matches, predicted, "sess-cc-exempt", tmp_path
+        )
+        assert len(kept_m) == 1, "Exempt lesson was withheld — should be kept"
+        assert kept_m[0]["path"] == exempt_path
+    finally:
+        hook._policy_manifest_cache = None
+
+
+def test_cc_dropout_withheld_has_effective_epsilon(hook, monkeypatch, tmp_path):
+    """Withheld records in CC hook must include effective_epsilon."""
+    import json
+    import random as _random
+
+    log_dir = tmp_path / "drop"
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "1.0")
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("GPTME_SESSION_ID", "sess-cc-eff-eps")
+
+    _random.seed(0)
+    matches = [{"path": "lessons/holdout/my-lesson.md", "title": "Holdout"}]
+    hook._apply_lesson_dropout_multi(matches, [], "sess-cc-eff-eps", tmp_path)
+
+    log_file = log_dir / "sess-cc-eff-eps.jsonl"
+    records = [json.loads(line) for line in log_file.read_text().splitlines() if line]
+    assert records, "No log written"
+    withheld = records[0]["withheld"]
+    assert withheld, "No withheld lessons"
+    assert (
+        "effective_epsilon" in withheld[0]
+    ), "effective_epsilon missing from withheld record in CC hook"

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1264,6 +1264,20 @@ def test_cc_dropout_epsilon_for_class(hook, monkeypatch):
     assert hook._get_dropout_epsilon_for_class("unknown", 0.15) == 0.15
 
 
+def test_cc_dropout_epsilon_for_class_global_zero_disables_validated_core(
+    hook, monkeypatch
+):
+    """Global epsilon=0 (documented no-op default) must disable validated_core
+    dropout too, not just holdout/unknown — validated_core must not use its own
+    (nonzero-by-default) epsilon while the global switch is off."""
+    monkeypatch.delenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", raising=False)
+    assert hook._get_dropout_epsilon_for_class("validated_core", 0.0) == 0.0
+    assert hook._get_dropout_epsilon_for_class("holdout", 0.0) == 0.0
+    assert hook._get_dropout_epsilon_for_class("unknown", 0.0) == 0.0
+    # exempt stays 0 regardless
+    assert hook._get_dropout_epsilon_for_class("exempt", 0.0) == 0.0
+
+
 def test_cc_dropout_exempt_lesson_never_withheld(hook, monkeypatch, tmp_path):
     """An exempt lesson must never be withheld even at epsilon=1.0 in the CC hook."""
     import random as _random

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1278,6 +1278,21 @@ def test_cc_dropout_epsilon_for_class_global_zero_disables_validated_core(
     assert hook._get_dropout_epsilon_for_class("exempt", 0.0) == 0.0
 
 
+def test_cc_dropout_epsilon_for_class_validated_core_bounded_by_global(
+    hook, monkeypatch
+):
+    """validated_core epsilon must never exceed the global epsilon — otherwise
+    a small global dropout (meant to be gentle) would withhold the lessons the
+    feature is meant to preserve at a HIGHER rate than ordinary lessons."""
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "0.05")
+    # global epsilon (0.01) is smaller than the validated_core default (0.05):
+    # the effective rate must be clamped down to the global epsilon.
+    assert hook._get_dropout_epsilon_for_class("validated_core", 0.01) == 0.01
+    # global epsilon (0.20) is larger than validated_core (0.05): the smaller
+    # class-specific rate wins, as before.
+    assert hook._get_dropout_epsilon_for_class("validated_core", 0.20) == 0.05
+
+
 def test_cc_dropout_exempt_lesson_never_withheld(hook, monkeypatch, tmp_path):
     """An exempt lesson must never be withheld even at epsilon=1.0 in the CC hook."""
     import random as _random

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1244,6 +1244,10 @@ def test_cc_dropout_epsilon_validated_core_env_override(hook, monkeypatch):
     assert hook._get_dropout_epsilon_validated_core() == 1.0
     monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "not-a-float")
     assert hook._get_dropout_epsilon_validated_core() == 0.05  # fallback to default
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", "nan")
+    assert (
+        hook._get_dropout_epsilon_validated_core() == 0.05
+    )  # NaN is not a probability
 
 
 def test_cc_dropout_epsilon_for_class(hook, monkeypatch):

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1230,6 +1230,18 @@ def test_extract_frontmatter_regex_fallback_quoted_active_not_dropped(
 # --- Class-aware dropout: differential epsilon (Phase 1) ---
 
 
+def test_cc_dropout_epsilon_global_non_finite(hook, monkeypatch):
+    """Non-finite LESSON_DROPOUT_EPSILON (inf, -inf, nan) must return 0.0, matching
+    the validated_core helper's handling — prevents accidental 100% dropout from a
+    mis-set env var (e.g. LESSON_DROPOUT_EPSILON=inf)."""
+    for non_finite in ("nan", "inf", "-inf"):
+        monkeypatch.setenv("LESSON_DROPOUT_EPSILON", non_finite)
+        result = hook._get_dropout_epsilon()
+        assert (
+            result == 0.0
+        ), f"Expected 0.0 for LESSON_DROPOUT_EPSILON={non_finite!r}, got {result}"
+
+
 def test_cc_dropout_epsilon_validated_core_default(hook, monkeypatch):
     monkeypatch.delenv("LESSON_DROPOUT_EPSILON_VALIDATED_CORE", raising=False)
     assert hook._get_dropout_epsilon_validated_core() == 0.05
@@ -1324,10 +1336,12 @@ def test_cc_dropout_exempt_lesson_never_withheld(hook, monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize("failure", ["malformed", "unreadable"])
-def test_cc_dropout_unreadable_manifest_falls_back_to_global_epsilon(
+def test_cc_dropout_unavailable_manifest_skips_dropout(
     hook, monkeypatch, tmp_path, failure
 ):
-    """A broken policy manifest must not abort dropout or lesson delivery."""
+    """A broken policy manifest activates the '*' sentinel, which must skip dropout
+    entirely to preserve the exempt guarantee: when classification is unreliable,
+    no lesson is withheld — not even lessons that would otherwise be holdout."""
     manifest_file = tmp_path / "manifest.yaml"
     manifest_file.write_text("[" if failure == "malformed" else "{}", encoding="utf-8")
     hook._policy_manifest_cache = None
@@ -1349,7 +1363,8 @@ def test_cc_dropout_unreadable_manifest_falls_back_to_global_epsilon(
         matches, [], f"sess-cc-{failure}", tmp_path
     )
 
-    assert kept_m == []
+    # Both failure modes activate the "*" sentinel → dropout is skipped, all lessons kept.
+    assert kept_m == matches, "Lessons should be kept when manifest is unavailable"
     assert kept_p == []
 
 
@@ -1363,9 +1378,20 @@ def test_cc_dropout_withheld_has_effective_epsilon(hook, monkeypatch, tmp_path):
     monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(log_dir))
     monkeypatch.setenv("GPTME_SESSION_ID", "sess-cc-eff-eps")
 
+    # Provide a real manifest (no "*" sentinel) so dropout is not suppressed.
+    # Without a manifest, the sentinel path skips dropout to preserve exempt safety.
+    hook._policy_manifest_cache = {
+        "version": 1,
+        "validated_core": [],
+        "exempt": [],
+        "holdout_population": [],  # real manifest, no "*" sentinel
+    }
     _random.seed(0)
     matches = [{"path": "lessons/holdout/my-lesson.md", "title": "Holdout"}]
-    hook._apply_lesson_dropout_multi(matches, [], "sess-cc-eff-eps", tmp_path)
+    try:
+        hook._apply_lesson_dropout_multi(matches, [], "sess-cc-eff-eps", tmp_path)
+    finally:
+        hook._policy_manifest_cache = None
 
     log_file = log_dir / "sess-cc-eff-eps.jsonl"
     records = [json.loads(line) for line in log_file.read_text().splitlines() if line]

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1298,9 +1298,9 @@ def test_cc_dropout_exempt_lesson_never_withheld(hook, monkeypatch, tmp_path):
     import random as _random
 
     log_dir = tmp_path / "drop"
-    exempt_path = "lessons/exempt/my-exempt-lesson.md"
+    exempt_path = tmp_path / "lessons" / "exempt" / "my-exempt-lesson.md"
 
-    # Inject a manifest that classifies this lesson as exempt (no root, uses lessons/ heuristic)
+    # Inject a manifest and use the absolute paths produced by scan_lessons.
     hook._policy_manifest_cache = {
         "version": 1,
         "validated_core": [],
@@ -1313,15 +1313,45 @@ def test_cc_dropout_exempt_lesson_never_withheld(hook, monkeypatch, tmp_path):
         monkeypatch.setenv("GPTME_SESSION_ID", "sess-cc-exempt")
 
         _random.seed(42)
-        matches = [{"path": exempt_path, "title": "Exempt Lesson"}]
+        matches = [{"path": str(exempt_path), "title": "Exempt Lesson"}]
         predicted: list = []
         kept_m, kept_p = hook._apply_lesson_dropout_multi(
             matches, predicted, "sess-cc-exempt", tmp_path
         )
         assert len(kept_m) == 1, "Exempt lesson was withheld — should be kept"
-        assert kept_m[0]["path"] == exempt_path
+        assert kept_m[0]["path"] == str(exempt_path)
     finally:
         hook._policy_manifest_cache = None
+
+
+@pytest.mark.parametrize("failure", ["malformed", "unreadable"])
+def test_cc_dropout_unreadable_manifest_falls_back_to_global_epsilon(
+    hook, monkeypatch, tmp_path, failure
+):
+    """A broken policy manifest must not abort dropout or lesson delivery."""
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text("[" if failure == "malformed" else "{}", encoding="utf-8")
+    hook._policy_manifest_cache = None
+    monkeypatch.setattr(hook, "_policy_manifest_path", lambda: manifest_file)
+    if failure == "unreadable":
+        real_open = open
+
+        def unreadable_manifest(path, *args, **kwargs):
+            if path == manifest_file:
+                raise PermissionError("manifest is unreadable")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", unreadable_manifest)
+    monkeypatch.setenv("LESSON_DROPOUT_EPSILON", "1.0")
+    monkeypatch.setenv("LESSON_DROPOUT_LOG_DIR", str(tmp_path / "drop"))
+
+    matches = [{"path": str(tmp_path / "lessons" / "broken.md"), "title": "Broken"}]
+    kept_m, kept_p = hook._apply_lesson_dropout_multi(
+        matches, [], f"sess-cc-{failure}", tmp_path
+    )
+
+    assert kept_m == []
+    assert kept_p == []
 
 
 def test_cc_dropout_withheld_has_effective_epsilon(hook, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Adds per-policy-class epsilon control to the CC hook lesson dropout system for causal LOO analysis
- `exempt` lessons: never withheld (epsilon 0.0)
- `validated_core` lessons: `LESSON_DROPOUT_EPSILON_VALIDATED_CORE` env var (default 0.05)
- `holdout` / `unknown` lessons: global `LESSON_DROPOUT_EPSILON`
- Withheld records now include `effective_epsilon` for per-class analysis downstream

Two new helpers (`_get_dropout_epsilon_validated_core`, `_get_dropout_epsilon_for_class`) dispatched from both `_apply_lesson_dropout` and `_apply_lesson_dropout_multi`. The change is backward-compatible: with default env (`LESSON_DROPOUT_EPSILON=0`), dropout remains off for all classes.

## Test plan

- [x] 5 new tests in `test_cc_match_lessons.py` covering: default/override validated_core epsilon, class dispatch table, exempt-never-withheld, and `effective_epsilon` in withheld records
- [x] All 83 existing CC hook tests pass
- [x] Mirrors changes already applied to `gptme/lessons/auto_include.py` + 17 passing tests there