### PR TITLE
fix(gptme-sessions): stamp trajectory_revision for all harnesses

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -35,7 +35,13 @@ from .replay import (
     resolve_replay_target,
     resolve_session_record_prefix,
 )
-from .record import ANNOTATABLE_FIELDS, ATTEMPT_KINDS, SessionRecord, normalize_run_type
+from .record import (
+    ANNOTATABLE_FIELDS,
+    ATTEMPT_KINDS,
+    SessionRecord,
+    normalize_run_type,
+    trajectory_revision_for,
+)
 from .pi import PI_EXTRACTION_SCHEMA_VERSION, PiSessionFormatError
 from .signals import extract_from_path
 from .store import (
@@ -469,12 +475,8 @@ def _normalize_session_path(path: str | Path) -> str:
 
 
 def _trajectory_revision(path: Path) -> str | None:
-    """Return a cheap revision for append-only trajectory change detection."""
-    try:
-        stat = path.stat()
-    except OSError:
-        return None
-    return f"{stat.st_dev}:{stat.st_ino}:{stat.st_size}:{stat.st_mtime_ns}"
+    """Compatibility alias for :func:`trajectory_revision_for`."""
+    return trajectory_revision_for(path)
 
 
 def _existing_session_paths(records: list[SessionRecord]) -> set[str]:
@@ -2408,6 +2410,18 @@ def sync(
                 for field in _usage_backfill_fields(existing.harness)
             )
             source_revision = _trajectory_revision(traj_path) if traj_path.is_file() else None
+            # Cheap backfill for non-Pi harnesses: stamp revision once the
+            # source file is still readable. Does not re-extract. Pi keeps
+            # revision as an extract-success marker so a failed extract can
+            # retry instead of looking "up to date".
+            if (
+                existing.harness != "pi"
+                and source_revision is not None
+                and existing.trajectory_revision is None
+                and "trajectory_revision" not in existing.annotated_fields
+            ):
+                existing.trajectory_revision = source_revision
+                needs_update = True
             pi_source_changed = (
                 existing.harness == "pi"
                 and source_revision is not None
@@ -2507,8 +2521,9 @@ def sync(
                 source_revision = _trajectory_revision(traj_path)
                 result = extract_from_path(traj_path)
                 _apply_extract_result_to_kwargs(record_kwargs, result)
-                if entry["harness"] == "pi":
+                if source_revision is not None:
                     record_kwargs["trajectory_revision"] = source_revision
+                if entry["harness"] == "pi":
                     record_kwargs["trajectory_extract_version"] = PI_EXTRACTION_SCHEMA_VERSION
             except Exception as exc:
                 signal_failures += 1

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -38,7 +38,7 @@ from .deliverables import (
 from .discovery import extract_project, extract_session_name
 from .failure_capture import capture_session_failure
 from .lesson_events import load_lesson_events
-from .record import SessionRecord
+from .record import SessionRecord, trajectory_revision_for
 from .signals import extract_from_path
 from .smell import compute_smell_score
 from .store import SessionStore
@@ -461,12 +461,16 @@ def post_session(
     ttft_ms_p50: float | None = None
     gen_ms_total: float | None = None
     tool_ms_total: float | None = None
+    trajectory_revision: str | None = None
 
     # --- Extract signals from trajectory ---
     if trajectory_path is not None and trajectory_path.is_file():
         try:
             result = extract_from_path(trajectory_path)
             signals = result
+            # Stamp after a successful extract so later syncs can skip
+            # unchanged files. Same contract as gptme-sessions sync.
+            trajectory_revision = trajectory_revision_for(trajectory_path)
             grade = result.get("grade")
             traj_productive = result.get("productive")
             usage = result.get("usage")
@@ -897,6 +901,8 @@ def post_session(
         project = extract_project(harness, trajectory_path)
         if project:
             record_kwargs["project"] = project
+    if trajectory_revision is not None:
+        record_kwargs["trajectory_revision"] = trajectory_revision
     # Fallback: if caller didn't provide journal_path, use the first
     # journal path extracted from the trajectory signals.
     if journal_path is None and signals:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -58,6 +58,20 @@ ANNOTATABLE_FIELDS: frozenset[str] = frozenset(
     ]
 )
 
+
+def trajectory_revision_for(path: Path) -> str | None:
+    """Return a cheap revision for append-only trajectory change detection.
+
+    Encodes device, inode, size, and mtime so an append or rewrite is visible
+    without hashing file contents. ``None`` if ``path`` cannot be stat'd.
+    """
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return f"{stat.st_dev}:{stat.st_ino}:{stat.st_size}:{stat.st_mtime_ns}"
+
+
 # Normalize model names to short canonical forms
 MODEL_ALIASES: dict[str, str] = {
     # Anthropic Claude models (bare) — dash and dot variants
@@ -346,10 +360,13 @@ class SessionRecord:
     # this may be nominal API-equivalent cost, not incremental billed spend.
     cost_usd: float | None = None
 
-    # Cheap source revision captured after a successful trajectory extraction.
-    # Pi sessions are append-only and resumable, so sync uses this to refresh
+    # Cheap source revision captured after a successful trajectory extraction
+    # (``dev:ino:size:mtime_ns`` from :func:`trajectory_revision_for`). Pi
+    # sessions are append-only and resumable, so sync uses this to refresh
     # cumulative signals when the native JSONL grows without reparsing
-    # unchanged historical sessions on every run.
+    # unchanged historical sessions on every run. Other harnesses persist it
+    # too so later syncs can skip unchanged files and coverage can see the
+    # field.
     trajectory_revision: str | None = None
     trajectory_extract_version: int | None = None
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1760,3 +1760,65 @@ class TestSyncRouteBackfill:
         assert records[0].model == "grok-4.6"
         assert records[0].cost_usd == 0.0
         assert records[0].stop_reason == "stop"
+
+    def test_sync_backfills_missing_trajectory_revision_without_reextract(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Existing non-Pi records missing revision get a cheap stat stamp."""
+        import sys
+
+        from gptme_sessions.cli import main
+        from gptme_sessions.record import trajectory_revision_for
+
+        fake_file = tmp_path / "session.jsonl"
+        fake_file.write_text("{}\n")
+
+        monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [])
+        monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+        monkeypatch.setattr(
+            "gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [fake_file]
+        )
+        monkeypatch.setattr("gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [])
+        monkeypatch.setattr("gptme_sessions.cli.discover_pi_sessions", lambda *a, **kw: [])
+
+        def _fail_extract(path: Path) -> dict:
+            raise AssertionError(f"revision backfill must not re-extract {path}")
+
+        monkeypatch.setattr("gptme_sessions.cli.extract_from_path", _fail_extract)
+
+        sessions_dir = tmp_path / "sessions"
+        store = SessionStore(sessions_dir=sessions_dir)
+        store.append(
+            SessionRecord(
+                harness="codex",
+                trajectory_path=str(fake_file),
+                outcome="productive",
+                duration_seconds=90,
+                token_count=1200,
+                input_tokens=800,
+                output_tokens=400,
+                cache_creation_tokens=10,
+                cache_read_tokens=20,
+                sys_prompt_tokens=100,
+                context_peak_tokens=900,
+                context_window=128000,
+                sys_prompt_bytes=400,
+                first_turn_bytes=800,
+                context_peak_bytes=800,
+                session_total_bytes=1600,
+            )
+        )
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["gptme-sessions", "--sessions-dir", str(sessions_dir), "sync", "--signals"],
+        )
+        rc = main()
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "updated 1" in captured.out
+
+        records = store.load_all()
+        assert len(records) == 1
+        assert records[0].trajectory_revision == trajectory_revision_for(fake_file)

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -8,7 +8,7 @@ import pytest
 
 from gptme_sessions.deliverables import looks_like_sha
 from gptme_sessions.post_session import PostSessionResult, post_session
-from gptme_sessions.record import SessionRecord
+from gptme_sessions.record import SessionRecord, trajectory_revision_for
 from gptme_sessions.store import SessionStore
 
 # gptme_sessions/__init__.py re-exports 'post_session' (function), shadowing the
@@ -160,6 +160,43 @@ def test_post_session_backfills_session_name_and_project_from_trajectory(tmp_pat
 
     assert result.record.session_name == "12345678"
     assert result.record.project == "/home/bob/bob"
+    assert result.record.trajectory_revision == trajectory_revision_for(fake_traj)
+
+
+def test_post_session_stamps_trajectory_revision_after_extract(tmp_path: Path):
+    """Successful extract persists a cheap source revision for any harness."""
+    store = SessionStore(sessions_dir=tmp_path)
+    trajectory = tmp_path / "trajectory.jsonl"
+    trajectory.write_text("{}\n")
+
+    with patch.object(
+        _post_session_mod,
+        "extract_from_path",
+        return_value={"productive": True, "usage": {"model": "grok-4.6"}},
+    ):
+        result = post_session(
+            store=store,
+            harness="grok-build",
+            model="grok-4.6",
+            duration_seconds=30,
+            trajectory_path=trajectory,
+        )
+
+    assert result.record.trajectory_revision == trajectory_revision_for(trajectory)
+    persisted = SessionStore(sessions_dir=tmp_path).load_all()
+    assert persisted[0].trajectory_revision == result.record.trajectory_revision
+
+
+def test_post_session_omits_trajectory_revision_without_trajectory(tmp_path: Path):
+    """No trajectory means no revision stamp."""
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        duration_seconds=30,
+    )
+    assert result.record.trajectory_revision is None
 
 
 def test_post_session_ab_group_invalid(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -7,7 +7,23 @@ from pathlib import Path
 
 import pytest
 
-from gptme_sessions.record import HARM_CATEGORY_LABELS, SessionRecord, normalize_model
+from gptme_sessions.record import (
+    HARM_CATEGORY_LABELS,
+    SessionRecord,
+    normalize_model,
+    trajectory_revision_for,
+)
+
+
+def test_trajectory_revision_for_encodes_stat_identity(tmp_path: Path) -> None:
+    """Revision encodes device/inode/size/mtime and is None for missing paths."""
+    path = tmp_path / "session.jsonl"
+    path.write_text("{}\n")
+    revision = trajectory_revision_for(path)
+    assert revision is not None
+    stat = path.stat()
+    assert revision == f"{stat.st_dev}:{stat.st_ino}:{stat.st_size}:{stat.st_mtime_ns}"
+    assert trajectory_revision_for(tmp_path / "missing.jsonl") is None
 
 
 def test_context_tier_default():

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -6289,7 +6289,19 @@ def test_sync_deduplicates_on_rerun(tmp_path: Path, capsys, monkeypatch):
     )
     main()
 
-    # Second sync — should skip the already-imported session
+    # Second sync — the first sync's record has no trajectory_revision yet
+    # (no --signals was passed), so this run backfills it once. That backfill
+    # counts as an update, not a no-op skip.
+    monkeypatch.setattr(
+        sys, "argv", ["gptme-sessions", "--sessions-dir", str(sessions_dir), "sync"]
+    )
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "updated 1" in captured.out
+
+    # Third sync — trajectory_revision is now stamped and the file is
+    # unchanged, so this run should skip the already-imported session.
     monkeypatch.setattr(
         sys, "argv", ["gptme-sessions", "--sessions-dir", str(sessions_dir), "sync"]
     )


### PR DESCRIPTION
## Why

`session-record-field-coverage.py` flagged `zero:trajectory_revision` (0/16k records). The field existed on `SessionRecord` and `sync` already computed the cheap `dev:ino:size:mtime` identity, but only Pi records persisted it. `post_session` never wrote it at all, so autonomous sessions (including the one Pi session that went through `post_session`) stayed at zero forever.

## What

- Lift `_trajectory_revision` to public `trajectory_revision_for()` on `record.py`.
- `post_session` stamps `trajectory_revision` after a successful extract, for every harness.
- `sync --signals` persists the revision on new imports for every harness, not just Pi.
- Existing **non-Pi** records with a surviving trajectory get a cheap stat-only backfill (no re-extract).
- Pi keeps revision as an extract-success marker so a failed extract can retry instead of looking up to date.

## Tests

- `test_trajectory_revision_for_encodes_stat_identity`
- `test_post_session_stamps_trajectory_revision_after_extract`
- `test_post_session_omits_trajectory_revision_without_trajectory`
- `test_sync_backfills_missing_trajectory_revision_without_reextract`
- Existing Pi revision/retry tests still pass (293 tests in post_session/cli/cli_pi/record).

## Follow-up

Do not bump the bob submodule until this merges. A local backfill of surviving 24h trajectories will clear the live coverage flag in this session.