### PR TITLE
fix(self-merge): don't treat policy-drop null score as abstention

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1022,7 +1022,17 @@ def ai_review_abstained(
     if "score" in marker:
         score = marker["score"]
         if score is None:
-            return True
+            # ``submodule_only: true`` (or omitted — fail-closed for
+            # gptme-cloud#850) means the reviewer had no source to assess
+            # and the PR is "not reviewed". Block.
+            #
+            # ``submodule_only: false`` means the reviewer assessed real
+            # source but all findings were out-of-scope (policy-drop).
+            # That is a review, not an abstention. Do not block — Greptile
+            # and CI are the independent quality gates for this case.
+            if marker.get("submodule_only", True):
+                return True
+            return False
         if isinstance(score, int) and not isinstance(score, bool) and 1 <= score <= 5:
             return False
         return None

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1030,9 +1030,13 @@ def ai_review_abstained(
             # source but all findings were out-of-scope (policy-drop).
             # That is a review, not an abstention. Do not block — Greptile
             # and CI are the independent quality gates for this case.
-            if marker.get("submodule_only", True):
-                return True
-            return False
+            #
+            # Strict identity: only an explicit boolean False bypasses.
+            # A present-but-null value (or any non-boolean) must not fail
+            # open — ``dict.get``'s default applies only to a missing key.
+            if marker.get("submodule_only") is False:
+                return False
+            return True
         if isinstance(score, int) and not isinstance(score, bool) and 1 <= score <= 5:
             return False
         return None

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -392,3 +392,48 @@ def test_abstention_for_the_current_head_still_blocks() -> None:
             head_sha="c096e25e50f8aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
     assert current is True
+
+
+# ---------------------------------------------------------------------------
+# Policy-drop null scores are reviews, not abstentions
+# ---------------------------------------------------------------------------
+
+
+def _marker_body(*, submodule_only: object) -> str:
+    """Build a null-score marker with an explicit submodule_only payload."""
+    payload = json.dumps(
+        {
+            "sha": "c096e25e50f8",
+            "score": None,
+            "engine": "llm",
+            "submodule_only": submodule_only,
+            "history": [],
+        }
+    )
+    return f"## 🤖 AI code review\n\n<!-- bob-ai-review {payload} -->\n"
+
+
+def test_policy_drop_explicit_false_is_not_an_abstention() -> None:
+    """Reviewer assessed real source; all findings were out-of-scope."""
+    assert _abstained(_marker_body(submodule_only=False)) is False
+
+
+def test_explicit_submodule_only_true_is_still_an_abstention() -> None:
+    """The #850 hole stays closed when the marker names a pointer bump."""
+    assert _abstained(_marker_body(submodule_only=True)) is True
+
+
+def test_present_but_null_submodule_only_fails_closed() -> None:
+    """A malformed marker with submodule_only: null must still block.
+
+    dict.get's default applies only for a missing key. A present null is
+    falsy, so a truthiness check would treat it as policy-drop and fail
+    open. Only an explicit boolean False may bypass the abstention veto.
+    """
+    assert _abstained(_marker_body(submodule_only=None)) is True
+
+
+@pytest.mark.parametrize("value", [0, "", "false", "False"])
+def test_non_boolean_submodule_only_fails_closed(value: object) -> None:
+    """Anything other than boolean False is not a policy-drop signal."""
+    assert _abstained(_marker_body(submodule_only=value)) is True


### PR DESCRIPTION
## Problem

`ai_review_abstained()` returned `True` for **all** null scores, including
policy-drop cases where the reviewer assessed real source but all findings
were out-of-scope (informational). This blocked self-merge even when Greptile
was 5/5 and all CI passed.

Incident: gptme/gptme-contrib#1590 blocked with "AI review abstained" despite:
- Greptile: 5/5 "The PR appears safe to merge"
- All CI passing (test 3.10/3.11/3.12, typecheck, pre-commit, integration)
- No human comments
- AI reviewer marker: `score: null, submodule_only: false` (policy-drop, not a real abstention)

## Root cause

The `ai_review_lib.py` docstring documents the intended behavior:

> The *negative* abstention path only blocks when the marker's `submodule_only` bit
> is true (or omitted — fail-closed for gptme-cloud#850). Policy-drop nulls are
> reviews of real source, not "not reviewed".

But `ai_review_abstained()` had no corresponding `submodule_only` check — it blocked
on ALL null scores, making the docstring incorrect.

## Fix

Check `marker.get("submodule_only", True)` before returning `True`:

- `submodule_only: true` (or omitted, fail-closed) → reviewer had no source → block
- `submodule_only: false` → reviewer assessed real source, all findings out-of-scope → don't block

The fail-closed default (`True`) preserves safety for old markers that predate the field.

## Security properties preserved

- Only markers from `expected_author` (TimeToBuildBob) are read — no injection risk
- `submodule_only: true` and omitted still block (fail-closed)
- Greptile 5/5 + CI remain the independent quality gates for policy-drop cases