### PR TITLE
fix(greptile): honor summary 'Last reviewed commit' footer in staleness check

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -240,6 +240,33 @@ _our_last_trigger_json() {
     _issue_comments_json | jq "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | sort_by(.created_at) | last // {}" 2>/dev/null || echo "{}"
 }
 
+# --- Helper: sha named by the Greptile summary's "Last reviewed commit" footer ---
+# Greptile does not always post a formal PR review object; on many PRs the only
+# artifact is an issue comment whose footer names the commit it actually read.
+# That footer is the same provenance self-merge-check.py gates on, so the helper
+# must read it from the same place or the two tools disagree about staleness.
+# Delegates to the sibling greptile-merge-signal.py rather than re-implementing
+# its parser here — one regex, already covered by
+# tests/test_greptile_merge_signal_provenance.py.
+# Prints the sha, or nothing when there is no summary/footer (caller falls back).
+_greptile_summary_reviewed_sha() {
+    local signal_py out
+    signal_py="$(dirname "${BASH_SOURCE[0]}")/greptile-merge-signal.py"
+    [ -f "$signal_py" ] || return 0
+    # The self-merge gate owns the enable/disable policy for the merge signal;
+    # don't let that tool's disable flag silently drop provenance here (same
+    # reasoning as self-merge-check.py, which pops the var before invoking).
+    # NOTE: a non-zero exit here is NOT a failure. greptile-merge-signal.py uses
+    # its exit code to report *merge eligibility* (e.g. exit 1 = "safe to merge"
+    # marker absent), and still prints a complete JSON payload. Gating on the
+    # exit status would silently drop provenance for every PR that is merely
+    # ineligible — which is most of the PRs this staleness check exists to serve.
+    out=$(env -u GREPTILE_MERGE_SIGNAL_DISABLED python3 "$signal_py" \
+        --repo "$REPO" "$PR_NUMBER" 2>/dev/null) || true
+    [ -n "$out" ] || return 0
+    printf '%s' "$out" | jq -r '.reviewed_commit // ""' 2>/dev/null || true
+}
+
 # --- Helper: check if re-review is needed (new commits since latest review) ---
 # Returns 0 = re-review needed, 1 = no re-review needed
 #
@@ -264,6 +291,20 @@ _needs_re_review() {
               | select((.user.login // "") | test("greptile"; "i"))
               | select((.commit_id // "") != "")]
             | sort_by(.submitted_at) | last | (.commit_id // "")' 2>/dev/null) || reviewed_sha=""
+
+    # No formal review object carries a commit_id (Greptile frequently reviews via
+    # issue comment only). Before falling back to the date heuristic, use the
+    # summary footer's "Last reviewed commit" — it is server-side, unambiguous,
+    # and is exactly what self-merge-check.py gates on. Without this the two tools
+    # deadlock: the gate demands a re-review of head while this helper reports
+    # "no new commits" and refuses to trigger one. Observed on
+    # gptme/gptme-cloud#892 (2026-09-02): head dcf167ea was committed at 12:08:15
+    # and Greptile posted its review of the PREVIOUS commit 63f9d6b7 at 12:08:47,
+    # so `committer.date > reviewed_at` counted zero new commits and the PR sat
+    # permanently ineligible while repo-wide CI stayed red.
+    if [ -z "$reviewed_sha" ]; then
+        reviewed_sha=$(_greptile_summary_reviewed_sha) || reviewed_sha=""
+    fi
 
     if [ -n "$reviewed_sha" ]; then
         head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha // ""' 2>/dev/null) || head_sha=""

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -114,13 +114,31 @@ def _iso_ago(*, minutes: int) -> str:
 
 
 def _make_greptile_comment(
-    score: int, reviewed_at: str, updated_at: str | None = None
+    score: int,
+    reviewed_at: str,
+    updated_at: str | None = None,
+    reviewed_commit: str | None = None,
 ) -> dict:
+    """Fake Greptile summary comment.
+
+    reviewed_commit: when set, append the real summary's "Last reviewed commit"
+    footer. That footer is the provenance self-merge-check.py gates on, so the
+    helper must honour it too.
+    """
+    body = (
+        f"<h3>Greptile Summary</h3>\nFindings.\n"
+        f"<h3>Confidence Score: {score}/5</h3>\nDetails."
+    )
+    if reviewed_commit:
+        body += (
+            f'\n\n<sub>Reviews (1): Last reviewed commit: ["fix(ci): x"]'
+            f"(https://github.com/o/r/commit/{reviewed_commit})</sub>"
+        )
     return {
         "user": {"login": "greptile-apps[bot]"},
         "created_at": reviewed_at,
         "updated_at": updated_at or reviewed_at,
-        "body": f"<h3>Greptile Summary</h3>\nFindings.\n<h3>Confidence Score: {score}/5</h3>\nDetails.",
+        "body": body,
     }
 
 
@@ -610,6 +628,71 @@ def test_no_pr_review_object_falls_back_to_date_heuristic():
     }
     status = _run_helper("status", fixture)
     assert status.stdout.strip() == "needs-re-review", f"stderr: {status.stderr}"
+
+
+def test_summary_footer_stale_sha_forces_re_review_when_date_says_no():
+    """Regression: gptme/gptme-cloud#892 (2026-09-02).
+
+    Greptile posted no formal PR review — only an issue comment whose footer
+    named the PREVIOUS commit. The new head was committed 32s BEFORE that
+    comment landed, so the date heuristic counted zero new commits and the
+    helper reported 'already-reviewed'. Meanwhile self-merge-check.py read the
+    same footer and refused the merge as stale: the PR could neither be merged
+    nor re-reviewed, while repo-wide CI stayed red.
+    """
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 892,
+        "raw_comments": [
+            _make_greptile_comment(
+                5,
+                reviewed_at=reviewed_at,
+                updated_at=reviewed_at,
+                reviewed_commit="63f9d6b7f16420bfe5c188fb01b97d7fa0649fde",
+            ),
+        ],
+        "raw_reviews": [],  # no formal review object → footer is the only provenance
+        "raw_pr": {
+            "head": {"sha": "dcf167eaafa3d6ecd4ddc8a7861edd231e294b53"},
+            "created_at": _iso_ago(minutes=120),
+        },
+        # Head predates the review comment, so the date heuristic sees no new
+        # commits — this is exactly what masked the stale review on #892.
+        "raw_commits": [_make_commit(_iso_ago(minutes=31))],
+        "bot_reaction_count": 1,
+    }
+    status = _run_helper("status", fixture, repo="gptme/gptme-cloud")
+    assert status.stdout.strip() == "needs-re-review", f"stderr: {status.stderr}"
+
+
+def test_summary_footer_matching_head_suppresses_re_review():
+    """Loop-safety control: footer names the current head → no re-review, even
+    though the date heuristic sees a commit newer than the review timestamp.
+
+    Without this the fix above would re-trigger on every PR whose commit dates
+    postdate the review, reintroducing the #1246 spam class.
+    """
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 893,
+        "raw_comments": [
+            _make_greptile_comment(
+                5,
+                reviewed_at=reviewed_at,
+                updated_at=reviewed_at,
+                reviewed_commit="dcf167eaafa3d6ecd4ddc8a7861edd231e294b53",
+            ),
+        ],
+        "raw_reviews": [],
+        "raw_pr": {
+            "head": {"sha": "dcf167eaafa3d6ecd4ddc8a7861edd231e294b53"},
+            "created_at": _iso_ago(minutes=120),
+        },
+        "raw_commits": [_make_commit(_iso_ago(minutes=5))],  # date says "new"
+        "bot_reaction_count": 1,
+    }
+    status = _run_helper("status", fixture, repo="gptme/gptme-cloud")
+    assert status.stdout.strip() == "already-reviewed", f"stderr: {status.stderr}"
 
 
 def test_fresh_pr_awaits_initial_review():


### PR DESCRIPTION
## Problem

`greptile-helper.sh` and `self-merge-check.py` disagreed about whether a Greptile review was stale, which **deadlocks the PR**: the merge gate demands a re-review of head, while the helper reports "no new commits" and refuses to trigger one.

The helper derived the reviewed commit only from **formal PR review objects**. Greptile frequently reviews via an in-place *issue comment* and posts no review object at all — so `reviewed_sha` came back empty and the helper fell through to a `committer.date > reviewed_at` heuristic. `self-merge-check.py` meanwhile reads the authoritative `Last reviewed commit` footer out of the summary body (via `greptile_summary_reviewed_commit`).

## Discriminating evidence — gptme/gptme-cloud#892

| fact | value |
|---|---|
| head `dcf167ea` committer.date | `12:08:15Z` |
| Greptile review posted | `12:08:47Z` |
| footer "Last reviewed commit" | `63f9d6b7` (the **previous** commit) |
| formal greptile reviews with `commit_id` | none |

The new head was authored 32s *before* the review landed, so `committer.date > reviewed_at` counted **zero** new commits → `already-reviewed`. But Greptile itself says it read `63f9d6b7`. `self-merge-check.py` correctly refused: `Greptile score 5/5 is stale (summary reviewed 63f9d6b7f164, head is dcf167eaafa3)`.

This is the same class the existing code comment warns about (commit dates not tracking push/review time, gptme#2987) — the date heuristic simply cannot see this.

Cost: #892 fixes a **repo-wide CI outage** (every gptme-cloud PR red on an unauthenticated submodule clone). It sat permanently self-merge-ineligible with no way to obtain the re-review that would clear it.

## Fix

When no review object carries a `commit_id`, take the reviewed sha from the summary footer via the sibling `greptile-merge-signal.py` — reusing the one parser that already exists (covered by `test_greptile_merge_signal_provenance.py`) rather than duplicating a regex in bash. Control flow then rejoins the existing SHA-compare + marker-suppression path **unchanged**, so loop safety is preserved. No footer → date heuristic, exactly as before.

One subtlety worth calling out: `greptile-merge-signal.py` exits non-zero to report merge *ineligibility* while still printing a valid payload, so its exit status must not gate parsing. My first attempt did gate on it — the live check passed anyway (that PR was eligible) and only the unit tests caught it.

## Verification

**Live API, before/after across 8 open PRs** — exactly one verdict changes, and it is the provably stale one:

| PR | before | after | footer vs head |
|---|---|---|---|
| gptme-cloud#892 | already-reviewed | **needs-re-review** | **differs** |
| gptme-cloud#890 | already-reviewed | already-reviewed | matches |
| gptme-cloud#891 | already-reviewed | already-reviewed | matches |
| gptme#3706 / #3705 / #3703 / #3702 / #3700 | already-reviewed | already-reviewed | matches |

So this does not broadly re-open PRs for re-review — no trigger-spam risk.

- `pytest tests/test_greptile_helper.py` — **49 passed**
- `shellcheck scripts/github/greptile-helper.sh` — clean
- Two new tests: the #892 regression (stale footer + date heuristic says "no new commits" → `needs-re-review`), and a loop-safety control (footer == head + date says "new" → `already-reviewed`, guarding the #1246 spam class)
- `test_no_pr_review_object_falls_back_to_date_heuristic` still passes — absent-footer behavior unchanged

## Note

Not re-triggering Greptile on #892 manually from this PR, per the anti-spam rule. #892 itself needs a **human merge** regardless (`self-merge-check.py` refuses it: touches `.github/workflows/`).