### PR TITLE
fix(gptme-dashboard): contain wide tables so 390px has no page overflow

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/base.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/base.html
@@ -60,6 +60,30 @@ footer {
 }
 
 {% block extra_style %}{% endblock %}
+
+/* Narrow-viewport containment (must stay last so it wins over per-page styles).
+
+   Wide tables are the dominant source of horizontal page overflow: a table
+   sizes to its content, so one wide row widens `body` and the whole document
+   scrolls sideways. Turning the table into a block-level scroll container
+   keeps the overflow inside the table instead of on the page, while the
+   surrounding headings and controls stay put. `.heatmap-wrap` already does
+   the same thing for the activity heatmap. */
+@media (max-width: 700px) {
+  .container { max-width: 100%; overflow-x: hidden; }
+  table {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  /* An overflowing block-level table must not also collapse its own columns. */
+  thead, tbody { width: max-content; min-width: 100%; }
+  pre, code { max-width: 100%; overflow-x: auto; }
+  /* Long unbroken identifiers (paths, slugs, URLs) must wrap, not push. */
+  td, th, li, p { overflow-wrap: anywhere; }
+}
 </style>
 {% block extra_head %}{% endblock %}
 </head>

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4328,3 +4328,87 @@ def test_static_safeurl_rejects_protocol_relative(workspace: Path, tmp_path: Pat
     )
     result = subprocess.run([node, "-e", script], capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_narrow_viewport_containment_css_present(workspace: Path, tmp_path: Path):
+    """Generated pages must carry the narrow-viewport containment block.
+
+    Wide tables are the dominant source of horizontal page overflow: without
+    this block a single wide row widens `body` and the whole document scrolls
+    sideways at phone widths (measured 762px document width in a 390px
+    viewport before the fix).
+    """
+    output = tmp_path / "site"
+    generate(workspace, output)
+
+    for page in ("index.html", "lessons/workflow/test-lesson.html"):
+        html = (output / page).read_text()
+        assert "@media (max-width: 700px)" in html, f"{page}: missing narrow-viewport block"
+        narrow = html.split("@media (max-width: 700px)", 1)[1][:600]
+        assert "display: block" in narrow, f"{page}: table not made a scroll container"
+        assert "overflow-x: auto" in narrow, f"{page}: table missing horizontal scroll"
+        # It must be the LAST media block in the stylesheet, otherwise a
+        # per-page rule emitted by `extra_style` can override the containment.
+        style = html.split("</style>", 1)[0]
+        assert style.rindex("@media (") == style.rindex(
+            "@media (max-width: 700px)"
+        ), f"{page}: containment block must come last in the stylesheet"
+
+
+def test_no_horizontal_overflow_at_390px(workspace: Path, tmp_path: Path):
+    """A 390px viewport must not scroll the document horizontally.
+
+    Real browser measurement; skipped when playwright is unavailable (it is not
+    a package dependency). Serves the site under a `/dashboard/` prefix so this
+    also covers the subpath deployment shape.
+    """
+    import functools
+    import http.server
+    import socketserver
+    import threading
+
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import sync_playwright  # noqa: PLC0415
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+
+    prefix = "/dashboard/"
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def translate_path(self, path: str) -> str:
+            clean = path.split("?", 1)[0].split("#", 1)[0]
+            if clean.startswith(prefix):
+                clean = clean[len(prefix) - 1 :]
+            return str(output) + clean
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    socketserver.TCPServer.allow_reuse_address = True
+    server = socketserver.TCPServer(
+        ("127.0.0.1", 0), functools.partial(Handler, directory=str(output))
+    )
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        with sync_playwright() as pw:
+            try:
+                browser = pw.chromium.launch()
+            except Exception as exc:  # no browser binaries installed
+                pytest.skip(f"chromium unavailable: {exc}")
+            page = browser.new_page(viewport={"width": 390, "height": 844})
+            for name in ("index.html", "lessons/workflow/test-lesson.html"):
+                page.goto(f"http://127.0.0.1:{port}{prefix}{name}", wait_until="load")
+                width = page.evaluate(
+                    "() => [document.documentElement.scrollWidth,"
+                    " document.documentElement.clientWidth]"
+                )
+                assert width[0] <= width[1], (
+                    f"{name}: document scrolls horizontally at 390px "
+                    f"(scrollWidth={width[0]}, viewport={width[1]})"
+                )
+            browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Problem

Measured, not guessed. A full generated workspace dashboard served under
`/dashboard/`, opened in headless chromium at 390x844:

```
viewport=390  documentElement.scrollWidth=762
```

The whole document scrolled sideways by ~2x. Cause: every wide table sizes to
its content, so a single wide row widens `body`. Offenders at the outermost
level were `#tasks-table` (738px), `#guidance-table` (593px),
`#summaries-table` (538px), `#journal-table` (528px), and the packages/plugins
tables (520px). Only the activity heatmap had a scroll container
(`.heatmap-wrap { overflow-x: auto }`).

## Fix

One narrow-viewport containment block in the shared `base.html`, emitted
**after** `{% block extra_style %}` so a per-page rule cannot override it:

- tables become block-level horizontal scroll containers (the overflow lives
  inside the table, headings and controls stay put)
- `thead`/`tbody` keep `width: max-content; min-width: 100%` so an overflowing
  table does not also collapse its own columns
- `pre`/`code` scroll instead of pushing
- long unbroken identifiers (paths, slugs, URLs) wrap

Applying it in `base.html` covers `index.html` and all seven detail templates
at once, rather than adding a wrapper at each of ~20 table sites.

## Verification

Same probe, after the change:

| page | before | after |
|---|---|---|
| `index.html` | 762 | **390** |
| task detail | — | **390** |
| journal index | — | **390** |

Table detail stays reachable by scrolling the table itself.

Two tests added:

- `test_narrow_viewport_containment_css_present` — source guard that the block
  exists and is the **last** media block in the stylesheet (the ordering is what
  makes it un-overridable).
- `test_no_horizontal_overflow_at_390px` — real browser measurement at 390px,
  serving the site under a `/dashboard/` prefix so it also covers the subpath
  deployment shape. `pytest.importorskip` + a launch-failure skip, since
  playwright is not a package dependency, so CI skips it cleanly.

Both were confirmed RED before the fix (`scrollWidth=428, viewport=390` on the
test fixture) and GREEN after. Full suite: 395 passed.

## Alternatives considered

- `section, .card { overflow-x: auto }` — also works, but scrolls the section
  heading and its show-more button along with the table.
- Wrapping each table in a `.table-scroll` div — the most semantic option, but
  ~20 template edit sites across 8 templates for the same measured result.

Part of the gptme-dashboard subpath/responsive work; follows
gptme/gptme-contrib#1592 (static search under `/dashboard/`).