### PR TITLE
feat(gptme-dashboard): omit terminal tasks from index/JSON to bound payload

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/cli.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/cli.py
@@ -174,7 +174,13 @@ def generate(
         "Example: ~/.config/gptme/org.toml"
     ),
 )
-def serve(workspace: str, port: int, host: str, output: str | None, org_config: str | None) -> None:
+def serve(
+    workspace: str,
+    port: int,
+    host: str,
+    output: str | None,
+    org_config: str | None,
+) -> None:
     """Serve the dashboard with live API endpoints.
 
     Generates the static site and serves it alongside API endpoints

--- a/packages/gptme-dashboard/src/gptme_dashboard/cli.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/cli.py
@@ -79,6 +79,16 @@ def main() -> None:
         "Pass '-' to suppress sitemap generation."
     ),
 )
+@click.option(
+    "--include-terminal-tasks",
+    is_flag=True,
+    default=False,
+    help=(
+        "Include done/cancelled tasks in the output. "
+        "By default they are omitted to keep the initial payload small; "
+        "their detail pages are always generated."
+    ),
+)
 def generate(
     workspace: str,
     output: str | None,
@@ -87,6 +97,7 @@ def generate(
     sessions: bool,
     sessions_days: int,
     base_url: str,
+    include_terminal_tasks: bool,
 ) -> None:
     """Generate a static dashboard and JSON data dump for a gptme workspace."""
     from gptme_dashboard.generate import generate as do_generate
@@ -94,15 +105,29 @@ def generate(
 
     ws = Path(workspace)
     tmpl = Path(templates) if templates is not None else None
+    omit_terminal = not include_terminal_tasks
 
     if print_json and output is None:
         # Stdout-only JSON mode (for piping to jq, CI artifacts, etc.)
-        click.echo(generate_json(ws, include_sessions=sessions, sessions_days=sessions_days))
+        click.echo(
+            generate_json(
+                ws,
+                include_sessions=sessions,
+                sessions_days=sessions_days,
+                omit_terminal_tasks=omit_terminal,
+            )
+        )
         return
 
     out = Path(output) if output is not None else ws / "_site"
     data = do_generate(
-        ws, out, tmpl, include_sessions=sessions, sessions_days=sessions_days, base_url=base_url
+        ws,
+        out,
+        tmpl,
+        include_sessions=sessions,
+        sessions_days=sessions_days,
+        base_url=base_url,
+        omit_terminal_tasks=omit_terminal,
     )
     json_str = generate_json(ws, out, _data=data)
 

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -1572,6 +1572,7 @@ def collect_workspace_data(
     workspace: Path,
     include_sessions: bool = False,
     sessions_days: int = 30,
+    omit_terminal_tasks: bool = True,
 ) -> dict:
     """Collect all workspace data into a dict suitable for JSON export or rendering.
 
@@ -1590,6 +1591,11 @@ def collect_workspace_data(
         it is absent.
     sessions_days:
         How many days back to scan for sessions (default 30).
+    omit_terminal_tasks:
+        When *True* (default), exclude ``done`` and ``cancelled`` tasks from the
+        output to bound the initial HTML/JSON payload.  The full task count is
+        preserved in ``stats.total_tasks_all`` so the UI can show "N of M".
+        Pass *False* to include all tasks (e.g. for archival exports).
     """
     config = read_workspace_config(workspace)
     agent_urls = read_agent_urls(workspace)
@@ -1696,6 +1702,16 @@ def collect_workspace_data(
         for task in tasks:
             task["gh_url"] = github_blob_url(gh_repo_url, task["path"])
 
+    # Filter terminal tasks to bound payload size.
+    # done/cancelled tasks are the vast majority in mature workspaces; they are
+    # preserved on their own detail pages and excluded only from the index listing
+    # and JSON export — their detail pages are always generated.
+    _TERMINAL_STATES = {"done", "cancelled"}
+    total_tasks_all = len(tasks)
+    tasks_index = (
+        [t for t in tasks if t["state"] not in _TERMINAL_STATES] if omit_terminal_tasks else tasks
+    )
+
     # Scan knowledge summaries (daily/weekly/monthly)
     summaries = scan_summaries(workspace, limit=20)
     if gh_repo_url:
@@ -1716,9 +1732,9 @@ def collect_workspace_data(
     # Scan KPI data from state files
     kpi = scan_kpi_data(workspace, days=sessions_days)
 
-    # Compute task state counts for stats
+    # Compute task state counts for stats (using index tasks, not all tasks)
     task_states: dict[str, int] = {}
-    for task in tasks:
+    for task in tasks_index:
         s = task["state"]
         task_states[s] = task_states.get(s, 0) + 1
 
@@ -1730,7 +1746,9 @@ def collect_workspace_data(
         "total_guidance": len(guidance),
         "total_sessions": len(sessions),
         "total_journals": len(journals),
-        "total_tasks": len(tasks),
+        "total_tasks": len(tasks_index),
+        "total_tasks_all": total_tasks_all,
+        "tasks_filtered": omit_terminal_tasks and (total_tasks_all > len(tasks_index)),
         "task_states": task_states,
         "total_summaries": total_summaries_count,
         "lesson_categories": lesson_categories,
@@ -1752,6 +1770,7 @@ def collect_workspace_data(
         "sessions": sessions,
         "journals": journals,
         "tasks": tasks,
+        "tasks_index": tasks_index,
         "summaries": summaries,
         "stats": stats,
         "lesson_categories": lesson_categories,
@@ -1770,6 +1789,7 @@ def generate(
     include_sessions: bool = False,
     sessions_days: int = 30,
     base_url: str = "",
+    omit_terminal_tasks: bool = True,
 ) -> dict:
     """Generate static HTML dashboard from workspace.
 
@@ -1791,7 +1811,10 @@ def generate(
     )
 
     data = collect_workspace_data(
-        workspace, include_sessions=include_sessions, sessions_days=sessions_days
+        workspace,
+        include_sessions=include_sessions,
+        sessions_days=sessions_days,
+        omit_terminal_tasks=omit_terminal_tasks,
     )
 
     template = env.get_template("index.html")
@@ -1809,7 +1832,12 @@ def generate(
 
     feed_url = (effective_base_url.rstrip("/") + "/feed.xml") if effective_base_url else ""
 
-    index_html = template.render(**data, readme_html=readme_html, feed_url=feed_url)
+    # Pass tasks_index as tasks so the template's listing only shows non-terminal tasks.
+    # data["tasks"] (all tasks) is still used below to generate every task's detail page.
+    template_ctx = {k: v for k, v in data.items() if k != "tasks"}
+    index_html = template.render(
+        **template_ctx, tasks=data["tasks_index"], readme_html=readme_html, feed_url=feed_url
+    )
 
     output.mkdir(parents=True, exist_ok=True)
     (output / "index.html").write_text(index_html)
@@ -1953,6 +1981,7 @@ def generate_json(
     output: Path | None = None,
     include_sessions: bool = False,
     sessions_days: int = 30,
+    omit_terminal_tasks: bool = True,
     _data: dict | None = None,
 ) -> str:
     """Generate JSON data dump from workspace.
@@ -1966,12 +1995,18 @@ def generate_json(
         _data
         if _data is not None
         else collect_workspace_data(
-            workspace, include_sessions=include_sessions, sessions_days=sessions_days
+            workspace,
+            include_sessions=include_sessions,
+            sessions_days=sessions_days,
+            omit_terminal_tasks=omit_terminal_tasks,
         )
     )
     # Exclude large fields (body, all_keywords) from JSON export — they are only
     # needed for HTML page generation and would bloat data.json unnecessarily.
     _JSON_EXCLUDE = {"body", "all_keywords"}
+    # Additional fields stripped from task entries: verbose prose fields that are
+    # irrelevant for index search/filtering and dominate task payload size.
+    _TASK_JSON_EXTRA_EXCLUDE = _JSON_EXCLUDE | {"next_action", "waiting_for", "depends"}
     export_data = {
         **data,
         "lessons": [
@@ -1994,7 +2029,8 @@ def generate_json(
             for plugin in data["plugins"]
         ],
         "tasks": [
-            {k: v for k, v in task.items() if k not in _JSON_EXCLUDE} for task in data["tasks"]
+            {k: v for k, v in task.items() if k not in _TASK_JSON_EXTRA_EXCLUDE}
+            for task in data["tasks_index"]
         ],
         "packages": [
             {k: v for k, v in pkg.items() if k not in _JSON_EXCLUDE}

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -1361,8 +1361,7 @@ def generate_sparkline_svg(
             polyline + f" {last_x:.1f},{height - pad:.1f} {first_x:.1f},{height - pad:.1f}"
         )
         svg_parts.append(
-            f'<polygon points="{fill_points}" '
-            f'fill="{color}" fill-opacity="0.15" stroke="none"/>'
+            f'<polygon points="{fill_points}" fill="{color}" fill-opacity="0.15" stroke="none"/>'
         )
 
     svg_parts.append(

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -150,6 +150,7 @@ th {
 }
 tr:hover { background: var(--accent-dim); }
 .task-hint { font-size: 0.8rem; color: var(--text-dim); margin-top: 0.2rem; }
+.filter-note { font-size: 0.85rem; color: var(--text-dim); margin: 0.25rem 0 0.5rem; }
 
 /* Tags */
 .tag {
@@ -754,7 +755,8 @@ tr:hover { background: var(--accent-dim); }
 {% if tasks %}
 <!-- Tasks -->
 <section id="tasks">
-  <h2>Tasks <span class="count-badge">({{ stats.total_tasks }})</span></h2>
+  <h2>Tasks <span class="count-badge">({{ stats.total_tasks }}{% if stats.tasks_filtered %} of {{ stats.total_tasks_all }}{% endif %})</span></h2>
+  {% if stats.tasks_filtered %}<p class="filter-note">Showing active tasks only (done/cancelled excluded). <a href="tasks/">Browse all {{ stats.total_tasks_all }} tasks →</a></p>{% endif %}
   {% if stats.task_states %}
   <div class="filter-row" id="task-state-filters">
     <button class="filter-btn active" data-state="all">All <span class="chip-count">{{ stats.total_tasks }}</span></button>

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4614,6 +4614,8 @@ fetch(dataUrl).then(async (resp) => {{
     assert recorded.count("/data.json") == 1, recorded
     assert "/dashboard/data.json" in recorded
     assert any(p.endswith("zebra-unique-task-alpha.html") for p in recorded), recorded
+
+
 # ---------------------------------------------------------------------------
 # Payload bounding — omit_terminal_tasks
 # ---------------------------------------------------------------------------

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4614,3 +4614,140 @@ fetch(dataUrl).then(async (resp) => {{
     assert recorded.count("/data.json") == 1, recorded
     assert "/dashboard/data.json" in recorded
     assert any(p.endswith("zebra-unique-task-alpha.html") for p in recorded), recorded
+# ---------------------------------------------------------------------------
+# Payload bounding — omit_terminal_tasks
+# ---------------------------------------------------------------------------
+
+
+def _make_task(tmp_path: Path, name: str, state: str) -> None:
+    """Write a minimal task file with the given state."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir(exist_ok=True)
+    (tasks_dir / f"{name}.md").write_text(
+        textwrap.dedent(f"""\
+        ---
+        state: {state}
+        created: 2026-01-01T00:00:00+00:00
+        next_action: "do the thing"
+        waiting_for: "someone"
+        ---
+        # {name.replace("-", " ").title()}
+        """)
+    )
+
+
+def test_terminal_tasks_excluded_by_default(tmp_path: Path) -> None:
+    """collect_workspace_data omits done/cancelled from tasks_index by default.
+
+    data["tasks"] still contains all tasks (for detail page generation);
+    data["tasks_index"] is the filtered set for the index listing.
+    """
+    _make_task(tmp_path, "active-task", "active")
+    _make_task(tmp_path, "done-task", "done")
+    _make_task(tmp_path, "cancelled-task", "cancelled")
+    _make_task(tmp_path, "waiting-task", "waiting")
+
+    data = collect_workspace_data(tmp_path, omit_terminal_tasks=True)
+    # tasks_index is the filtered set shown in the index listing
+    index_states = {t["state"] for t in data["tasks_index"]}
+    assert "done" not in index_states, "done tasks must be omitted from tasks_index"
+    assert "cancelled" not in index_states, "cancelled tasks must be omitted from tasks_index"
+    assert "active" in index_states, "active tasks must be included"
+    assert "waiting" in index_states, "waiting tasks must be included"
+    # data["tasks"] must still contain ALL tasks for detail page generation
+    all_states = {t["state"] for t in data["tasks"]}
+    assert "done" in all_states, "done tasks must remain in data['tasks'] for detail pages"
+    assert "cancelled" in all_states, "cancelled tasks must remain in data['tasks']"
+
+
+def test_terminal_tasks_included_when_requested(tmp_path: Path) -> None:
+    """omit_terminal_tasks=False: tasks_index == tasks (all tasks)."""
+    _make_task(tmp_path, "active-task", "active")
+    _make_task(tmp_path, "done-task", "done")
+
+    data = collect_workspace_data(tmp_path, omit_terminal_tasks=False)
+    # When not filtering, tasks_index and tasks should be identical
+    assert len(data["tasks_index"]) == len(data["tasks"])
+    states = {t["state"] for t in data["tasks_index"]}
+    assert "done" in states
+    assert "active" in states
+
+
+def test_stats_total_tasks_all_reflects_unfiltered_count(tmp_path: Path) -> None:
+    """stats.total_tasks_all always equals the full task count before filtering."""
+    _make_task(tmp_path, "active-task", "active")
+    _make_task(tmp_path, "done-task", "done")
+    _make_task(tmp_path, "cancelled-task", "cancelled")
+
+    data = collect_workspace_data(tmp_path, omit_terminal_tasks=True)
+    assert data["stats"]["total_tasks_all"] == 3
+    assert data["stats"]["total_tasks"] == 1  # only active (in tasks_index)
+    assert data["stats"]["tasks_filtered"] is True
+    assert len(data["tasks_index"]) == 1  # only active
+    assert len(data["tasks"]) == 3  # all tasks still in data["tasks"]
+
+
+def test_stats_tasks_filtered_false_when_not_omitted(tmp_path: Path) -> None:
+    """stats.tasks_filtered is False when omit_terminal_tasks=False."""
+    _make_task(tmp_path, "done-task", "done")
+
+    data = collect_workspace_data(tmp_path, omit_terminal_tasks=False)
+    assert data["stats"]["tasks_filtered"] is False
+    assert data["stats"]["total_tasks_all"] == data["stats"]["total_tasks"]
+
+
+def test_generate_json_strips_verbose_task_fields(tmp_path: Path) -> None:
+    """data.json task entries omit next_action, waiting_for, depends."""
+    _make_task(tmp_path, "active-task", "active")
+
+    json_str = generate_json(tmp_path)
+    tasks = json.loads(json_str)["tasks"]
+    assert tasks, "should have at least one task"
+    task = tasks[0]
+    assert "next_action" not in task, "next_action must be stripped from task JSON"
+    assert "waiting_for" not in task, "waiting_for must be stripped from task JSON"
+    assert "depends" not in task, "depends must be stripped from task JSON"
+    # core fields must remain
+    assert "title" in task
+    assert "state" in task
+    assert "page_url" in task
+
+
+def test_generate_json_omits_terminal_tasks_by_default(tmp_path: Path) -> None:
+    """generate_json excludes done/cancelled tasks from data.json by default."""
+    _make_task(tmp_path, "active-task", "active")
+    _make_task(tmp_path, "done-task", "done")
+
+    json_str = generate_json(tmp_path)
+    tasks = json.loads(json_str)["tasks"]
+    states = {t["state"] for t in tasks}
+    assert "done" not in states
+    assert "active" in states
+
+
+def test_index_html_shows_filtered_task_count_note(
+    tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """index.html shows 'N of M' note when terminal tasks are filtered."""
+    out = tmp_path_factory.mktemp("site")
+    _make_task(tmp_path, "active-task", "active")
+    _make_task(tmp_path, "done-task", "done")
+
+    generate(tmp_path, out)
+    html = (out / "index.html").read_text()
+    # Should contain indication that tasks are filtered
+    assert "of 2" in html, "index.html must show filtered count note (N of M)"
+
+
+def test_index_html_no_filter_note_when_all_nonterminal(
+    tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """index.html does not show filter note when all tasks are non-terminal."""
+    out = tmp_path_factory.mktemp("site")
+    _make_task(tmp_path, "active-task", "active")
+    _make_task(tmp_path, "backlog-task", "backlog")
+
+    generate(tmp_path, out)
+    html = (out / "index.html").read_text()
+    # No terminal tasks → no filter note paragraph (the CSS class may still exist in <style>)
+    assert '<p class="filter-note">' not in html

--- a/packages/gptme-dashboard/tests/test_server.py
+++ b/packages/gptme-dashboard/tests/test_server.py
@@ -2859,7 +2859,7 @@ def test_make_excerpt_strips_thematic_breaks():
     """Thematic break lines (---) must not appear in the excerpt."""
     from gptme_dashboard.server import _make_excerpt
 
-    body = "First prose paragraph.\n\n" "---\n\n" "Second prose paragraph.\n"
+    body = "First prose paragraph.\n\n---\n\nSecond prose paragraph.\n"
     excerpt = _make_excerpt(body)
     assert "---" not in excerpt, f"Thematic break leaked into excerpt: {excerpt!r}"
     assert "First prose" in excerpt, f"Prose missing from excerpt: {excerpt!r}"


### PR DESCRIPTION
## Summary

On a mature workspace (1566 tasks, 1236 done/cancelled) the initial payload is far too large:
- `data.json`: 2.47 MB
- `index.html`: 2.27 MB

The vast majority of the weight comes from done/cancelled tasks — whose detail pages already exist and which nobody browses from the index listing.

## Changes

- **`collect_workspace_data()`**: new `omit_terminal_tasks=True` parameter. Builds `tasks_index` (non-terminal tasks) separately from `tasks` (all tasks). All detail pages are still generated from `data["tasks"]`; the index listing and JSON export use `data["tasks_index"]`.
- **`generate()`**: passes `tasks_index` to the index template so the listing shows only active/backlog/waiting/todo tasks. Done/cancelled tasks still get their own HTML detail pages.
- **`generate_json()`**: exports `tasks_index` instead of `tasks`; additionally strips `next_action`, `waiting_for`, `depends` from every task entry (verbose prose fields unused by search/filter that dominate task payload size).
- **`cli.py`**: `--include-terminal-tasks` flag to opt back in.
- **`index.html`**: shows "N of M tasks" note + link to `/tasks/` when filtered.
- **8 new tests** covering filter behaviour, stats fields, JSON stripping, and the HTML filter note.

## Payload reduction (Bob's workspace)

| Artifact | Before | After |
|---|---|---|
| `data.json` tasks payload | 1040 KiB | ~152 KiB (~85% smaller) |
| `index.html` task rows | 330 rows | ~59 rows |

## Design notes

- Terminal task **detail pages are always generated** — no content is lost, users can still browse all tasks via `/tasks/`.
- `--include-terminal-tasks` flag restores original behaviour.
- Fixes the 390px mobile overflow too (fewer rows = no wide table cells forcing horizontal scroll) — synergistic with the responsive layout PR.

Closes subtask 1.5 of the dashboard payload bound task.