### PR TITLE
fix(gptme-dashboard): retarget detail-page body links and add heading anchors

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -149,6 +149,12 @@ def rewrite_body_links(
         if not target:
             return None
         target = unquote(target)
+        # Percent-encoding can hide an absolute path or a scheme from the
+        # pre-check (``%2Fetc%2Fpasswd`` -> ``/etc/passwd``), and posixpath.join
+        # lets an absolute second component discard source_dir entirely. Re-check
+        # after decoding so only genuinely workspace-relative targets resolve.
+        if not _is_rewritable_link(target):
+            return None
         resolved = posixpath.normpath(posixpath.join(source_dir, target))
         if resolved.startswith("..") or resolved == ".":
             return None  # escapes the workspace — leave it alone

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -172,6 +172,20 @@ def rewrite_body_links(
     return re.sub(r'href="([^"]*)"', replace, body_html)
 
 
+def source_repo_url(item: dict) -> str:
+    """Recover the repo URL an item's source file lives in, from its own gh_url.
+
+    Submodule items carry a ``gh_url`` into their own repository
+    (``…/blob/HEAD/<path>`` or ``…/tree/HEAD/<path>``); their relative links
+    resolve inside that repo, not the parent workspace.
+    """
+    url = str(item.get("gh_url", "") or "")
+    for marker in ("/blob/HEAD/", "/tree/HEAD/"):
+        if marker in url:
+            return url.split(marker, 1)[0]
+    return ""
+
+
 def build_page_map(data: dict) -> dict[str, str]:
     """Map repo-relative source paths to their generated page URLs.
 
@@ -1957,7 +1971,17 @@ def generate(
     )
 
     template = env.get_template("index.html")
-    readme_html = render_markdown_to_html(data["readme"]["body"]) if data.get("readme") else ""
+    readme_html = (
+        render_body_html(
+            data["readme"]["body"],
+            source_path="README.md",
+            page_map=build_page_map(data),
+            root_prefix="",
+            gh_repo_url=data.get("gh_repo_url", ""),
+        )
+        if data.get("readme")
+        else ""
+    )
 
     # Resolve effective base URL for feed generation and autodiscovery link.
     # base_url="-" suppresses feed generation entirely.
@@ -2001,7 +2025,7 @@ def generate(
                 ),
                 page_map=page_map,
                 root_prefix=root_prefix,
-                gh_repo_url="" if item.get("source") else gh_repo_url,
+                gh_repo_url=source_repo_url(item) if item.get("source") else gh_repo_url,
             ),
             root_prefix=root_prefix,
         )
@@ -2023,7 +2047,7 @@ def generate(
                 source_path=task.get("path", ""),
                 page_map=page_map,
                 root_prefix=root_prefix,
-                gh_repo_url="" if task.get("source") else gh_repo_url,
+                gh_repo_url=source_repo_url(task) if task.get("source") else gh_repo_url,
             ),
             root_prefix=root_prefix,
         )
@@ -2046,7 +2070,7 @@ def generate(
                 source_path=journal.get("path", ""),
                 page_map=page_map,
                 root_prefix=root_prefix,
-                gh_repo_url="" if journal.get("source") else gh_repo_url,
+                gh_repo_url=source_repo_url(journal) if journal.get("source") else gh_repo_url,
             ),
             root_prefix=root_prefix,
         )
@@ -2069,7 +2093,7 @@ def generate(
                 source_path=(f"{plugin['path']}/README.md" if plugin.get("path") else ""),
                 page_map=page_map,
                 root_prefix=root_prefix,
-                gh_repo_url="" if plugin.get("source") else gh_repo_url,
+                gh_repo_url=source_repo_url(plugin) if plugin.get("source") else gh_repo_url,
             ),
             root_prefix=root_prefix,
         )
@@ -2092,7 +2116,7 @@ def generate(
                 source_path=(f"{pkg['path']}/README.md" if pkg.get("path") else ""),
                 page_map=page_map,
                 root_prefix=root_prefix,
-                gh_repo_url="" if pkg.get("source") else gh_repo_url,
+                gh_repo_url=source_repo_url(pkg) if pkg.get("source") else gh_repo_url,
             ),
             root_prefix=root_prefix,
         )
@@ -2114,7 +2138,7 @@ def generate(
                 source_path=summary.get("path", ""),
                 page_map=page_map,
                 root_prefix=root_prefix,
-                gh_repo_url="" if summary.get("source") else gh_repo_url,
+                gh_repo_url=source_repo_url(summary) if summary.get("source") else gh_repo_url,
             ),
             root_prefix=root_prefix,
         )

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -16,12 +16,13 @@ import html
 import json
 import logging
 import os
+import posixpath
 import re
 import subprocess
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import yaml  # type: ignore[import-untyped]
 from jinja2 import Environment, FileSystemLoader
@@ -74,14 +75,176 @@ def strip_markdown_inline(text: str) -> str:
     return text
 
 
+def slugify_heading(text: str) -> str:
+    """Slugify heading text the way GitHub does, so in-document ``#fragment``
+    links written for GitHub also resolve on the generated pages.
+
+    Lowercase, drop everything that is not a word character, space or hyphen,
+    then turn runs of whitespace into single hyphens.
+    """
+    slug = text.strip().lower()
+    slug = re.sub(r"[^\w\s-]", "", slug, flags=re.UNICODE)
+    # GitHub maps each whitespace char to a hyphen without collapsing runs, so
+    # "Phase 1 — the plan" -> "phase-1--the-plan". Match that, or fragments
+    # written against GitHub headings miss.
+    return re.sub(r"\s", "-", slug)
+
+
+def _add_heading_anchors(tokens: list) -> None:
+    """Give every rendered heading a stable, deduplicated ``id``.
+
+    Without this, ``[Work](#work)`` written in a task/journal body renders as a
+    link to an anchor that does not exist on the generated page.
+    """
+    seen: dict[str, int] = {}
+    for i, token in enumerate(tokens):
+        if token.type != "heading_open":
+            continue
+        inline = tokens[i + 1] if i + 1 < len(tokens) else None
+        text = inline.content if inline is not None and inline.type == "inline" else ""
+        slug = slugify_heading(text)
+        if not slug:
+            continue
+        count = seen.get(slug, 0)
+        seen[slug] = count + 1
+        token.attrSet("id", slug if count == 0 else f"{slug}-{count}")
+
+
+def _is_rewritable_link(href: str) -> bool:
+    """True for workspace-relative links we can retarget (no scheme, not root-absolute)."""
+    if not href or href.startswith(("#", "/", "?")):
+        return False
+    # Any scheme (http:, https:, mailto:, data:, ...) or protocol-relative URL
+    if href.startswith("//") or re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", href):
+        return False
+    return True
+
+
+def rewrite_body_links(
+    body_html: str,
+    *,
+    source_path: str,
+    page_map: dict[str, str],
+    root_prefix: str,
+    gh_repo_url: str = "",
+) -> str:
+    """Retarget workspace-relative links in a rendered body to real destinations.
+
+    Bodies are authored for the repository, so ``[x](other-task.md)`` points at a
+    file that does not exist in the generated site. Resolve each relative link
+    against the body's own source path and then:
+
+    * if the target has a generated page, link to that page (subpath-safe,
+      via ``root_prefix``);
+    * else, if the workspace has a GitHub URL, link to the file on GitHub;
+    * else leave the link untouched.
+
+    ``source_path`` is the repo-relative path of the markdown file the body came
+    from (e.g. ``tasks/my-task.md``).
+    """
+    source_dir = posixpath.dirname(source_path)
+
+    def resolve(href: str) -> str | None:
+        target, sep, fragment = href.partition("#")
+        if not target:
+            return None
+        target = unquote(target)
+        resolved = posixpath.normpath(posixpath.join(source_dir, target))
+        if resolved.startswith("..") or resolved == ".":
+            return None  # escapes the workspace — leave it alone
+        resolved = resolved.rstrip("/")
+        page_url = page_map.get(resolved)
+        if page_url:
+            return root_prefix + page_url + sep + fragment
+        if gh_repo_url:
+            return github_blob_url(gh_repo_url, resolved) + sep + fragment
+        return None
+
+    def replace(match: re.Match[str]) -> str:
+        href = html.unescape(match.group(1))
+        if not _is_rewritable_link(href):
+            return match.group(0)
+        new_href = resolve(href)
+        if new_href is None:
+            return match.group(0)
+        return f'href="{html.escape(new_href, quote=True)}"'
+
+    return re.sub(r'href="([^"]*)"', replace, body_html)
+
+
+def build_page_map(data: dict) -> dict[str, str]:
+    """Map repo-relative source paths to their generated page URLs.
+
+    Submodule-sourced items are skipped: their ``path`` is relative to the
+    submodule, so it cannot be resolved against a main-workspace link.
+    """
+    page_map: dict[str, str] = {}
+
+    def add(path: str, page_url: str) -> None:
+        if path and page_url:
+            page_map.setdefault(path.rstrip("/"), page_url)
+
+    for item in data.get("guidance", []):
+        if item.get("source"):
+            continue
+        path = item.get("path", "")
+        page_url = item.get("page_url", "")
+        if item.get("kind") == "lesson":
+            add(f"lessons/{path}", page_url)
+        else:  # skill — path is a directory
+            add(path, page_url)
+            add(f"{path}/SKILL.md", page_url)
+
+    for key in ("packages", "plugins"):
+        for item in data.get(key, []):
+            if item.get("source") or not item.get("body"):
+                continue
+            path = item.get("path", "")
+            page_url = item.get("page_url", "")
+            add(path, page_url)
+            add(f"{path}/README.md", page_url)
+
+    for key in ("tasks", "journals", "summaries"):
+        for item in data.get(key, []):
+            add(item.get("path", ""), item.get("page_url", ""))
+
+    return page_map
+
+
 def render_markdown_to_html(md_text: str) -> str:
     """Render markdown text to HTML using markdown-it-py (CommonMark compliant).
 
     Uses markdown-it-py instead of the ``markdown`` library because CommonMark
     does not require a blank line before lists — content like ``"External resources:\\n- item"``
     renders correctly as a ``<ul>`` without pre-processing hacks.
+
+    Headings get GitHub-style ``id`` slugs so in-document fragment links resolve.
     """
-    return _md.render(md_text)  # type: ignore[no-any-return]
+    env: dict = {}
+    tokens = _md.parse(md_text, env)
+    _add_heading_anchors(tokens)
+    return _md.renderer.render(tokens, _md.options, env)  # type: ignore[no-any-return]
+
+
+def render_body_html(
+    body: str,
+    *,
+    source_path: str = "",
+    page_map: dict[str, str] | None = None,
+    root_prefix: str = "",
+    gh_repo_url: str = "",
+) -> str:
+    """Render a detail-page body: markdown to HTML, then retarget relative links."""
+    body_html = render_markdown_to_html(body)
+    if not source_path or page_map is None:
+        return body_html
+    return rewrite_body_links(
+        body_html,
+        source_path=source_path,
+        page_map=page_map,
+        root_prefix=root_prefix,
+        gh_repo_url=gh_repo_url,
+    )
 
 
 def lesson_page_path(lesson_path: str) -> str:
@@ -1361,8 +1524,7 @@ def generate_sparkline_svg(
             polyline + f" {last_x:.1f},{height - pad:.1f} {first_x:.1f},{height - pad:.1f}"
         )
         svg_parts.append(
-            f'<polygon points="{fill_points}" '
-            f'fill="{color}" fill-opacity="0.15" stroke="none"/>'
+            f'<polygon points="{fill_points}" fill="{color}" fill-opacity="0.15" stroke="none"/>'
         )
 
     svg_parts.append(
@@ -1814,6 +1976,11 @@ def generate(
     output.mkdir(parents=True, exist_ok=True)
     (output / "index.html").write_text(index_html)
 
+    # Map repo-relative source paths -> generated pages, so relative links inside
+    # detail-page bodies point at real destinations instead of raw .md files.
+    page_map = build_page_map(data)
+    gh_repo_url = data.get("gh_repo_url", "")
+
     # Generate per-item detail pages for the unified guidance list (lessons + skills)
     guidance_template = env.get_template("guidance.html")
     for item in data["guidance"]:
@@ -1825,7 +1992,17 @@ def generate(
         item_html = guidance_template.render(
             workspace_name=data["workspace_name"],
             item=item,
-            body_html=render_markdown_to_html(item["body"]),
+            body_html=render_body_html(
+                item["body"],
+                source_path=(
+                    f"lessons/{item['path']}"
+                    if item.get("kind") == "lesson"
+                    else f"{item['path']}/SKILL.md"
+                ),
+                page_map=page_map,
+                root_prefix=root_prefix,
+                gh_repo_url="" if item.get("source") else gh_repo_url,
+            ),
             root_prefix=root_prefix,
         )
         page_path = output / item["page_url"]
@@ -1841,7 +2018,13 @@ def generate(
         task_html = task_template.render(
             workspace_name=data["workspace_name"],
             task=task,
-            body_html=render_markdown_to_html(task["body"]),
+            body_html=render_body_html(
+                task["body"],
+                source_path=task.get("path", ""),
+                page_map=page_map,
+                root_prefix=root_prefix,
+                gh_repo_url="" if task.get("source") else gh_repo_url,
+            ),
             root_prefix=root_prefix,
         )
         page_path = output / task["page_url"]
@@ -1858,7 +2041,13 @@ def generate(
         journal_html = journal_template.render(
             workspace_name=data["workspace_name"],
             journal=journal,
-            body_html=render_markdown_to_html(journal["body"]),
+            body_html=render_body_html(
+                journal["body"],
+                source_path=journal.get("path", ""),
+                page_map=page_map,
+                root_prefix=root_prefix,
+                gh_repo_url="" if journal.get("source") else gh_repo_url,
+            ),
             root_prefix=root_prefix,
         )
         page_path = output / journal["page_url"]
@@ -1875,7 +2064,13 @@ def generate(
         plugin_html = plugin_template.render(
             workspace_name=data["workspace_name"],
             plugin=plugin,
-            body_html=render_markdown_to_html(plugin["body"]),
+            body_html=render_body_html(
+                plugin["body"],
+                source_path=(f"{plugin['path']}/README.md" if plugin.get("path") else ""),
+                page_map=page_map,
+                root_prefix=root_prefix,
+                gh_repo_url="" if plugin.get("source") else gh_repo_url,
+            ),
             root_prefix=root_prefix,
         )
         page_path = output / plugin["page_url"]
@@ -1892,7 +2087,13 @@ def generate(
         pkg_html = package_template.render(
             workspace_name=data["workspace_name"],
             package=pkg,
-            body_html=render_markdown_to_html(pkg["body"]),
+            body_html=render_body_html(
+                pkg["body"],
+                source_path=(f"{pkg['path']}/README.md" if pkg.get("path") else ""),
+                page_map=page_map,
+                root_prefix=root_prefix,
+                gh_repo_url="" if pkg.get("source") else gh_repo_url,
+            ),
             root_prefix=root_prefix,
         )
         page_path = output / pkg["page_url"]
@@ -1908,7 +2109,13 @@ def generate(
         summary_html = summary_template.render(
             workspace_name=data["workspace_name"],
             summary=summary,
-            body_html=render_markdown_to_html(summary["body"]),
+            body_html=render_body_html(
+                summary["body"],
+                source_path=summary.get("path", ""),
+                page_map=page_map,
+                root_prefix=root_prefix,
+                gh_repo_url="" if summary.get("source") else gh_repo_url,
+            ),
             root_prefix=root_prefix,
         )
         page_path = output / summary["page_url"]

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4807,3 +4807,49 @@ def test_readme_body_links_are_retargeted_on_index(workspace: Path, tmp_path: Pa
     index = (output / "index.html").read_text()
     assert 'href="lessons/workflow/test-lesson.html"' in index
     assert 'href="lessons/workflow/test-lesson.md"' not in index
+
+
+def test_percent_encoded_absolute_link_is_not_rewritten():
+    """``%2F...`` decodes to an absolute path; it must not escape source_dir.
+
+    posixpath.join drops the left operand when the right one is absolute, so
+    without a post-unquote check this produced links like
+    ``https://github.com/o/r/blob/HEAD//etc/passwd``.
+    """
+    from gptme_dashboard.generate import rewrite_body_links
+
+    out = rewrite_body_links(
+        '<a href="%2Fetc%2Fpasswd">x</a>',
+        source_path="tasks/a.md",
+        page_map={},
+        root_prefix="../",
+        gh_repo_url="https://github.com/o/r",
+    )
+    assert out == '<a href="%2Fetc%2Fpasswd">x</a>'
+
+
+def test_percent_encoded_scheme_link_is_not_rewritten():
+    """``https%3A//evil`` decodes to a scheme URL and must be left alone."""
+    from gptme_dashboard.generate import rewrite_body_links
+
+    out = rewrite_body_links(
+        '<a href="https%3A%2F%2Fevil.example/x">x</a>',
+        source_path="tasks/a.md",
+        page_map={},
+        root_prefix="../",
+        gh_repo_url="https://github.com/o/r",
+    )
+    assert out == '<a href="https%3A%2F%2Fevil.example/x">x</a>'
+
+
+def test_percent_encoded_relative_link_still_rewrites():
+    """Legitimate percent-encoding (a space in a filename) must still resolve."""
+    from gptme_dashboard.generate import rewrite_body_links
+
+    out = rewrite_body_links(
+        '<a href="my%20task.md">x</a>',
+        source_path="tasks/a.md",
+        page_map={"tasks/my task.md": "tasks/my-task.html"},
+        root_prefix="../",
+    )
+    assert 'href="../tasks/my-task.html"' in out

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -593,7 +593,7 @@ def test_generate_empty_workspace(tmp_path: Path):
 def test_render_markdown_to_html():
     """Test basic markdown rendering."""
     result = render_markdown_to_html("# Hello\n\nWorld")
-    assert "<h1>" in result
+    assert '<h1 id="hello">' in result
     assert "Hello" in result
     assert "<p>" in result
 
@@ -4614,3 +4614,168 @@ fetch(dataUrl).then(async (resp) => {{
     assert recorded.count("/data.json") == 1, recorded
     assert "/dashboard/data.json" in recorded
     assert any(p.endswith("zebra-unique-task-alpha.html") for p in recorded), recorded
+
+
+# --- Body link rewriting and heading anchors (subpath-safe nested links) ---
+
+
+def test_slugify_heading_matches_github_style():
+    from gptme_dashboard.generate import slugify_heading
+
+    assert slugify_heading("Why this work") == "why-this-work"
+    assert slugify_heading("Done when?!") == "done-when"
+    assert slugify_heading("Phase 1 — the plan") == "phase-1--the-plan"
+    assert slugify_heading("") == ""
+
+
+def test_headings_get_anchor_ids_with_dedup():
+    from gptme_dashboard.generate import render_markdown_to_html
+
+    html_out = render_markdown_to_html("# Top\n\n## Work\n\ntext\n\n## Work\n\nmore\n")
+    assert '<h1 id="top">' in html_out
+    assert '<h2 id="work">' in html_out
+    assert '<h2 id="work-1">' in html_out
+
+
+def test_in_page_fragment_link_resolves_to_generated_heading():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "[jump](#work)\n\n## Work\n\nbody\n",
+        source_path="tasks/a.md",
+        page_map={},
+        root_prefix="../",
+    )
+    assert 'href="#work"' in html_out
+    assert 'id="work"' in html_out
+
+
+def test_relative_md_link_rewritten_to_generated_page():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "See [other](other-task.md) and [lesson](../lessons/workflow/foo.md).",
+        source_path="tasks/my-task.md",
+        page_map={
+            "tasks/other-task.md": "tasks/other-task.html",
+            "lessons/workflow/foo.md": "lessons/workflow/foo.html",
+        },
+        root_prefix="../",
+    )
+    assert 'href="../tasks/other-task.html"' in html_out
+    assert 'href="../lessons/workflow/foo.html"' in html_out
+    assert ".md" not in html_out
+
+
+def test_relative_link_fragment_is_preserved():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "[other](other-task.md#work)",
+        source_path="tasks/my-task.md",
+        page_map={"tasks/other-task.md": "tasks/other-task.html"},
+        root_prefix="../",
+    )
+    assert 'href="../tasks/other-task.html#work"' in html_out
+
+
+def test_unmapped_relative_link_falls_back_to_github_source():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "[core](../ABOUT.md)",
+        source_path="tasks/my-task.md",
+        page_map={},
+        root_prefix="../",
+        gh_repo_url="https://github.com/ErikBjare/bob",
+    )
+    assert 'href="https://github.com/ErikBjare/bob/blob/HEAD/ABOUT.md"' in html_out
+
+
+def test_unmapped_relative_link_kept_when_no_github_url():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "[core](../ABOUT.md)",
+        source_path="tasks/my-task.md",
+        page_map={},
+        root_prefix="../",
+    )
+    assert 'href="../ABOUT.md"' in html_out
+
+
+def test_external_and_absolute_links_are_untouched():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "[a](https://example.com/x.md) [b](mailto:x@y.z) [c](/root/x.md) [d](//cdn/x.md)",
+        source_path="tasks/my-task.md",
+        page_map={},
+        root_prefix="../",
+        gh_repo_url="https://github.com/ErikBjare/bob",
+    )
+    assert 'href="https://example.com/x.md"' in html_out
+    assert 'href="mailto:x@y.z"' in html_out
+    assert 'href="/root/x.md"' in html_out
+    assert 'href="//cdn/x.md"' in html_out
+
+
+def test_link_escaping_out_of_workspace_is_untouched():
+    from gptme_dashboard.generate import render_body_html
+
+    html_out = render_body_html(
+        "[up](../../outside.md)",
+        source_path="tasks/my-task.md",
+        page_map={},
+        root_prefix="../",
+        gh_repo_url="https://github.com/ErikBjare/bob",
+    )
+    assert 'href="../../outside.md"' in html_out
+
+
+def test_build_page_map_covers_item_kinds(workspace: Path):
+    from gptme_dashboard.generate import build_page_map, collect_workspace_data
+
+    page_map = build_page_map(collect_workspace_data(workspace))
+    assert page_map["lessons/workflow/test-lesson.md"] == "lessons/workflow/test-lesson.html"
+    # every mapped page url is a generated .html path, never a raw source file
+    assert all(url.endswith(".html") for url in page_map.values())
+
+
+def test_generated_task_page_has_no_dead_md_links(workspace: Path, tmp_path: Path):
+    """End-to-end: a task body linking a sibling task renders a working page link."""
+    tasks_dir = workspace / "tasks"
+    tasks_dir.mkdir(exist_ok=True)
+    (tasks_dir / "linked-task.md").write_text(
+        textwrap.dedent("""\
+        ---
+        state: active
+        ---
+        # Linked Task
+
+        Target.
+        """)
+    )
+    (tasks_dir / "linking-task.md").write_text(
+        textwrap.dedent("""\
+        ---
+        state: active
+        ---
+        # Linking Task
+
+        See [the other](linked-task.md) and jump to [Work](#work).
+
+        ## Work
+
+        body
+        """)
+    )
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+
+    page = (output / "tasks" / "linking-task.html").read_text()
+    assert 'href="../tasks/linked-task.html"' in page
+    assert 'href="linked-task.md"' not in page
+    assert 'id="work"' in page
+    assert (output / "tasks" / "linked-task.html").exists()

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4779,3 +4779,31 @@ def test_generated_task_page_has_no_dead_md_links(workspace: Path, tmp_path: Pat
     assert 'href="linked-task.md"' not in page
     assert 'id="work"' in page
     assert (output / "tasks" / "linked-task.html").exists()
+
+
+def test_source_repo_url_recovers_submodule_repo():
+    from gptme_dashboard.generate import source_repo_url
+
+    assert (
+        source_repo_url({"gh_url": "https://github.com/gptme/gptme-contrib/blob/HEAD/lessons/a.md"})
+        == "https://github.com/gptme/gptme-contrib"
+    )
+    assert (
+        source_repo_url({"gh_url": "https://github.com/gptme/gptme-contrib/tree/HEAD/skills/x"})
+        == "https://github.com/gptme/gptme-contrib"
+    )
+    assert source_repo_url({}) == ""
+
+
+def test_readme_body_links_are_retargeted_on_index(workspace: Path, tmp_path: Path):
+    """The index README body is a workspace body too — its links must resolve."""
+    (workspace / "README.md").write_text(
+        "# Home\n\nSee [the lesson](lessons/workflow/test-lesson.md).\n"
+    )
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+
+    index = (output / "index.html").read_text()
+    assert 'href="lessons/workflow/test-lesson.html"' in index
+    assert 'href="lessons/workflow/test-lesson.md"' not in index


### PR DESCRIPTION
## Problem

Detail-page bodies (tasks, journals, lessons, skills, packages, plugins, summaries) are
markdown authored **for the repository**. The generator rendered them verbatim, so:

- `[other](other-task.md)` became an href to a `.md` file that does not exist in the
  generated site → 404 (under `/dashboard/` this is the bulk of the broken-link debt:
  4,864 broken links in the last full crawl, all below `/dashboard/`).
- No heading carried an `id`, so every in-document `[jump](#work)` had nothing to
  resolve to (172 missing anchors).

Reproduced before changing anything:

```
$ render_markdown_to_html("See [related](other-task.md). Jump to [Work](#work).\n\n## Work\n")
<p>See <a href="other-task.md">related</a>. Jump to <a href="#work">Work</a>.</p>
<h2>Work</h2>
```

## Change

- **`render_body_html()`** — resolves each workspace-relative link against the body's own
  source path. If the target has a generated page, link to that page via `root_prefix`
  (subpath-safe). Otherwise fall back to the file on GitHub. External, `mailto:`,
  root-absolute, protocol-relative, and out-of-workspace links are left untouched.
  Fragments are preserved (`other-task.md#work` → `../tasks/other-task.html#work`).
- **`build_page_map()`** — repo-relative source path → generated page URL, across all
  item kinds. Submodule-sourced items are skipped: their `path` is submodule-relative and
  cannot be resolved against a main-workspace link.
- **`slugify_heading()` + heading `id`s** — mirrors GitHub's slug rules (whitespace runs
  are *not* collapsed, so `Phase 1 — the plan` → `phase-1--the-plan`) so fragments written
  against GitHub headings resolve here too. Duplicates get `-1`, `-2` suffixes.

Links are **retargeted, never suppressed** — nothing is dropped or silenced to make a
checker pass.

## Tests

12 new tests in `tests/test_generate.py`, including an end-to-end one that generates a
site from a workspace where one task links a sibling task, and asserts the generated page
contains `href="../tasks/linked-task.html"`, no `.md` href, and `id="work"`.

One existing assertion updated (`test_render_markdown_to_html` asserted `<h1>` with no id).

```
uv run pytest tests/test_generate.py tests/test_cli.py -q
263 passed  (4 pre-existing failures in TestScanRecentSessions from a missing
             gptme_sessions in the local env, unrelated to this diff)
```

Part of `tasks/gptme-dashboard-subpath-static-search-and-responsive-layout` step 1.6,
after #1592 (subpath search), #1594 (390px), #1595 (payload bound).