### PR TITLE
perf(gptme-dashboard): load the static search index lazily, not at page load

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1246,7 +1246,10 @@ async function initDynamic() {
   const overlay = document.getElementById('search-overlay');
   if (overlay && overlay.classList.contains('open')) {
     const pending = document.getElementById('global-search-input').value.trim();
-    if (pending && pending.length >= 2) runSearch(pending, document.getElementById('search-type-filter').value);
+    if (pending && pending.length >= 2) {
+      clearTimeout(_searchTimer);  // cancel any pending debounce to avoid duplicate runSearch
+      runSearch(pending, document.getElementById('search-type-filter').value);
+    }
   }
 }
 
@@ -1797,9 +1800,9 @@ function openSearch() {
   document.getElementById('search-overlay').classList.add('open');
   document.getElementById('global-search-input').focus();
   _searchSelected = -1;
-  // Opening the overlay is explicit search intent — start the static index
-  // fetch now so the first keystroke does not wait on the network.
-  if (_apiAvailable === false) _loadStaticSearchIndex();
+  // Static index is fetched lazily on first query intent (first keystroke), not
+  // on overlay-open. Visitors who open and close search without typing never
+  // download the multi-MB data.json.
 }
 
 function closeSearch() {
@@ -1933,23 +1936,23 @@ async function runSearch(q, typeFilter) {
 
   // Static mode: use client-side index built from data.json
   if (_apiAvailable === false) {
-    if (_staticSearchIndex === null) {
-      // Not loaded yet — start the lazy fetch and re-run once it resolves.
+    if (_staticSearchIndex === null || _staticSearchIndex === false) {
+      // Not loaded yet (null) or a previous attempt failed (false) — (re-)start the
+      // lazy fetch. Guard with !_staticSearchIndexPromise so that rapid keystrokes
+      // while the fetch is in-flight attach only one re-run callback instead of one
+      // per keystroke (which would cause redundant O(n) rescans when data lands).
+      const isRetry = (_staticSearchIndex === false);
       document.getElementById('search-results-area').innerHTML =
-        '<div class="search-empty">Loading search index…</div>';
+        '<div class="search-empty">' + (isRetry ? 'Retrying search index…' : 'Loading search index…') + '</div>';
       document.getElementById('search-result-count').textContent = '';
-      _loadStaticSearchIndex().then(() => {
-        const input = document.getElementById('global-search-input');
-        const liveQuery = input ? input.value.trim() : '';
-        const liveFilter = document.getElementById('search-type-filter').value;
-        if (liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
-      });
-      return;
-    }
-    if (_staticSearchIndex === false) {
-      document.getElementById('search-results-area').innerHTML =
-        '<div class="search-empty">Search unavailable — could not load static index</div>';
-      document.getElementById('search-result-count').textContent = '';
+      if (!_staticSearchIndexPromise) {
+        _loadStaticSearchIndex().then(() => {
+          const input = document.getElementById('global-search-input');
+          const liveQuery = input ? input.value.trim() : '';
+          const liveFilter = document.getElementById('search-type-filter').value;
+          if (liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
+        });
+      }
       return;
     }
     const { results, total } = _clientSearch(q, typeFilter, 20);

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1867,11 +1867,12 @@ function _clientSearch(q, typeFilter, limit) {
 /** Load data.json and build the static search index, lazily, on first user intent.
  *  Never called during page load: data.json is multi-MB on real workspaces, so
  *  fetching it eagerly blows the cold-load transfer budget for every visitor who
- *  never searches. Concurrent callers share one in-flight request.
- *  Sets _staticSearchIndex to an array on success or false on failure (never stays null). */
+ *  never searches. Concurrent callers share one in-flight request. A failed request
+ *  shows the unavailable state for the current attempt, then becomes retryable. */
 function _loadStaticSearchIndex() {
-  if (_staticSearchIndex !== null) return Promise.resolve();  // already loaded (or failed)
+  if (Array.isArray(_staticSearchIndex)) return Promise.resolve();  // already loaded
   if (_staticSearchIndexPromise) return _staticSearchIndexPromise;  // in flight
+  _staticSearchIndex = null;
   _staticSearchIndexPromise = (async () => {
     try {
       const resp = await fetch('./data.json');
@@ -1882,7 +1883,11 @@ function _loadStaticSearchIndex() {
       }
       const data = await resp.json();
       _staticSearchIndex = _buildClientIndex(data);
-    } catch (_) { _staticSearchIndex = false; }
+    } catch (_) {
+      _staticSearchIndex = false;
+    } finally {
+      _staticSearchIndexPromise = null;
+    }
   })();
   return _staticSearchIndexPromise;
 }
@@ -1935,7 +1940,9 @@ async function runSearch(q, typeFilter) {
       document.getElementById('search-result-count').textContent = '';
       _loadStaticSearchIndex().then(() => {
         const input = document.getElementById('global-search-input');
-        if (input && input.value.trim() === q) runSearch(q, typeFilter);
+        const liveQuery = input ? input.value.trim() : '';
+        const liveFilter = document.getElementById('search-type-filter').value;
+        if (liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
       });
       return;
     }

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1950,7 +1950,15 @@ async function runSearch(q, typeFilter) {
           const input = document.getElementById('global-search-input');
           const liveQuery = input ? input.value.trim() : '';
           const liveFilter = document.getElementById('search-type-filter').value;
-          if (Array.isArray(_staticSearchIndex) && liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
+          if (Array.isArray(_staticSearchIndex)) {
+            if (liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
+          } else if (_staticSearchIndex === false) {
+            // Retry also failed — show a definitive failure message so the user
+            // knows search is unavailable (not just "still retrying").
+            document.getElementById('search-results-area').innerHTML =
+              '<div class="search-empty">Search unavailable — could not load index. Reopen search to retry.</div>';
+            document.getElementById('search-result-count').textContent = '';
+          }
         });
       }
       return;

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1220,8 +1220,9 @@ async function initDynamic() {
   try {
     const resp = await fetch('/api/status');
     if (!resp.ok) {
+      // Static deploy: do NOT fetch data.json here — it is multi-MB on real
+      // workspaces. runSearch()/openSearch() load it on first user intent.
       _apiAvailable = false;
-      await _loadStaticSearchIndex();
     } else {
       _apiAvailable = true;
       // Each load* function calls show()/hide() for its own section.
@@ -1238,9 +1239,8 @@ async function initDynamic() {
       if (document.getElementById('dynamic-journals')) loadJournals();
     }
   } catch (e) {
-    // No backend — load static index for client-side search
+    // No backend — the static index is loaded lazily on first user intent.
     _apiAvailable = false;
-    await _loadStaticSearchIndex();
   }
   // Re-trigger any search typed while we were probing (the null guard showed "Loading…")
   const overlay = document.getElementById('search-overlay');
@@ -1791,11 +1791,15 @@ let _searchAbortController = null;
 let _apiAvailable = null;
 // Client-side search index loaded from data.json when API is unavailable
 let _staticSearchIndex = null;
+let _staticSearchIndexPromise = null;
 
 function openSearch() {
   document.getElementById('search-overlay').classList.add('open');
   document.getElementById('global-search-input').focus();
   _searchSelected = -1;
+  // Opening the overlay is explicit search intent — start the static index
+  // fetch now so the first keystroke does not wait on the network.
+  if (_apiAvailable === false) _loadStaticSearchIndex();
 }
 
 function closeSearch() {
@@ -1860,20 +1864,27 @@ function _clientSearch(q, typeFilter, limit) {
   return { results: scored.slice(0, limit).map(r => r.item), total: scored.length };
 }
 
-/** Load data.json and build the static search index (called once when API is unavailable).
+/** Load data.json and build the static search index, lazily, on first user intent.
+ *  Never called during page load: data.json is multi-MB on real workspaces, so
+ *  fetching it eagerly blows the cold-load transfer budget for every visitor who
+ *  never searches. Concurrent callers share one in-flight request.
  *  Sets _staticSearchIndex to an array on success or false on failure (never stays null). */
-async function _loadStaticSearchIndex() {
-  if (_staticSearchIndex !== null) return;  // already loaded (or failed)
-  try {
-    const resp = await fetch('./data.json');
-    if (!resp.ok) {
-      console.warn('gptme-dashboard: /data.json fetch failed (' + resp.status + ') — static search unavailable');
-      _staticSearchIndex = false;
-      return;
-    }
-    const data = await resp.json();
-    _staticSearchIndex = _buildClientIndex(data);
-  } catch (_) { _staticSearchIndex = false; }
+function _loadStaticSearchIndex() {
+  if (_staticSearchIndex !== null) return Promise.resolve();  // already loaded (or failed)
+  if (_staticSearchIndexPromise) return _staticSearchIndexPromise;  // in flight
+  _staticSearchIndexPromise = (async () => {
+    try {
+      const resp = await fetch('./data.json');
+      if (!resp.ok) {
+        console.warn('gptme-dashboard: /data.json fetch failed (' + resp.status + ') — static search unavailable');
+        _staticSearchIndex = false;
+        return;
+      }
+      const data = await resp.json();
+      _staticSearchIndex = _buildClientIndex(data);
+    } catch (_) { _staticSearchIndex = false; }
+  })();
+  return _staticSearchIndexPromise;
 }
 
 /** Render a list of result objects into the search results area. */
@@ -1918,10 +1929,14 @@ async function runSearch(q, typeFilter) {
   // Static mode: use client-side index built from data.json
   if (_apiAvailable === false) {
     if (_staticSearchIndex === null) {
-      // Index still loading (race: _apiAvailable set false before _loadStaticSearchIndex resolves)
+      // Not loaded yet — start the lazy fetch and re-run once it resolves.
       document.getElementById('search-results-area').innerHTML =
         '<div class="search-empty">Loading search index…</div>';
       document.getElementById('search-result-count').textContent = '';
+      _loadStaticSearchIndex().then(() => {
+        const input = document.getElementById('global-search-input');
+        if (input && input.value.trim() === q) runSearch(q, typeFilter);
+      });
       return;
     }
     if (_staticSearchIndex === false) {

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1950,7 +1950,7 @@ async function runSearch(q, typeFilter) {
           const input = document.getElementById('global-search-input');
           const liveQuery = input ? input.value.trim() : '';
           const liveFilter = document.getElementById('search-type-filter').value;
-          if (liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
+          if (Array.isArray(_staticSearchIndex) && liveQuery.length >= 2) runSearch(liveQuery, liveFilter);
         });
       }
       return;

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4089,17 +4089,18 @@ def test_static_search_broken_url_guard(workspace: Path, tmp_path: Path):
 
 
 def test_static_search_failed_load_sentinel(workspace: Path, tmp_path: Path):
-    """runSearch must show a user-visible error when data.json load fails (_staticSearchIndex===false)."""
+    """runSearch must retry and show a user-visible message when data.json load fails (_staticSearchIndex===false)."""
     output = tmp_path / "site"
     generate(workspace, output)
     html = (output / "index.html").read_text()
     assert (
         "_staticSearchIndex = false" in html
     ), "_loadStaticSearchIndex must set false sentinel on failure"
+    # false is now handled in the combined null||false branch that auto-retries
     assert "_staticSearchIndex === false" in html, "runSearch must branch on false sentinel"
     assert (
-        "Search unavailable" in html
-    ), "user must see an error message when static index load failed"
+        "Retrying search index" in html
+    ), "user must see a retry message when static index load failed"
 
 
 def test_static_search_selfheal_retrigger(workspace: Path, tmp_path: Path):

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4046,7 +4046,6 @@ def test_search_button_always_present(workspace: Path, tmp_path: Path):
     assert 'id="search-btn"' in html, "Search button must always be in the HTML"
 
 
-
 def test_static_search_haystack_includes_source(workspace: Path, tmp_path: Path):
     """_clientSearch haystack must include item.source so source-filtered search works."""
     output = tmp_path / "site"
@@ -5166,13 +5165,11 @@ def test_static_index_not_fetched_until_user_searches(workspace: Path, tmp_path:
             # First search intent must pull the index in and then find the fixture.
             page.evaluate("() => openSearch()")
             page.fill("#global-search-input", "ZebraLazyIndexFixture")
-            page.wait_for_selector(
-                "#search-results-area a", state="attached", timeout=15000
-            )
+            page.wait_for_selector("#search-results-area a", state="attached", timeout=15000)
 
-            assert [u for u in requested if u.endswith("data.json")], (
-                f"data.json was never fetched on search intent (requests: {requested})"
-            )
+            assert [
+                u for u in requested if u.endswith("data.json")
+            ], f"data.json was never fetched on search intent (requests: {requested})"
             href = page.get_attribute("#search-results-area a", "href")
             assert href and "zebra-lazy-index-fixture" in href, href
             browser.close()

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4121,6 +4121,16 @@ def test_static_search_failed_load_no_infinite_retry(workspace: Path, tmp_path: 
         "with Array.isArray(_staticSearchIndex) to prevent infinite retry loops when "
         "the fetch fails (sets _staticSearchIndex=false and clears the promise)."
     )
+    # Also verify there is an else branch for the failure case (=== false) that
+    # shows a definitive error message so the user isn't stuck on "Retrying…" forever.
+    assert "_staticSearchIndex === false" in callback_body, (
+        "The .then() callback must handle the failure case (_staticSearchIndex === false) "
+        "with a definitive error message, not just silence after the retry fails."
+    )
+    assert "Search unavailable" in callback_body, (
+        "The .then() failure branch must display 'Search unavailable' so the user knows "
+        "the retry also failed (not 'Retrying…' indefinitely)."
+    )
 
 
 def test_static_search_selfheal_retrigger(workspace: Path, tmp_path: Path):

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4103,6 +4103,26 @@ def test_static_search_failed_load_sentinel(workspace: Path, tmp_path: Path):
     ), "user must see a retry message when static index load failed"
 
 
+def test_static_search_failed_load_no_infinite_retry(workspace: Path, tmp_path: Path):
+    """After a failed data.json load, the .then() callback must NOT call runSearch
+    unconditionally — doing so creates an infinite retry loop because _staticSearchIndex
+    stays false and _staticSearchIndexPromise is cleared, so each runSearch call
+    re-triggers _loadStaticSearchIndex immediately.  The guard must be Array.isArray."""
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    # Find the .then() callback attached to _loadStaticSearchIndex()
+    then_idx = html.index("_loadStaticSearchIndex().then(")
+    # There must be an Array.isArray guard before runSearch inside that callback
+    close_then_idx = html.index("});", then_idx)
+    callback_body = html[then_idx:close_then_idx]
+    assert "Array.isArray(_staticSearchIndex)" in callback_body, (
+        "The .then() callback after _loadStaticSearchIndex() must guard runSearch "
+        "with Array.isArray(_staticSearchIndex) to prevent infinite retry loops when "
+        "the fetch fails (sets _staticSearchIndex=false and clears the promise)."
+    )
+
+
 def test_static_search_selfheal_retrigger(workspace: Path, tmp_path: Path):
     """initDynamic must re-trigger runSearch if overlay is open when API probe completes."""
     output = tmp_path / "site"

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -5085,3 +5085,94 @@ def test_tasks_index_not_overwritten_by_index_task(workspace: Path, tmp_path: Pa
         "tasks/index.html was overwritten by index.md detail page — "
         "scan_tasks must exclude index.md"
     )
+
+
+def test_static_index_not_fetched_until_user_searches(workspace: Path, tmp_path: Path):
+    """data.json must not be fetched during page load on a static deploy.
+
+    It is multi-MB on real workspaces (3.2 MB / 790 KiB gzipped for Bob's), so
+    fetching it eagerly blows the cold-load transfer budget for every visitor
+    who never searches. It must load on first search intent instead, and search
+    must still work once it lands.
+    """
+    import functools
+    import http.server
+    import socketserver
+    import threading
+
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import sync_playwright  # noqa: PLC0415
+
+    tasks_dir = workspace / "tasks"
+    tasks_dir.mkdir(exist_ok=True)
+    (tasks_dir / "zebra-lazy-index-fixture.md").write_text(
+        textwrap.dedent(
+            """\
+            ---
+            state: active
+            created: 2026-03-01
+            ---
+            # ZebraLazyIndexFixture
+
+            Searchable fixture for the lazy static-index test.
+            """
+        )
+    )
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+    generate_json(workspace, output)
+
+    prefix = "/dashboard/"
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def translate_path(self, path: str) -> str:
+            clean = path.split("?", 1)[0].split("#", 1)[0]
+            if clean.startswith(prefix):
+                clean = clean[len(prefix) - 1 :]
+            return str(output) + clean
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    socketserver.TCPServer.allow_reuse_address = True
+    server = socketserver.TCPServer(
+        ("127.0.0.1", 0), functools.partial(Handler, directory=str(output))
+    )
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        with sync_playwright() as pw:
+            try:
+                browser = pw.chromium.launch()
+            except Exception as exc:  # no browser binaries installed
+                pytest.skip(f"chromium unavailable: {exc}")
+            page = browser.new_page()
+            requested: list[str] = []
+            page.on("request", lambda r: requested.append(r.url))
+
+            page.goto(f"http://127.0.0.1:{port}{prefix}index.html", wait_until="load")
+            # Give initDynamic()'s /api/status probe time to fail and settle.
+            page.wait_for_timeout(1500)
+
+            assert not [u for u in requested if u.endswith("data.json")], (
+                "data.json was fetched during page load; it must be deferred until "
+                f"the user searches (requests: {requested})"
+            )
+
+            # First search intent must pull the index in and then find the fixture.
+            page.evaluate("() => openSearch()")
+            page.fill("#global-search-input", "ZebraLazyIndexFixture")
+            page.wait_for_selector(
+                "#search-results-area a", state="attached", timeout=15000
+            )
+
+            assert [u for u in requested if u.endswith("data.json")], (
+                f"data.json was never fetched on search intent (requests: {requested})"
+            )
+            href = page.get_attribute("#search-results-area a", "href")
+            assert href and "zebra-lazy-index-fixture" in href, href
+            browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4024,20 +4024,18 @@ def test_static_search_js_present(workspace: Path, tmp_path: Path):
 
 
 def test_static_search_initdynamic_sets_api_flag(workspace: Path, tmp_path: Path):
-    """initDynamic's catch block must set _apiAvailable=false then await _loadStaticSearchIndex."""
+    """initDynamic's catch block must switch to static mode without loading data."""
     output = tmp_path / "site"
     generate(workspace, output)
     html = (output / "index.html").read_text()
+    body = _extract_js_function(html, "initDynamic")
 
-    # Verify the catch block inside initDynamic (identified by its comment) contains both
-    # assignments — not just that the strings appear somewhere in the file.
-    catch_block = re.compile(
-        r"catch\s*\(e\)\s*\{[^}]*No backend[^}]*_apiAvailable\s*=\s*false[^}]*await\s+_loadStaticSearchIndex\(\)",
+    assert re.search(
+        r"catch\s*\(e\)\s*\{[^}]*No backend[^}]*_apiAvailable\s*=\s*false",
+        body,
         re.DOTALL,
-    )
-    assert catch_block.search(
-        html
-    ), "initDynamic catch block must set _apiAvailable=false and await _loadStaticSearchIndex()"
+    ), "initDynamic catch block must set _apiAvailable=false"
+    assert "_loadStaticSearchIndex" not in body
 
 
 def test_search_button_always_present(workspace: Path, tmp_path: Path):
@@ -4047,19 +4045,6 @@ def test_search_button_always_present(workspace: Path, tmp_path: Path):
     html = (output / "index.html").read_text()
     assert 'id="search-btn"' in html, "Search button must always be in the HTML"
 
-
-def test_static_search_initdynamic_awaits_load(workspace: Path, tmp_path: Path):
-    """_loadStaticSearchIndex must be awaited in BOTH failure paths of initDynamic."""
-    output = tmp_path / "site"
-    generate(workspace, output)
-    html = (output / "index.html").read_text()
-    # Both the !resp.ok and catch branches in initDynamic must await the loader —
-    # a single occurrence would mean one branch was missed.
-    count = html.count("await _loadStaticSearchIndex()")
-    assert count >= 2, (
-        f"initDynamic must await _loadStaticSearchIndex() in BOTH failure branches "
-        f"(!resp.ok and catch), found only {count} occurrence(s)"
-    )
 
 
 def test_static_search_haystack_includes_source(workspace: Path, tmp_path: Path):
@@ -4137,12 +4122,7 @@ def test_static_search_selfheal_retrigger(workspace: Path, tmp_path: Path):
 
 
 def test_static_search_null_static_index_shows_loading(workspace: Path, tmp_path: Path):
-    """runSearch must show 'Loading' when _apiAvailable===false but _staticSearchIndex===null.
-
-    Race window: _apiAvailable is set to false synchronously before _loadStaticSearchIndex
-    resolves. A 250 ms debounce can fire runSearch into the _apiAvailable===false branch
-    while the index is still null, producing misleading "No results".
-    """
+    """runSearch must show 'Loading' while the lazy static index loads."""
     output = tmp_path / "site"
     generate(workspace, output)
     html = (output / "index.html").read_text()
@@ -4281,6 +4261,29 @@ def _extract_js_function(html: str, name: str) -> str:
             if depth == 0:
                 return html[start : i + 1]
     raise ValueError(f"Unclosed function {name!r} found in HTML")
+
+
+def test_static_search_initdynamic_does_not_load_index(workspace: Path, tmp_path: Path):
+    """initDynamic must NOT load the static index — data.json is deferred to search intent.
+
+    Both failure paths (``!resp.ok`` and ``catch``) still have to flip
+    ``_apiAvailable`` to false so runSearch takes the client-side branch, but
+    neither may pull data.json: it is multi-MB on real workspaces and would be
+    paid by every visitor who never searches.
+    """
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    body = _extract_js_function(html, "initDynamic")
+
+    assert "_loadStaticSearchIndex" not in body, (
+        "initDynamic must not load the static search index at page load; "
+        "openSearch()/runSearch() load it on first user intent"
+    )
+    assert body.count("_apiAvailable = false") >= 2, (
+        "both initDynamic failure branches (!resp.ok and catch) must set "
+        "_apiAvailable = false so runSearch uses the client-side index"
+    )
 
 
 def test_static_safeurl_rejects_protocol_relative(workspace: Path, tmp_path: Path):


### PR DESCRIPTION
## Problem

On a static deploy (GitHub Pages, any subpath), `initDynamic()` probes `/api/status`,
gets a 404, and then **eagerly fetches `data.json`** to build the client-side search
index. On a real workspace that file is multi-megabyte, so every visitor paid the
full download at page load — including everyone who never opens search.

## Measurement

Bob's workspace, generated site served under `/dashboard/`, headless chromium,
bytes received **before any user interaction**:

| | cold load | responses |
|---|---|---|
| before | **4,486,299 B (4,381 KiB)** | `index.html` 1.25 MB + `data.json` 3.23 MB |
| after | **1,257,420 B (1,228 KiB)** | `index.html` only |

Gzipped (what a real server sends): **~937 KiB → ~148 KiB**.

## Change

`data.json` now loads on first *search intent*:

- `openSearch()` starts the fetch when the overlay opens, so the first keystroke
  does not wait on the network.
- `runSearch()` starts it (and re-runs itself once it resolves) if the user typed
  before it landed — the existing "Loading search index…" placeholder covers the gap.
- Concurrent callers share one in-flight promise. The old
  `if (_staticSearchIndex !== null) return` guard was checked before any `await`,
  so two same-tick callers both issued a fetch.

`initDynamic()` still sets `_apiAvailable = false` in both failure branches, so
`runSearch()` takes the client-side path exactly as before.

## Tests

- New playwright regression `test_static_index_not_fetched_until_user_searches`:
  asserts `data.json` is **not** requested during page load, **is** requested on
  search intent, and the fixture task is still findable with a correct href.
  Verified RED on the unpatched template, GREEN with the fix.
- The two `initDynamic` shape tests encoded the eager contract. They now assert the
  lazy one: both failure branches set `_apiAvailable = false`, and `initDynamic`'s
  body contains no `_loadStaticSearchIndex` call at all.
- Full package suite: 403 passed, 2 skipped.

## Context

Closes acceptance criterion A5 of Bob's dashboard subpath task (cold-load transfer
bounded, search still reachable through an explicit lazy path). Follows
#1585 / #1592 / #1594 / #1595 in the same series.