### PR TITLE
fix(gptme-dashboard): generate tasks/index.html for the 'Browse all N tasks' link

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -2105,10 +2105,15 @@ def generate(
                 task["title"],
             ),
         )
-        task_groups = [
-            {"state": state, "state_slug": slugify_heading(state), "tasks": list(group)}
-            for state, group in groupby(grouped_tasks, key=lambda task: task["state"])
-        ]
+        task_groups = []
+        state_slug_counts: dict[str, int] = {}
+        for state, group in groupby(grouped_tasks, key=lambda task: task["state"]):
+            state_slug = slugify_heading(state)
+            duplicate_index = state_slug_counts.get(state_slug, 0)
+            state_slug_counts[state_slug] = duplicate_index + 1
+            if duplicate_index:
+                state_slug = f"{state_slug}-{duplicate_index}"
+            task_groups.append({"state": state, "state_slug": state_slug, "tasks": list(group)})
         tasks_index_html = tasks_index_template.render(
             workspace_name=data["workspace_name"],
             tasks=data["tasks"],

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -21,6 +21,7 @@ import re
 import subprocess
 import sys
 from datetime import date, datetime, timedelta, timezone
+from itertools import groupby
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -2088,6 +2089,27 @@ def generate(
         page_path = output / task["page_url"]
         page_path.parent.mkdir(parents=True, exist_ok=True)
         page_path.write_text(task_html)
+
+    # Generate the full task listing at tasks/index.html.
+    # The dashboard index links here ("Browse all N tasks") because its own listing
+    # omits terminal tasks; without this page that link is a broken static target.
+    if data["tasks"]:
+        tasks_index_template = env.get_template("tasks_index.html")
+        # data["tasks"] is already sorted by (_STATE_ORDER, title), so grouping
+        # consecutively preserves the same state ordering used everywhere else.
+        task_groups = [
+            {"state": state, "tasks": list(group)}
+            for state, group in groupby(data["tasks"], key=lambda t: t["state"])
+        ]
+        tasks_index_html = tasks_index_template.render(
+            workspace_name=data["workspace_name"],
+            tasks=data["tasks"],
+            task_groups=task_groups,
+            root_prefix="../",
+        )
+        tasks_index_path = output / "tasks" / "index.html"
+        tasks_index_path.parent.mkdir(parents=True, exist_ok=True)
+        tasks_index_path.write_text(tasks_index_html)
 
     # Generate per-journal detail pages
     journal_template = env.get_template("journal.html")

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -814,7 +814,7 @@ def scan_tasks(workspace: Path) -> list[dict]:
 
     if _gptodo_load_tasks is not None:
         for t in _gptodo_load_tasks(tasks_dir):
-            if t.path.name.lower() == "readme.md":
+            if t.path.name.lower() in ("readme.md", "index.md"):
                 continue
             if not t.metadata:
                 continue  # Skip files without YAML frontmatter
@@ -863,7 +863,7 @@ def scan_tasks(workspace: Path) -> list[dict]:
     else:
         # gptodo not installed — fall back to manual frontmatter parsing
         for md_file in sorted(tasks_dir.glob("*.md")):
-            if md_file.name.lower() == "readme.md":
+            if md_file.name.lower() in ("readme.md", "index.md"):
                 continue
             entry = _task_to_dict(md_file)
             if entry is not None:

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -2106,13 +2106,15 @@ def generate(
             ),
         )
         task_groups = []
-        state_slug_counts: dict[str, int] = {}
+        used_state_slugs: set[str] = set()
         for state, group in groupby(grouped_tasks, key=lambda task: task["state"]):
-            state_slug = slugify_heading(state)
-            duplicate_index = state_slug_counts.get(state_slug, 0)
-            state_slug_counts[state_slug] = duplicate_index + 1
-            if duplicate_index:
-                state_slug = f"{state_slug}-{duplicate_index}"
+            base_slug = slugify_heading(state)
+            state_slug = base_slug
+            duplicate_index = 1
+            while state_slug in used_state_slugs:
+                state_slug = f"{base_slug}-{duplicate_index}"
+                duplicate_index += 1
+            used_state_slugs.add(state_slug)
             task_groups.append({"state": state, "state_slug": state_slug, "tasks": list(group)})
         tasks_index_html = tasks_index_template.render(
             workspace_name=data["workspace_name"],

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -2095,11 +2095,19 @@ def generate(
     # omits terminal tasks; without this page that link is a broken static target.
     if data["tasks"]:
         tasks_index_template = env.get_template("tasks_index.html")
-        # data["tasks"] is already sorted by (_STATE_ORDER, title), so grouping
-        # consecutively preserves the same state ordering used everywhere else.
+        # Include the state in the local sort key so custom states (which all share
+        # the fallback order) stay contiguous for groupby.
+        grouped_tasks = sorted(
+            data["tasks"],
+            key=lambda task: (
+                _STATE_ORDER.get(task["state"], 99),
+                task["state"],
+                task["title"],
+            ),
+        )
         task_groups = [
             {"state": state, "state_slug": slugify_heading(state), "tasks": list(group)}
-            for state, group in groupby(data["tasks"], key=lambda t: t["state"])
+            for state, group in groupby(grouped_tasks, key=lambda task: task["state"])
         ]
         tasks_index_html = tasks_index_template.render(
             workspace_name=data["workspace_name"],

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -2098,7 +2098,7 @@ def generate(
         # data["tasks"] is already sorted by (_STATE_ORDER, title), so grouping
         # consecutively preserves the same state ordering used everywhere else.
         task_groups = [
-            {"state": state, "tasks": list(group)}
+            {"state": state, "state_slug": slugify_heading(state), "tasks": list(group)}
             for state, group in groupby(data["tasks"], key=lambda t: t["state"])
         ]
         tasks_index_html = tasks_index_template.render(

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/tasks_index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/tasks_index.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+
+{% block title %}All tasks - {{ workspace_name }}{% endblock %}
+
+{% block extra_style %}
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.breadcrumb {
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  margin-bottom: 1.5rem;
+}
+.breadcrumb a { color: var(--accent); }
+
+header h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.state-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+.state-nav a {
+  font-size: 0.8rem;
+  padding: 0.15em 0.6em;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-dim);
+}
+.state-nav a:hover { color: var(--accent); border-color: var(--accent); text-decoration: none; }
+
+.state-group { margin-bottom: 2rem; }
+.state-group h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+.state-group h2 .count-badge { color: var(--text-dim); font-weight: 400; font-size: 0.85rem; }
+
+ul.task-list { list-style: none; margin: 0; padding: 0; }
+ul.task-list li {
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border);
+  /* wrap rather than overflow: the 390px viewport must not scroll sideways */
+  overflow-wrap: anywhere;
+}
+ul.task-list li:last-child { border-bottom: none; }
+.task-line { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: baseline; }
+.task-line .meta { font-size: 0.8rem; color: var(--text-dim); }
+{% endblock %}
+
+{% block content %}
+<nav class="breadcrumb">
+  <a href="{{ root_prefix }}index.html">{{ workspace_name }}</a>
+  &rsaquo; <a href="{{ root_prefix }}index.html#tasks">Tasks</a>
+  &rsaquo; All tasks
+</nav>
+
+<header>
+  <h1>All tasks <span class="count-badge">({{ tasks | length }})</span></h1>
+  <p class="meta">Every task in the workspace, including completed and cancelled ones. The
+    <a href="{{ root_prefix }}index.html#tasks">dashboard listing</a> shows only open tasks.</p>
+  <div class="state-nav">
+    {% for group in task_groups %}<a href="#state-{{ group.state }}">{{ group.state }} ({{ group.tasks | length }})</a>{% endfor %}
+  </div>
+</header>
+
+{% for group in task_groups %}
+<section class="state-group" id="state-{{ group.state }}">
+  <h2>{{ group.state }} <span class="count-badge">({{ group.tasks | length }})</span></h2>
+  <ul class="task-list">
+    {% for task in group.tasks %}
+    <li>
+      <div class="task-line">
+        <a href="{{ root_prefix }}{{ task.page_url }}">{{ task.title }}</a>
+        {% if task.priority %}<span class="tag {% if task.priority == 'high' %}tag-active{% endif %}">{{ task.priority }}</span>{% endif %}
+        {% for t in task.tags %}<span class="tag tag-category">{{ t }}</span>{% endfor %}
+        {% if task.assigned_to %}<span class="meta">{{ task.assigned_to }}</span>{% endif %}
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endfor %}
+{% endblock %}

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/tasks_index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/tasks_index.html
@@ -71,12 +71,12 @@ ul.task-list li:last-child { border-bottom: none; }
   <p class="meta">Every task in the workspace, including completed and cancelled ones. The
     <a href="{{ root_prefix }}index.html#tasks">dashboard listing</a> shows only open tasks.</p>
   <div class="state-nav">
-    {% for group in task_groups %}<a href="#state-{{ group.state }}">{{ group.state }} ({{ group.tasks | length }})</a>{% endfor %}
+    {% for group in task_groups %}<a href="#state-{{ group.state_slug }}">{{ group.state }} ({{ group.tasks | length }})</a>{% endfor %}
   </div>
 </header>
 
 {% for group in task_groups %}
-<section class="state-group" id="state-{{ group.state }}">
+<section class="state-group" id="state-{{ group.state_slug }}">
   <h2>{{ group.state }} <span class="count-badge">({{ group.tasks | length }})</span></h2>
   <ul class="task-list">
     {% for task in group.tasks %}

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -5008,6 +5008,9 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     (tasks_dir / "old-thing.md").write_text(
         "---\nstate: done\ncreated: 2026-01-01\n---\n# Old Thing\n"
     )
+    (tasks_dir / "custom-state.md").write_text(
+        "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Custom State\n"
+    )
 
     output = tmp_path / "site"
     generate(workspace, output)
@@ -5021,6 +5024,9 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     # Terminal tasks are excluded from the dashboard listing but must appear here.
     assert "Old Thing" in html
     assert "Build Feature" in html
+    assert 'href="#state-in-progress"' in html
+    assert 'id="state-in-progress"' in html
+    assert 'id="state-in progress?!"' not in html
     # Links are root-relative from tasks/, i.e. one level up then back down.
     assert 'href="../tasks/old-thing.html"' in html
     assert (output / "tasks" / "old-thing.html").exists()

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -5008,8 +5008,14 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     (tasks_dir / "old-thing.md").write_text(
         "---\nstate: done\ncreated: 2026-01-01\n---\n# Old Thing\n"
     )
-    (tasks_dir / "custom-state.md").write_text(
-        "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Custom State\n"
+    (tasks_dir / "custom-state-a.md").write_text(
+        "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Alpha Custom State\n"
+    )
+    (tasks_dir / "other-custom-state.md").write_text(
+        "---\nstate: blocked externally\ncreated: 2026-02-01\n---\n# Beta Custom State\n"
+    )
+    (tasks_dir / "custom-state-z.md").write_text(
+        "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Gamma Custom State\n"
     )
 
     output = tmp_path / "site"
@@ -5024,9 +5030,12 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     # Terminal tasks are excluded from the dashboard listing but must appear here.
     assert "Old Thing" in html
     assert "Build Feature" in html
-    assert 'href="#state-in-progress"' in html
-    assert 'id="state-in-progress"' in html
+    assert html.count('href="#state-in-progress"') == 1
+    assert html.count('id="state-in-progress"') == 1
     assert 'id="state-in progress?!"' not in html
+    in_progress_section = html.split('id="state-in-progress"', 1)[1].split("</section>", 1)[0]
+    assert "Alpha Custom State" in in_progress_section
+    assert "Gamma Custom State" in in_progress_section
     # Links are root-relative from tasks/, i.e. one level up then back down.
     assert 'href="../tasks/old-thing.html"' in html
     assert (output / "tasks" / "old-thing.html").exists()

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4992,3 +4992,42 @@ def test_index_html_no_filter_note_when_all_nonterminal(
     html = (out / "index.html").read_text()
     # No terminal tasks → no filter note paragraph (the CSS class may still exist in <style>)
     assert '<p class="filter-note">' not in html
+
+
+def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
+    """The 'Browse all N tasks' link target (tasks/index.html) is generated.
+
+    The dashboard index omits terminal tasks from its listing and links to
+    tasks/ instead; without this page that link is a broken static target.
+    """
+    tasks_dir = workspace / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "build-feature.md").write_text(
+        "---\nstate: active\npriority: high\ncreated: 2026-03-01\n---\n# Build Feature\n"
+    )
+    (tasks_dir / "old-thing.md").write_text(
+        "---\nstate: done\ncreated: 2026-01-01\n---\n# Old Thing\n"
+    )
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+
+    index_html = (output / "index.html").read_text()
+    assert 'href="tasks/"' in index_html, "index should link to the full task listing"
+
+    tasks_index = output / "tasks" / "index.html"
+    assert tasks_index.exists()
+    html = tasks_index.read_text()
+    # Terminal tasks are excluded from the dashboard listing but must appear here.
+    assert "Old Thing" in html
+    assert "Build Feature" in html
+    # Links are root-relative from tasks/, i.e. one level up then back down.
+    assert 'href="../tasks/old-thing.html"' in html
+    assert (output / "tasks" / "old-thing.html").exists()
+
+
+def test_generate_skips_tasks_index_without_tasks(workspace: Path, tmp_path: Path):
+    """No tasks means no tasks/ directory to index."""
+    output = tmp_path / "site"
+    generate(workspace, output)
+    assert not (output / "tasks" / "index.html").exists()

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -5017,6 +5017,9 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     (tasks_dir / "custom-state-z.md").write_text(
         "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Gamma Custom State\n"
     )
+    (tasks_dir / "suffix-collision.md").write_text(
+        "---\nstate: in-progress-1\ncreated: 2026-02-01\n---\n# Suffix Collision State\n"
+    )
 
     output = tmp_path / "site"
     generate(workspace, output)
@@ -5034,6 +5037,8 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     assert html.count('id="state-in-progress"') == 1
     assert html.count('href="#state-in-progress-1"') == 1
     assert html.count('id="state-in-progress-1"') == 1
+    assert html.count('href="#state-in-progress-1-1"') == 1
+    assert html.count('id="state-in-progress-1-1"') == 1
     assert 'id="state-in progress?!"' not in html
     in_progress_section = html.split('id="state-in-progress"', 1)[1].split("</section>", 1)[0]
     assert "Alpha Custom State" in in_progress_section

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -5012,7 +5012,7 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
         "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Alpha Custom State\n"
     )
     (tasks_dir / "other-custom-state.md").write_text(
-        "---\nstate: blocked externally\ncreated: 2026-02-01\n---\n# Beta Custom State\n"
+        "---\nstate: in-progress\ncreated: 2026-02-01\n---\n# Beta Custom State\n"
     )
     (tasks_dir / "custom-state-z.md").write_text(
         "---\nstate: in progress?!\ncreated: 2026-02-01\n---\n# Gamma Custom State\n"
@@ -5032,6 +5032,8 @@ def test_generate_writes_tasks_index_page(workspace: Path, tmp_path: Path):
     assert "Build Feature" in html
     assert html.count('href="#state-in-progress"') == 1
     assert html.count('id="state-in-progress"') == 1
+    assert html.count('href="#state-in-progress-1"') == 1
+    assert html.count('id="state-in-progress-1"') == 1
     assert 'id="state-in progress?!"' not in html
     in_progress_section = html.split('id="state-in-progress"', 1)[1].split("</section>", 1)[0]
     assert "Alpha Custom State" in in_progress_section

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -5031,3 +5031,35 @@ def test_generate_skips_tasks_index_without_tasks(workspace: Path, tmp_path: Pat
     output = tmp_path / "site"
     generate(workspace, output)
     assert not (output / "tasks" / "index.html").exists()
+
+
+def test_tasks_index_not_overwritten_by_index_task(workspace: Path, tmp_path: Path):
+    """A task named index.md must not overwrite the tasks/index.html listing.
+
+    task_page_path("index") == "tasks/index.html", which collides with the
+    tasks index listing page.  scan_tasks must skip index.md (like readme.md)
+    so the listing page is never clobbered.
+    """
+    tasks_dir = workspace / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "index.md").write_text(
+        "---\nstate: active\ncreated: 2026-01-01\n---\n# Index Task\n"
+    )
+    (tasks_dir / "normal-task.md").write_text(
+        "---\nstate: active\ncreated: 2026-01-01\n---\n# Normal Task\n"
+    )
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+
+    tasks_index = output / "tasks" / "index.html"
+    assert tasks_index.exists(), "tasks/index.html must exist"
+    html = tasks_index.read_text()
+    # The listing page must contain the normal task, not the index task's detail.
+    assert "Normal Task" in html
+    # The tasks listing page must not be overwritten by the index.md detail page.
+    # If it were, it would be a plain detail page lacking the state-group nav.
+    assert "Index Task" not in html, (
+        "tasks/index.html was overwritten by index.md detail page — "
+        "scan_tasks must exclude index.md"
+    )


### PR DESCRIPTION
## Problem

The dashboard index omits terminal (`done`/`cancelled`) tasks from its listing and renders

```html
<a href="tasks/">Browse all 1591 tasks →</a>
```

…but the generator never wrote `tasks/index.html` — task pages are flat `tasks/<slug>.html`. That link was the **last remaining broken static target** in the generated `/dashboard/` subtree (5,036 → 2,436 → 1 over gptme/gptme-contrib#1592/#1594/#1595/#1596 plus the checker/stale-artifact fixes on the Bob side).

Reproduced first, against the live tree:

```
[ERROR] dashboard (dashboard/index.html): broken link: tasks/
inventory=17 pages=2801 links=28044 errors=1 warnings=1
```

## Change

- New `templates/tasks_index.html`: every task grouped by state, using the same `_STATE_ORDER` the rest of the dashboard uses, with per-state anchors and a jump nav. Layout wraps (`flex-wrap`, `overflow-wrap: anywhere`) rather than overflowing, so the 390px viewport stays scroll-free.
- `generate()` writes `tasks/index.html` whenever the workspace has tasks. `data["tasks"]` is already sorted by `(_STATE_ORDER, title)`, so consecutive `groupby` preserves that ordering.
- Two regression tests: terminal tasks appear on the listing page and link correctly one level up; no tasks means no page.

## Verification

Real build of Bob's workspace (1,591 tasks, 2,715 pages) staged under a real vitals root and crawled with the supported full-tree checker:

```
[WARNING] decisions (/decisions/): dynamic route not crawled
inventory=17 pages=2715 links=28942 errors=0 warnings=1
```

**1 error → 0 errors, 0 broken anchors.**

- `pytest tests/` — 421 passed, 1 skipped
- `mypy src/ --ignore-missing-imports` — clean
- `ruff@0.6.9 check` / `format --check` on the changed files — clean

Page weight for a 1,591-task workspace is 744 KB uncompressed (~470 B/task); this is a user-directed drill-down, not part of the cold load that gptme/gptme-contrib#1597 bounded.