### PR TITLE
fix(gptme-sessions): follow-up fixes for #1565 ai-reviewer findings

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -748,6 +748,19 @@ class SessionRecord:
                 continue
             _remember_commit_id(commit_ids, commit_id)
 
+        # How many merge_commits have gh_pr_merge evidence?  Each one can "cover"
+        # exactly one gh_pr_merge PR text entry, preventing double-counting.
+        # Using a budget counter instead of a blanket any() avoids the multi-PR
+        # edge case: N PRs merged with M < N merge_commits recorded would drop
+        # all N PRs under the old any() test, under-counting by N-M deliveries.
+        _gh_pr_merge_commit_budget = sum(
+            1
+            for d in dd
+            if d.get("kind") == "merge_commit"
+            and isinstance(d.get("evidence"), dict)
+            and d["evidence"].get("action") == "gh_pr_merge"
+        )
+
         pr_ids: list[str] = []
         for detail in dd:
             if detail.get("kind") != "pull_request":
@@ -755,12 +768,8 @@ class SessionRecord:
             evidence = detail.get("evidence")
             action = evidence.get("action") if isinstance(evidence, dict) else None
             evidence_sha = evidence.get("commit_sha") if isinstance(evidence, dict) else None
-            if action == "gh_pr_merge" and any(
-                isinstance(commit_detail.get("evidence"), dict)
-                and commit_detail["evidence"].get("action") == "gh_pr_merge"
-                for commit_detail in dd
-                if commit_detail.get("kind") == "merge_commit"
-            ):
+            if action == "gh_pr_merge" and _gh_pr_merge_commit_budget > 0:
+                _gh_pr_merge_commit_budget -= 1
                 continue
             if isinstance(evidence_sha, str):
                 normalized_sha = _commit_identity(evidence_sha)

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -278,32 +278,20 @@ def _pr_identity(value: object) -> str:
     return stripped.lower()
 
 
-def _remember_pr_id(pr_ids: list[str], pr_id: str) -> None:
-    """Record a PR identity, merging ``#N`` with ``owner/repo#N``.
+def _remember_pr_id(pr_ids: list[str], pr_id: str, *, may_alias_qualified: bool = False) -> None:
+    """Record a PR identity without guessing across repositories.
 
-    Caller URLs normalize to ``owner/repo#N``; trajectory text like
-    ``merge PR #N`` normalizes to ``#N``. Those are the same delivery when
-    merge-SHA resolution failed and both producers recorded the PR.
-    Distinct qualified identities with the same number stay distinct.
+    A qualified ``owner/repo#N`` and unqualified ``#N`` may only be merged when
+    producer evidence says the unqualified value came from ``gh pr merge``.
+    Otherwise they can represent same-numbered PRs in different repositories.
     """
-    if "#" not in pr_id:
-        if pr_id not in pr_ids:
-            pr_ids.append(pr_id)
+    if pr_id in pr_ids:
         return
-    number = pr_id.rsplit("#", 1)[-1]
-    qualified = not pr_id.startswith("#")
-    for i, known in enumerate(pr_ids):
-        if "#" not in known:
-            continue
-        if known.rsplit("#", 1)[-1] != number:
-            continue
-        known_qualified = not known.startswith("#")
-        if known == pr_id:
-            return
-        if not qualified and known_qualified:
-            return
-        if qualified and not known_qualified:
-            pr_ids[i] = pr_id
+    if may_alias_qualified and pr_id.startswith("#"):
+        number = pr_id[1:]
+        if any(
+            not known.startswith("#") and known.rsplit("#", 1)[-1] == number for known in pr_ids
+        ):
             return
     pr_ids.append(pr_id)
 
@@ -745,8 +733,8 @@ class SessionRecord:
 
         # Delivery patterns (from deliverable_details). Commit details can be
         # duplicated across trajectory and caller producers. Prefer unique SHA
-        # identities; identical identity-less values also count once. PRs are
-        # commit-bearing fallback evidence only when no commit detail exists.
+        # identities; identical identity-less values also count once. A PR is
+        # metadata only when its evidence ties it to one of those commits.
         dd = self.deliverable_details or []
         commit_ids: list[str] = []
         anonymous_commit_values: set[str] = set()
@@ -760,14 +748,36 @@ class SessionRecord:
                 continue
             _remember_commit_id(commit_ids, commit_id)
 
-        commit_count = len(commit_ids) + len(anonymous_commit_values)
-        if commit_count == 0:
-            pr_ids: list[str] = []
-            for detail in dd:
-                if detail.get("kind") != "pull_request":
+        pr_ids: list[str] = []
+        for detail in dd:
+            if detail.get("kind") != "pull_request":
+                continue
+            evidence = detail.get("evidence")
+            action = evidence.get("action") if isinstance(evidence, dict) else None
+            evidence_sha = evidence.get("commit_sha") if isinstance(evidence, dict) else None
+            if action == "gh_pr_merge" and any(
+                isinstance(commit_detail.get("evidence"), dict)
+                and commit_detail["evidence"].get("action") == "gh_pr_merge"
+                for commit_detail in dd
+                if commit_detail.get("kind") == "merge_commit"
+            ):
+                continue
+            if isinstance(evidence_sha, str):
+                normalized_sha = _commit_identity(evidence_sha)
+                if normalized_sha is not None and any(
+                    normalized_sha.startswith(commit_id) or commit_id.startswith(normalized_sha)
+                    for commit_id in commit_ids
+                ):
                     continue
-                _remember_pr_id(pr_ids, _pr_identity(detail.get("value")))
-            commit_count = len(pr_ids)
+            # gh_pr_merge evidence means this text ("merge PR #N") came from an
+            # in-repo merge — allow it to alias a qualified URL for the same number.
+            _remember_pr_id(
+                pr_ids,
+                _pr_identity(detail.get("value")),
+                may_alias_qualified=(action == "gh_pr_merge"),
+            )
+
+        commit_count = len(commit_ids) + len(anonymous_commit_values) + len(pr_ids)
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 
         # Partition on commit cardinality: 0 / 1 / 2+. Two-commit sessions

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -278,20 +278,14 @@ def _pr_identity(value: object) -> str:
     return stripped.lower()
 
 
-def _pr_group_key(identity: str, aliasable_numbers: set[str]) -> str:
+def _pr_group_key(identity: str, aliasable_prs: dict[str, str]) -> str:
     """Canonical grouping key for a PR identity.
 
-    A qualified ``owner/repo#N`` and unqualified ``#N`` only collapse into the
-    same group when producer evidence says *some* detail for PR ``N`` came
-    from ``gh pr merge`` (``aliasable_numbers``) — order-independent, so it
-    doesn't matter whether the qualified or unqualified value was seen first.
-    Otherwise they stay distinct, since same-numbered PRs can live in
-    different repositories.
+    An unqualified ``#N`` aliases to the sole qualified ``owner/repo#N`` with
+    ``gh pr merge`` evidence. Qualified identities always remain distinct, so
+    same-numbered PRs in different repositories cannot collapse.
     """
-    if "#" not in identity:
-        return identity
-    number = identity.rsplit("#", 1)[-1]
-    return f"#{number}" if number in aliasable_numbers else identity
+    return aliasable_prs.get(identity, identity)
 
 
 @dataclass
@@ -750,26 +744,41 @@ class SessionRecord:
         # one gh_pr_merge-evidenced PR, preventing double-counting. A commit
         # explicitly sha-paired to a PR (below) is removed from this pool
         # first, so it can't *also* pay for a different, unrelated PR.
-        gh_pr_merge_commit_ids = [
-            cid
-            for d in dd
-            if d.get("kind") == "merge_commit"
-            and isinstance(d.get("evidence"), dict)
-            and d["evidence"].get("action") == "gh_pr_merge"
-            and (cid := _commit_identity(d.get("value"), kind="merge_commit")) is not None
-        ]
+        gh_pr_merge_commit_ids: list[str] = []
+        for detail in dd:
+            evidence = detail.get("evidence")
+            if (
+                detail.get("kind") != "merge_commit"
+                or not isinstance(evidence, dict)
+                or evidence.get("action") != "gh_pr_merge"
+            ):
+                continue
+            commit_id = _commit_identity(detail.get("value"), kind="merge_commit")
+            if commit_id is not None:
+                _remember_commit_id(gh_pr_merge_commit_ids, commit_id)
 
-        # Numbers with at least one gh_pr_merge-evidenced detail: a qualified
-        # URL and unqualified "#N" for the same number are one delivery
-        # regardless of which one appears first in deliverable_details.
-        aliasable_numbers = {
-            number
-            for d in dd
-            if d.get("kind") == "pull_request"
-            and isinstance(d.get("evidence"), dict)
-            and d["evidence"].get("action") == "gh_pr_merge"
-            and "#" in (identity := _pr_identity(d.get("value")))
-            for number in [identity.rsplit("#", 1)[-1]]
+        # An unqualified "#N" with gh_pr_merge evidence may alias to exactly
+        # one qualified PR with that number. Never alias qualified identities
+        # to each other: same-numbered PRs can belong to different repositories.
+        merge_numbers: set[str] = set()
+        qualified_prs: dict[str, set[str]] = {}
+        for detail in dd:
+            if detail.get("kind") != "pull_request":
+                continue
+            identity = _pr_identity(detail.get("value"))
+            if "#" not in identity:
+                continue
+            number = identity.rsplit("#", 1)[-1]
+            if identity.startswith("#"):
+                evidence = detail.get("evidence")
+                if isinstance(evidence, dict) and evidence.get("action") == "gh_pr_merge":
+                    merge_numbers.add(number)
+            else:
+                qualified_prs.setdefault(number, set()).add(identity)
+        aliasable_prs = {
+            f"#{number}": next(iter(qualified_prs[number]))
+            for number in merge_numbers
+            if len(qualified_prs.get(number, ())) == 1
         }
 
         pr_groups: dict[str, dict[str, bool]] = {}
@@ -779,7 +788,7 @@ class SessionRecord:
             evidence = detail.get("evidence")
             action = evidence.get("action") if isinstance(evidence, dict) else None
             evidence_sha = evidence.get("commit_sha") if isinstance(evidence, dict) else None
-            key = _pr_group_key(_pr_identity(detail.get("value")), aliasable_numbers)
+            key = _pr_group_key(_pr_identity(detail.get("value")), aliasable_prs)
             group = pr_groups.setdefault(key, {"sha_paired": False, "gh_pr_merge": False})
             if action == "gh_pr_merge":
                 group["gh_pr_merge"] = True

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -278,22 +278,20 @@ def _pr_identity(value: object) -> str:
     return stripped.lower()
 
 
-def _remember_pr_id(pr_ids: list[str], pr_id: str, *, may_alias_qualified: bool = False) -> None:
-    """Record a PR identity without guessing across repositories.
+def _pr_group_key(identity: str, aliasable_numbers: set[str]) -> str:
+    """Canonical grouping key for a PR identity.
 
-    A qualified ``owner/repo#N`` and unqualified ``#N`` may only be merged when
-    producer evidence says the unqualified value came from ``gh pr merge``.
-    Otherwise they can represent same-numbered PRs in different repositories.
+    A qualified ``owner/repo#N`` and unqualified ``#N`` only collapse into the
+    same group when producer evidence says *some* detail for PR ``N`` came
+    from ``gh pr merge`` (``aliasable_numbers``) — order-independent, so it
+    doesn't matter whether the qualified or unqualified value was seen first.
+    Otherwise they stay distinct, since same-numbered PRs can live in
+    different repositories.
     """
-    if pr_id in pr_ids:
-        return
-    if may_alias_qualified and pr_id.startswith("#"):
-        number = pr_id[1:]
-        if any(
-            not known.startswith("#") and known.rsplit("#", 1)[-1] == number for known in pr_ids
-        ):
-            return
-    pr_ids.append(pr_id)
+    if "#" not in identity:
+        return identity
+    number = identity.rsplit("#", 1)[-1]
+    return f"#{number}" if number in aliasable_numbers else identity
 
 
 @dataclass
@@ -748,45 +746,66 @@ class SessionRecord:
                 continue
             _remember_commit_id(commit_ids, commit_id)
 
-        # How many merge_commits have gh_pr_merge evidence?  Each one can "cover"
-        # exactly one gh_pr_merge PR text entry, preventing double-counting.
-        # Using a budget counter instead of a blanket any() avoids the multi-PR
-        # edge case: N PRs merged with M < N merge_commits recorded would drop
-        # all N PRs under the old any() test, under-counting by N-M deliveries.
-        _gh_pr_merge_commit_budget = sum(
-            1
+        # merge_commits with gh_pr_merge evidence: each one can "cover" exactly
+        # one gh_pr_merge-evidenced PR, preventing double-counting. A commit
+        # explicitly sha-paired to a PR (below) is removed from this pool
+        # first, so it can't *also* pay for a different, unrelated PR.
+        gh_pr_merge_commit_ids = [
+            cid
             for d in dd
             if d.get("kind") == "merge_commit"
             and isinstance(d.get("evidence"), dict)
             and d["evidence"].get("action") == "gh_pr_merge"
-        )
+            and (cid := _commit_identity(d.get("value"), kind="merge_commit")) is not None
+        ]
 
-        pr_ids: list[str] = []
+        # Numbers with at least one gh_pr_merge-evidenced detail: a qualified
+        # URL and unqualified "#N" for the same number are one delivery
+        # regardless of which one appears first in deliverable_details.
+        aliasable_numbers = {
+            number
+            for d in dd
+            if d.get("kind") == "pull_request"
+            and isinstance(d.get("evidence"), dict)
+            and d["evidence"].get("action") == "gh_pr_merge"
+            and "#" in (identity := _pr_identity(d.get("value")))
+            for number in [identity.rsplit("#", 1)[-1]]
+        }
+
+        pr_groups: dict[str, dict[str, bool]] = {}
         for detail in dd:
             if detail.get("kind") != "pull_request":
                 continue
             evidence = detail.get("evidence")
             action = evidence.get("action") if isinstance(evidence, dict) else None
             evidence_sha = evidence.get("commit_sha") if isinstance(evidence, dict) else None
-            if action == "gh_pr_merge" and _gh_pr_merge_commit_budget > 0:
-                _gh_pr_merge_commit_budget -= 1
-                continue
-            if isinstance(evidence_sha, str):
+            key = _pr_group_key(_pr_identity(detail.get("value")), aliasable_numbers)
+            group = pr_groups.setdefault(key, {"sha_paired": False, "gh_pr_merge": False})
+            if action == "gh_pr_merge":
+                group["gh_pr_merge"] = True
+            if not group["sha_paired"] and isinstance(evidence_sha, str):
                 normalized_sha = _commit_identity(evidence_sha)
                 if normalized_sha is not None and any(
                     normalized_sha.startswith(commit_id) or commit_id.startswith(normalized_sha)
                     for commit_id in commit_ids
                 ):
-                    continue
-            # gh_pr_merge evidence means this text ("merge PR #N") came from an
-            # in-repo merge — allow it to alias a qualified URL for the same number.
-            _remember_pr_id(
-                pr_ids,
-                _pr_identity(detail.get("value")),
-                may_alias_qualified=(action == "gh_pr_merge"),
-            )
+                    group["sha_paired"] = True
+                    for i, gh_cid in enumerate(gh_pr_merge_commit_ids):
+                        if normalized_sha.startswith(gh_cid) or gh_cid.startswith(normalized_sha):
+                            del gh_pr_merge_commit_ids[i]
+                            break
 
-        commit_count = len(commit_ids) + len(anonymous_commit_values) + len(pr_ids)
+        pr_count = 0
+        gh_pr_merge_commit_budget = len(gh_pr_merge_commit_ids)
+        for group in pr_groups.values():
+            if group["sha_paired"]:
+                continue
+            if group["gh_pr_merge"] and gh_pr_merge_commit_budget > 0:
+                gh_pr_merge_commit_budget -= 1
+                continue
+            pr_count += 1
+
+        commit_count = len(commit_ids) + len(anonymous_commit_values) + pr_count
         file_count = sum(1 for d in dd if d.get("kind") == "file")
 
         # Partition on commit cardinality: 0 / 1 / 2+. Two-commit sessions

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -1191,6 +1191,47 @@ def test_step_types_unpaired_pr_plus_commit_is_multi():
     assert "single_commit" not in labels
 
 
+def test_step_types_two_gh_pr_merge_one_commit_is_multi():
+    """Two PRs merged via gh pr merge with only one merge_commit recorded.
+
+    Regression for gptme/gptme-contrib#1599 AI review P1: the old any()-based
+    skip dropped ALL gh_pr_merge PR entries when any merge_commit with
+    gh_pr_merge evidence existed, so 2 PRs + 1 merge_commit → single_commit.
+    The budget counter (skip at most N, where N = number of merge_commits)
+    lets the second PR count as a distinct delivery.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "pull_request",
+                "value": "merge PR #43",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels, f"expected multi_commit, got {labels}"
+    assert "single_commit" not in labels
+
+
 def test_step_types_zero_spans_not_shallow():
     """Zero completed spans must not be coerced into an observed shallow_session.
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -1232,6 +1232,87 @@ def test_step_types_two_gh_pr_merge_one_commit_is_multi():
     assert "single_commit" not in labels
 
 
+def test_step_types_gh_pr_merge_url_and_text_and_commit_is_single():
+    """A qualified URL, gh_pr_merge text, and its merge_commit are one delivery.
+
+    Regression for gptme/gptme-contrib#1599 AI review P1 (round 2): the
+    budget skip ran before PR-identity aliasing, so an unaliased qualified
+    URL for the same PR number was counted separately from the (budget-
+    skipped) gh_pr_merge text, over-counting a single merged PR as two
+    deliveries.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/42",
+            },
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "single_commit" in labels, f"expected single_commit, got {labels}"
+    assert "multi_commit" not in labels
+
+
+def test_step_types_two_gh_pr_merge_prs_one_sha_paired_is_multi():
+    """Two merged PRs, one commit recorded, one explicitly sha-paired.
+
+    Regression for gptme/gptme-contrib#1599 AI review P1 (round 2): the sha
+    match and the gh_pr_merge budget both drew from the same commit without
+    tracking that it had already been spent, so the sha-paired PR's commit
+    could *also* pay for the other, unrelated gh_pr_merge PR — undercounting
+    two real deliveries as one.
+    """
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "pull_request",
+                "value": "merge PR #43",
+                "evidence": {"action": "gh_pr_merge", "commit_sha": "abc1234"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels, f"expected multi_commit, got {labels}"
+    assert "single_commit" not in labels
+
+
 def test_step_types_zero_spans_not_shallow():
     """Zero completed spans must not be coerced into an observed shallow_session.
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -1049,6 +1049,34 @@ def test_step_types_unqualified_pr_without_merge_evidence_stays_distinct():
     assert "single_commit" not in labels
 
 
+def test_step_types_same_number_qualified_cross_repo_prs_stay_distinct():
+    """gh_pr_merge evidence must not merge two qualified cross-repo PRs."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/org-a/repo-a/pull/42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/org-b/repo-b/pull/42",
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
+
+
 def test_step_types_two_pr_only_is_multi():
     """Distinct PR-only deliveries keep their cardinality.
 
@@ -1229,6 +1257,45 @@ def test_step_types_two_gh_pr_merge_one_commit_is_multi():
     r.populate_step_types()
     labels = r.step_types or []
     assert "multi_commit" in labels, f"expected multi_commit, got {labels}"
+    assert "single_commit" not in labels
+
+
+def test_step_types_duplicate_gh_pr_merge_commits_do_not_double_budget():
+    """Duplicate producer records for one merge commit buy one PR pairing."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "pull_request",
+                "value": "merge PR #43",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+            {
+                "kind": "merge_commit",
+                "value": "merge-commit (abc1234)",
+                "evidence": {"action": "gh_pr_merge"},
+            },
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
     assert "single_commit" not in labels
 
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -825,6 +825,7 @@ def test_step_types_deduplicates_same_commit_across_producers():
             {
                 "kind": "pull_request",
                 "value": "https://github.com/gptme/gptme/pull/3646",
+                "evidence": {"commit_sha": "48225d823eba894164b90290cb7a6d2ecfaf3508"},
             },
         ],
     )
@@ -992,7 +993,7 @@ def test_step_types_grok_leading_sha_not_overridden_by_message_paren():
 
 
 def test_step_types_pr_url_and_text_same_pr_is_single():
-    """URL and ``PR #N`` forms of the same PR are one delivery.
+    """URL and merge evidence for ``PR #N`` are one delivery.
 
     Regression for gptme/gptme-contrib#1565 Greptile P1 (round 2): when
     merge-SHA resolution fails, ``owner/repo#N`` and ``#N`` were counted
@@ -1011,13 +1012,41 @@ def test_step_types_pr_url_and_text_same_pr_is_single():
                 "kind": "pull_request",
                 "value": "https://github.com/gptme/gptme/pull/42",
             },
-            {"kind": "pull_request", "value": "merge PR #42"},
+            {
+                "kind": "pull_request",
+                "value": "merge PR #42",
+                "evidence": {"action": "gh_pr_merge"},
+            },
         ],
     )
     r.populate_step_types()
     labels = r.step_types or []
     assert "single_commit" in labels
     assert "multi_commit" not in labels
+
+
+def test_step_types_unqualified_pr_without_merge_evidence_stays_distinct():
+    """An unqualified PR must not absorb a qualified cross-repo PR."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/gptme/gptme/pull/42",
+            },
+            {"kind": "pull_request", "value": "PR #42"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
 
 
 def test_step_types_two_pr_only_is_multi():
@@ -1116,8 +1145,8 @@ def test_step_types_pr_merge_pair_plus_commit_is_multi():
     assert "single_commit" not in labels
 
 
-def test_step_types_pr_metadata_does_not_inflate_merge_commit():
-    """PR metadata beside one merge commit remains one logical delivery."""
+def test_step_types_pr_metadata_does_not_inflate_matching_commit():
+    """A PR explicitly tied to a commit remains one logical delivery."""
     r = SessionRecord(
         session_id="step-types",
         span_aggregates={
@@ -1127,7 +1156,11 @@ def test_step_types_pr_metadata_does_not_inflate_merge_commit():
             "retry_depth": 0,
         },
         deliverable_details=[
-            {"kind": "pull_request", "value": "https://github.com/org/repo/pull/99"},
+            {
+                "kind": "pull_request",
+                "value": "https://github.com/org/repo/pull/99",
+                "evidence": {"commit_sha": "abc1234"},
+            },
             {"kind": "merge_commit", "value": "merge-commit (abc1234)"},
         ],
     )
@@ -1135,6 +1168,27 @@ def test_step_types_pr_metadata_does_not_inflate_merge_commit():
     labels = r.step_types or []
     assert "single_commit" in labels
     assert "multi_commit" not in labels
+
+
+def test_step_types_unpaired_pr_plus_commit_is_multi():
+    """A PR without matching commit or merge evidence is count-bearing."""
+    r = SessionRecord(
+        session_id="step-types",
+        span_aggregates={
+            "total_spans": 20,
+            "error_spans": 0,
+            "tool_counts": {"Bash": 20},
+            "retry_depth": 0,
+        },
+        deliverable_details=[
+            {"kind": "commit", "value": "abc1234"},
+            {"kind": "pull_request", "value": "https://github.com/org/repo/pull/99"},
+        ],
+    )
+    r.populate_step_types()
+    labels = r.step_types or []
+    assert "multi_commit" in labels
+    assert "single_commit" not in labels
 
 
 def test_step_types_zero_spans_not_shallow():


### PR DESCRIPTION
Follow-up to gptme/gptme-contrib#1565 per Erik's request (@TimeToBuildBob).

## Changes

### P1 (high) — PR counting when commits also exist

Previously #1565 made PRs commit-bearing fallback only when no commit detail exists. The ai-reviewer correctly flagged this: a session that commits code AND opens an unpaired PR represents two distinct deliveries, but was labeled `single_commit` instead of `multi_commit`.

**Fix**: A PR is metadata only when tied to a commit by:
- `gh_pr_merge` evidence aliasing against a qualified URL for the same PR number, or
- explicit `evidence.commit_sha` matching a known commit identity.

Unpaired PRs (no merge or SHA evidence) now count as additional deliveries.

New tests:
- `test_step_types_unpaired_pr_plus_commit_is_multi` — commit + unpaired PR → multi_commit
- `test_step_types_unqualified_pr_without_merge_evidence_stays_distinct` — two same-numbered PRs without merge evidence → multi_commit

### P2 (medium) — _commit_identity leading vs trailing precedence

The reviewer described a case where `_commit_identity` for `commit`/`merge_commit` kinds prefers trailing parenthetical over leading SHA. **This is intentional and correct.**

Trajectory-format values use `message (sha)` where any leading hex token is part of the message, not the identity. The existing `test_step_types_trailing_sha_not_overridden_by_leading_message_token` regression-tests exactly this case — trailing wins for `commit` kind. P2 is a false positive; no code change.