### PR TITLE
fix(gptme-sessions): recognise codex-tui and codex_cli_rs originator types (#1567)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -353,7 +353,16 @@ def _detect_format(msgs: list[dict]) -> str:
         # Codex: first line is always session_meta
         if first.get("type") == "session_meta":
             payload = first.get("payload") or {}
-            if payload.get("originator") in ("codex_exec", "codex_interactive"):
+            # "codex_exec" / "codex_interactive" = older CLI shapes;
+            # "codex-tui" = interactive TUI (gpt-5.5 era);
+            # "codex_cli_rs" = Rust-rewrite CLI.
+            # All share the same JSONL schema and extractor.
+            if payload.get("originator") in (
+                "codex_exec",
+                "codex_interactive",
+                "codex-tui",
+                "codex_cli_rs",
+            ):
                 return "codex"
         # Copilot: first line is always session.start
         if first.get("type") == "session.start":

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3773,6 +3773,38 @@ def test_detect_format_codex_interactive():
     assert detect_format(msgs) == "codex"
 
 
+@pytest.mark.parametrize(
+    "originator",
+    [
+        "codex_exec",
+        "codex_interactive",
+        "codex-tui",
+        "codex_cli_rs",
+    ],
+)
+def test_detect_format_codex_all_originators(originator: str) -> None:
+    """All known Codex originator values are recognised as the 'codex' format.
+
+    Regression for #1567: codex-tui (gpt-5.5 TUI sessions) and codex_cli_rs
+    (Rust CLI rewrite sessions) were silently falling through to the 'gptme'
+    default, causing extract_from_path() to return zero deliverables and the
+    session to be graded as noop even when work was shipped.
+    """
+    msgs = [
+        {
+            "timestamp": "2026-08-31T20:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "test-session",
+                "originator": originator,
+                "cwd": "/home/bob/bob",
+            },
+        }
+    ]
+    assert detect_format(msgs) == "codex"
+    assert _detect_format(msgs) == "codex"
+
+
 def test_extract_signals_codex_basic():
     """Extract signals from a minimal Codex trajectory.
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3782,14 +3782,11 @@ def test_detect_format_codex_interactive():
         "codex_cli_rs",
     ],
 )
-def test_detect_format_codex_all_originators(originator: str) -> None:
-    """All known Codex originator values are recognised as the 'codex' format.
+def test_extract_from_path_codex_all_originators(tmp_path: Path, originator: str) -> None:
+    """All known Codex originators route through end-to-end extraction."""
+    from gptme_sessions.signals import extract_from_path
 
-    Regression for #1567: codex-tui (gpt-5.5 TUI sessions) and codex_cli_rs
-    (Rust CLI rewrite sessions) were silently falling through to the 'gptme'
-    default, causing extract_from_path() to return zero deliverables and the
-    session to be graded as noop even when work was shipped.
-    """
+    trajectory_file = tmp_path / f"{originator}.jsonl"
     msgs = [
         {
             "timestamp": "2026-08-31T20:00:00.000Z",
@@ -3797,12 +3794,34 @@ def test_detect_format_codex_all_originators(originator: str) -> None:
             "payload": {
                 "id": "test-session",
                 "originator": originator,
-                "cwd": "/home/bob/bob",
+                "cwd": "/workspace",
             },
-        }
+        },
+        {
+            "timestamp": "2026-08-31T20:00:01.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "call_id": "call_patch",
+                "success": True,
+                "changes": {
+                    "/workspace/src/fix.py": {"type": "update"},
+                    "/workspace/src/helper.py": {"type": "add"},
+                },
+            },
+        },
     ]
+    trajectory_file.write_text("".join(json.dumps(msg) + "\n" for msg in msgs), encoding="utf-8")
+
     assert detect_format(msgs) == "codex"
     assert _detect_format(msgs) == "codex"
+    result = extract_from_path(trajectory_file)
+    assert result["format"] == "codex"
+    assert result["file_writes"] == [
+        "/workspace/src/fix.py",
+        "/workspace/src/helper.py",
+    ]
+    assert result["productive"] is True
 
 
 def test_extract_signals_codex_basic():


### PR DESCRIPTION
## Problem

`_detect_format()` only covered `codex_exec` and `codex_interactive` as Codex originators. Two additional originator values from real sessions silently fell through to the `gptme` default:

- **`codex-tui`** — Codex TUI (interactive terminal UI) sessions, used heavily in the gpt-5.5 era
- **`codex_cli_rs`** — Rust rewrite of the Codex CLI

Because the format was detected as `gptme` (not `codex`), `extract_from_path()` ran the wrong extractor and returned `{git_commits: [], file_writes: [], productive: False}`. Sessions that shipped real work were then graded as noop, corrupting bandit rewards and dashboards.

This is a distinct root cause from the wait-continuation bug fixed in #1575 — the affected sessions don't use the async `wait` shape; they fail at format detection before extraction even begins.

## Fix

Add `codex-tui` and `codex_cli_rs` to the originator tuple in `_detect_format()`, with comments documenting each originator's provenance.

Add a parametrized regression test covering all four known Codex originator values (`codex_exec`, `codex_interactive`, `codex-tui`, `codex_cli_rs`).

## Verification

Before fix: `_detect_format()` returned `'gptme'` for a 5 MB `codex-tui` session with 66 `custom_tool_call:exec` records → `extract_from_path()` returned `tool_calls: {}, productive: False`.

After fix: same session detects as `'codex'` → `tool_calls: {exec: 66, ...}, file_writes: 2, productive: True`.

Closes remaining scope of #1567 (companion to #1575, #1578, #1580).

<!-- gptme-id:v1:gai_xYjItE5jFfXM7Q9mpxiDDIuTtc9ob2LfyCp776jbTQW -->