### PR TITLE
feat(gptme-sessions): resolve subagent tree and count their work in the parent

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/__init__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__init__.py
@@ -75,8 +75,12 @@ from .thompson_sampling import Bandit, BanditArm, BanditState, load_bandit_means
 from .transcript import (
     NormalizedMessage,
     SessionTranscript,
+    SessionTree,
+    SubagentNode,
     TRANSCRIPT_SCHEMA_VERSION,
+    read_session_tree,
     read_transcript,
+    subagent_record_files,
 )
 
 __all__ = [
@@ -124,8 +128,12 @@ __all__ = [
     "PostSessionResult",
     "NormalizedMessage",
     "SessionTranscript",
+    "SessionTree",
+    "SubagentNode",
     "TRANSCRIPT_SCHEMA_VERSION",
+    "read_session_tree",
     "read_transcript",
+    "subagent_record_files",
     "SpanAggregates",
     "ToolSpan",
     "extract_spans_from_cc_jsonl",

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -774,6 +774,12 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     # command used `gh pr merge` without an explicit number). Keyed by tool_use_id.
     _pr_merge_num_by_tool_id: dict[str, int] = {}
     detail_by_value: dict[str, dict[str, object]] = {}
+    # Subagent transcripts can repeat parent context verbatim. Count each
+    # tool invocation/result once across the flattened session, keyed by the
+    # stable Claude tool-use id. Records without an id cannot be identified
+    # safely and retain the historical per-record behavior.
+    seen_tool_use_ids: set[str] = set()
+    seen_tool_result_ids: set[str] = set()
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -795,17 +801,22 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                 tool = item.get("name", "")
                 if not tool:
                     continue
-                tool_calls[tool] = tool_calls.get(tool, 0) + 1
-                step_has_tool = True
 
-                # Track id → name for commit detection filtering and timing
+                # Track id → name for commit detection filtering and timing.
+                # Skip an invocation already seen in parent/ancestor context.
                 tool_id = item.get("id", "")
                 if tool_id:
+                    if tool_id in seen_tool_use_ids:
+                        continue
+                    seen_tool_use_ids.add(tool_id)
                     tool_id_to_name[tool_id] = tool
                     # Record dispatch ids for this assistant turn so each tool
                     # can later be tagged with the final batch size of the turn.
                     if ts is not None:
                         dispatch_ids.append((tool_id, tool))
+
+                tool_calls[tool] = tool_calls.get(tool, 0) + 1
+                step_has_tool = True
 
                 if tool in _CC_WRITE_TOOLS:
                     inp = item.get("input", {})
@@ -951,6 +962,10 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     continue
 
                 tool_use_id = item.get("tool_use_id", "")
+                if tool_use_id:
+                    if tool_use_id in seen_tool_result_ids:
+                        continue
+                    seen_tool_result_ids.add(tool_use_id)
 
                 # Per-tool-call duration: match result back to dispatch.
                 # When an assistant message batches multiple tool calls, they all
@@ -1576,6 +1591,30 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
     }
     if stop_reason is not None:
         result["stop_reason"] = stop_reason
+    return result
+
+
+def _combine_cc_usage(parts: list[dict]) -> dict:
+    """Roll up usage extracted independently from parent and subagents."""
+    if not parts:
+        return {}
+
+    additive_fields = (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "total_tokens",
+    )
+    result = {
+        field: sum(_as_int(part.get(field)) or 0 for part in parts) for field in additive_fields
+    }
+    # Parent metadata describes the aggregate session. Fall back to a child
+    # only when the parent did not carry the field at all.
+    for field in ("model", "sys_prompt_tokens", "context_peak_tokens", "stop_reason"):
+        value = next((part.get(field) for part in parts if part.get(field) is not None), None)
+        if value is not None:
+            result[field] = value
     return result
 
 
@@ -2993,20 +3032,28 @@ def extract_from_path(jsonl_path: Path) -> dict:
                 f"{jsonl_path} is a directory and does not contain conversation.jsonl"
             )
     msgs = parse_trajectory(jsonl_path)
-    # Include subagent records so their tool calls, tokens and file writes
-    # count toward the parent session (trajectory attribution, item 1).
+    parent_msgs = list(msgs)
+    subagent_msgs: list[list[dict]] = []
+    # Include subagent records so their tool calls and file writes count toward
+    # the parent session (trajectory attribution, item 1). Keep each transcript
+    # separate for usage extraction: a stream-json ``result`` is cumulative for
+    # one transcript and must not replace assistant usage from its siblings.
     # Best-effort: subagent resolution must never break signal extraction.
     try:
         from .transcript import subagent_record_files
 
         for sub_file in subagent_record_files(jsonl_path):
-            msgs.extend(parse_trajectory(sub_file))
+            child_msgs = parse_trajectory(sub_file)
+            subagent_msgs.append(child_msgs)
+            msgs.extend(child_msgs)
     except Exception:
         pass
     fmt = detect_format(msgs)
     if fmt == "claude_code":
         signals = extract_signals_cc(msgs)
-        usage = extract_usage_cc(msgs)
+        usage_parts = [extract_usage_cc(part) for part in [parent_msgs, *subagent_msgs]]
+        usage_parts = [part for part in usage_parts if part]
+        usage = _combine_cc_usage(usage_parts)
     elif fmt == "pi":
         signals = extract_signals_pi(msgs)
         usage = extract_usage_pi(msgs)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2993,6 +2993,16 @@ def extract_from_path(jsonl_path: Path) -> dict:
                 f"{jsonl_path} is a directory and does not contain conversation.jsonl"
             )
     msgs = parse_trajectory(jsonl_path)
+    # Include subagent records so their tool calls, tokens and file writes
+    # count toward the parent session (trajectory attribution, item 1).
+    # Best-effort: subagent resolution must never break signal extraction.
+    try:
+        from .transcript import subagent_record_files
+
+        for sub_file in subagent_record_files(jsonl_path):
+            msgs.extend(parse_trajectory(sub_file))
+    except Exception:
+        pass
     fmt = detect_format(msgs)
     if fmt == "claude_code":
         signals = extract_signals_cc(msgs)

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -18,6 +18,10 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass  # avoid circular import; subagent_record_files imported lazily
 
 _EXIT_CODE_RE = re.compile(r"(?:Exit code|exit code):\s*(\d+)")
 
@@ -252,6 +256,10 @@ class ToolSpan:
     cache_creation_tokens: int | None = None
     cache_read_tokens: int | None = None
     cost_usd: float | None = None
+    # Subagent provenance (item 1b): present when the span comes from a child
+    # transcript rather than the parent session's own JSONL.
+    spawn_depth: int = 0
+    agent_type: str | None = None  # e.g. "claude" / "general-purpose" / None for parent
 
 
 @dataclass
@@ -335,37 +343,32 @@ class SpanAggregates:
         )
 
 
-def extract_spans_from_cc_jsonl(
-    path: Path | str,
-    session_id: str | None = None,
+def _extract_cc_spans_from_text(
+    text: str,
+    session_id: str,
+    turn_offset: int = 0,
+    spawn_depth: int = 0,
+    agent_type: str | None = None,
 ) -> list[ToolSpan]:
-    """Extract ToolSpan objects from a Claude Code JSONL trajectory file.
+    """Core loop: extract ToolSpan objects from one CC JSONL file's text.
 
-    Parses assistant tool_use dispatches and user tool_result arrivals,
-    pairs them by tool_use_id, and computes per-span timing.
+    Separated from the public function so that ``extract_spans_from_cc_jsonl``
+    can call it for the parent *and* all subagent files (item 1a), tagging
+    each span with its provenance (item 1b).
 
     Args:
-        path: Path to the .jsonl trajectory file.
-        session_id: Session ID to assign to all spans. Defaults to the
-            filename stem (e.g. ``"abc123"`` for ``abc123.jsonl``).
-
-    Returns:
-        List of spans in chronological dispatch order.
+        text: Raw JSONL content (already read from disk).
+        session_id: Session ID to attribute these spans to.
+        turn_offset: Add this to every span's ``turn_index`` so parent and
+            child spans can be sorted in a global turn order if needed.
+        spawn_depth: Depth in the subagent tree (0 = parent).
+        agent_type: Agent type string from the subagent's ``.meta.json``.
     """
-    path = Path(path)
-    if session_id is None:
-        session_id = path.stem
-
     # pending maps tool_use_id → (tool_name, dispatch_ts, dispatch_ts_str,
     #                             input_size, turn_index, attributed_usage)
     pending: dict[str, tuple[str, datetime | None, str, int, int, _TurnUsage | None]] = {}
     spans: list[ToolSpan] = []
-    turn_index = 0
-
-    try:
-        text = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return []
+    turn_index = turn_offset
 
     for line in text.splitlines():
         line = line.strip()
@@ -447,8 +450,80 @@ def extract_spans_from_cc_jsonl(
                         cache_creation_tokens=usage.cache_creation_tokens if usage else None,
                         cache_read_tokens=usage.cache_read_tokens if usage else None,
                         cost_usd=usage.cost_usd if usage else None,
+                        spawn_depth=spawn_depth,
+                        agent_type=agent_type,
                     )
                 )
+
+    return spans
+
+
+def extract_spans_from_cc_jsonl(
+    path: Path | str,
+    session_id: str | None = None,
+    include_subagents: bool = True,
+) -> list[ToolSpan]:
+    """Extract ToolSpan objects from a Claude Code JSONL trajectory file.
+
+    Parses assistant tool_use dispatches and user tool_result arrivals,
+    pairs them by tool_use_id, and computes per-span timing.
+
+    When ``include_subagents=True`` (default), also reads every child
+    transcript under ``<session>/subagents/`` so that subagent tool calls
+    count for the parent session (item 1a). Each span carries ``spawn_depth``
+    and ``agent_type`` for downstream attribution (item 1b).
+
+    Args:
+        path: Path to the .jsonl trajectory file.
+        session_id: Session ID to assign to all spans. Defaults to the
+            filename stem (e.g. ``"abc123"`` for ``abc123.jsonl``).
+        include_subagents: When True (default), also extract spans from every
+            child transcript in the session's subagents/ directory.
+
+    Returns:
+        List of spans in chronological dispatch order (parent first, then
+        subagents in discovery order).
+    """
+    path = Path(path)
+    if session_id is None:
+        session_id = path.stem
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    spans = _extract_cc_spans_from_text(text, session_id, spawn_depth=0)
+
+    if include_subagents:
+        # Lazy import to avoid circular dependency (transcript → signals → spans).
+        from .transcript import subagent_record_files  # noqa: PLC0415
+
+        for child_path in subagent_record_files(path):
+            # Read depth and agentType from the .meta.json sidecar.
+            # Convention: agent-<id>.jsonl → agent-<id>.meta.json, same dir.
+            meta_path = child_path.with_suffix(".meta.json")
+            meta: dict = {}
+            if meta_path.is_file():
+                try:
+                    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    pass
+            depth = int(meta.get("spawnDepth", 1) or 1)
+            a_type = meta.get("agentType") or None
+
+            try:
+                child_text = child_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            spans.extend(
+                _extract_cc_spans_from_text(
+                    child_text,
+                    session_id=session_id,
+                    spawn_depth=depth,
+                    agent_type=a_type,
+                )
+            )
 
     return spans
 

--- a/packages/gptme-sessions/src/gptme_sessions/transcript.py
+++ b/packages/gptme-sessions/src/gptme_sessions/transcript.py
@@ -891,7 +891,9 @@ def _agent_tool_use_ids(records: list[dict]) -> list[tuple[str, dict]]:
                 and block.get("type") == "tool_use"
                 and block.get("name") == "Agent"
             ):
-                out.append((block.get("id"), block))
+                tool_id = block.get("id")
+                if tool_id is not None:
+                    out.append((tool_id, block))
     return out
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/transcript.py
+++ b/packages/gptme-sessions/src/gptme_sessions/transcript.py
@@ -954,8 +954,8 @@ def read_session_tree(path: Path) -> SessionTree:
     The parent transcript is returned as ``tree.parent``. Each ``Agent`` tool
     call whose ``tool_use.id`` matches a subagent ``.meta.json`` ``toolUseId``
     is expanded into a :class:`SubagentNode`, recursively by ``spawnDepth``.
-    Workflow agents (no ``toolUseId``) are attached as direct children of the
-    parent.
+    Workflow agents and flat agents without readable metadata (no
+    ``toolUseId``) are attached as direct children of the parent.
 
     A session without subagents returns a tree with an empty ``subagents``
     list whose ``flatten_records`` / ``flatten_messages`` are identical to the
@@ -976,18 +976,24 @@ def read_session_tree(path: Path) -> SessionTree:
                 continue
             child_stem = meta_path.name.removesuffix(".meta.json")
             child_path = meta_path.parent / f"{child_stem}.jsonl"
+            if not child_path.exists():
+                continue
             tool_use_id = meta.get("toolUseId", "")
             if tool_use_id:
                 agent_map[tool_use_id] = (meta, child_path)
-            elif child_path.exists():
+            else:
                 workflow_files.append(child_path)
-        # Catch workflow jsonl files whose .meta.json was absent.
+        # Catch flat and workflow JSONL files whose .meta.json was absent or
+        # unreadable. Without a tool-use join they are attached at the root,
+        # preserving their work instead of silently dropping it.
+        mapped = {c for _, c in agent_map.values()}
+        fallback_files = sorted(sub_dir.glob("agent-*.jsonl"))
         wf_dir = sub_dir / "workflows"
         if wf_dir.is_dir():
-            mapped = {c for _, c in agent_map.values()}
-            for child_path in sorted(wf_dir.glob("*/agent-*.jsonl")):
-                if child_path not in mapped and child_path not in workflow_files:
-                    workflow_files.append(child_path)
+            fallback_files += sorted(wf_dir.glob("*/agent-*.jsonl"))
+        for child_path in fallback_files:
+            if child_path not in mapped and child_path not in workflow_files:
+                workflow_files.append(child_path)
 
     tree = SessionTree(parent=parent, parent_records=parent_records)
     visited: set[str] = set()

--- a/packages/gptme-sessions/src/gptme_sessions/transcript.py
+++ b/packages/gptme-sessions/src/gptme_sessions/transcript.py
@@ -736,3 +736,262 @@ def read_transcript(path: Path) -> SessionTranscript:
         capabilities=capabilities,
         messages=norm_msgs,
     )
+
+
+# ---------------------------------------------------------------------------
+# Subagent tree resolution
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SubagentNode:
+    """A resolved subagent transcript with provenance.
+
+    Fields
+    ------
+    session_id : str
+        Child session id (the ``agent-<id>`` file stem).
+    agent_type : str | None
+        ``agentType`` from the child's ``.meta.json`` (e.g. ``"Explore"``,
+        ``"workflow-subagent"``), falling back to the parent tool's
+        ``subagent_type``.
+    description : str | None
+        Task description from ``.meta.json`` or the parent tool input.
+    spawn_depth : int
+        Nesting depth. ``1`` is a direct child of the parent session.
+    tool_use_id : str | None
+        The parent's ``tool_use.id`` that spawned this child (``None`` for
+        workflow agents, which carry no tool-use link).
+    trajectory_path : str
+        Absolute path to the child JSONL file.
+    transcript : SessionTranscript
+        Normalized transcript of the child session.
+    records : list[dict]
+        Raw harness JSONL records of the child (for signal extraction).
+    children : list[SubagentNode]
+        Nested subagents spawned by this child.
+    """
+
+    session_id: str
+    trajectory_path: str
+    transcript: SessionTranscript
+    records: list[dict] = field(default_factory=list)
+    children: list["SubagentNode"] = field(default_factory=list)
+    agent_type: str | None = None
+    description: str | None = None
+    spawn_depth: int = 1
+    tool_use_id: str | None = None
+
+
+@dataclass
+class SessionTree:
+    """A session with its subagents resolved into a tree.
+
+    ``parent`` is the root transcript. ``subagents`` holds the direct
+    subagents (spawn depth 1), each of which may itself have ``children``.
+    """
+
+    parent: SessionTranscript
+    parent_records: list[dict] = field(default_factory=list)
+    subagents: list[SubagentNode] = field(default_factory=list)
+
+    @property
+    def total_subagents(self) -> int:
+        """Total number of subagent nodes in the tree (all depths)."""
+
+        def count(nodes: list[SubagentNode]) -> int:
+            return sum(1 + count(n.children) for n in nodes)
+
+        return count(self.subagents)
+
+    def flatten_records(self) -> list[dict]:
+        """Raw JSONL records: parent first, then all descendants pre-order.
+
+        Suitable for feeding harness signal extractors so subagent tool calls,
+        tokens, file writes and commits count toward the parent session.
+        """
+        out = list(self.parent_records)
+
+        def walk(nodes: list[SubagentNode]) -> None:
+            for n in nodes:
+                out.extend(n.records)
+                walk(n.children)
+
+        walk(self.subagents)
+        return out
+
+    def flatten_messages(self) -> list[NormalizedMessage]:
+        """Normalized messages: parent first, then all descendants pre-order."""
+        out = list(self.parent.messages)
+
+        def walk(nodes: list[SubagentNode]) -> None:
+            for n in nodes:
+                out.extend(n.transcript.messages)
+                walk(n.children)
+
+        walk(self.subagents)
+        return out
+
+
+def _resolve_parent_jsonl(path: Path) -> Path:
+    """Resolve a session path (directory or JSONL file) to its parent JSONL."""
+    if path.is_dir():
+        jsonl = path / "conversation.jsonl"
+        if jsonl.exists():
+            return jsonl
+        raise FileNotFoundError(f"{path} is a directory and does not contain conversation.jsonl")
+    return path
+
+
+def _find_subagents_dir(parent_jsonl: Path) -> Path | None:
+    """Locate the ``subagents/`` directory for a session, or ``None``.
+
+    Claude Code stores subagents under ``<session-id>/subagents/`` next to the
+    ``<session-id>.jsonl`` parent; gptme stores them under the session
+    directory (which contains ``conversation.jsonl``) as ``subagents/``.
+    """
+    candidates = (
+        parent_jsonl.parent / parent_jsonl.stem / "subagents",  # claude-code
+        parent_jsonl.parent / "subagents",  # gptme session dir
+    )
+    for c in candidates:
+        if c.is_dir():
+            return c
+    return None
+
+
+def subagent_record_files(path: Path) -> list[Path]:
+    """JSONL files of every subagent spawned by the session at ``path``.
+
+    Accepts a JSONL file or a gptme session directory. Covers both the flat
+    ``agent-*.jsonl`` agents (nested ones included) and workflow agents under
+    ``workflows/*/``. Returns ``[]`` when the session has no subagents.
+    """
+    parent_jsonl = _resolve_parent_jsonl(path)
+    sub_dir = _find_subagents_dir(parent_jsonl)
+    if sub_dir is None:
+        return []
+    files = sorted(sub_dir.glob("agent-*.jsonl"))
+    files += sorted(sub_dir.glob("workflows/*/agent-*.jsonl"))
+    return files
+
+
+def _agent_tool_use_ids(records: list[dict]) -> list[tuple[str, dict]]:
+    """Return ``(tool_use_id, block)`` for each ``Agent`` tool use in records."""
+    out: list[tuple[str, dict]] = []
+    for r in records:
+        if r.get("type") != "assistant":
+            continue
+        content = r.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == "Agent"
+            ):
+                out.append((block.get("id"), block))
+    return out
+
+
+def _make_subagent_node(
+    child_path: Path,
+    meta: dict,
+    tool_use_id: str | None,
+    parent_depth: int,
+    agent_map: dict[str, tuple[dict, Path]],
+    visited: set[str],
+) -> SubagentNode:
+    """Build a SubagentNode for ``child_path``, recursing into its children."""
+    child_records = parse_trajectory(child_path)
+    visited.add(str(child_path))
+    return SubagentNode(
+        session_id=child_path.stem,
+        agent_type=meta.get("agentType"),
+        description=meta.get("description"),
+        spawn_depth=int(meta.get("spawnDepth", parent_depth + 1) or parent_depth + 1),
+        tool_use_id=tool_use_id,
+        trajectory_path=str(child_path),
+        transcript=read_transcript(child_path),
+        records=child_records,
+        children=_build_subagent_nodes(child_records, agent_map, parent_depth + 1, visited),
+    )
+
+
+def _build_subagent_nodes(
+    records: list[dict],
+    agent_map: dict[str, tuple[dict, Path]],
+    parent_depth: int,
+    visited: set[str],
+) -> list[SubagentNode]:
+    """Resolve the subagents whose tool-use ids appear in ``records``.
+
+    ``visited`` guards against self-loops: a subagent's JSONL carries the
+    parent's ``Agent`` tool-use as context, so its own ``toolUseId`` re-matches
+    the node itself. Skipping already-visited children also breaks any
+    cross-referential cycle.
+    """
+    nodes: list[SubagentNode] = []
+    for tool_use_id, block in _agent_tool_use_ids(records):
+        entry = agent_map.get(tool_use_id)
+        if entry is None:
+            continue
+        meta, child_path = entry
+        if str(child_path) in visited:
+            continue
+        nodes.append(
+            _make_subagent_node(child_path, meta, tool_use_id, parent_depth, agent_map, visited)
+        )
+    return nodes
+
+
+def read_session_tree(path: Path) -> SessionTree:
+    """Read a session and resolve its subagent tree.
+
+    The parent transcript is returned as ``tree.parent``. Each ``Agent`` tool
+    call whose ``tool_use.id`` matches a subagent ``.meta.json`` ``toolUseId``
+    is expanded into a :class:`SubagentNode`, recursively by ``spawnDepth``.
+    Workflow agents (no ``toolUseId``) are attached as direct children of the
+    parent.
+
+    A session without subagents returns a tree with an empty ``subagents``
+    list whose ``flatten_records`` / ``flatten_messages`` are identical to the
+    parent transcript alone.
+    """
+    parent_jsonl = _resolve_parent_jsonl(path)
+    parent_records = parse_trajectory(parent_jsonl)
+    parent = read_transcript(parent_jsonl)
+
+    agent_map: dict[str, tuple[dict, Path]] = {}
+    workflow_files: list[Path] = []
+    sub_dir = _find_subagents_dir(parent_jsonl)
+    if sub_dir is not None:
+        for meta_path in sorted(sub_dir.glob("agent-*.meta.json")):
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            child_stem = meta_path.name.removesuffix(".meta.json")
+            child_path = meta_path.parent / f"{child_stem}.jsonl"
+            tool_use_id = meta.get("toolUseId", "")
+            if tool_use_id:
+                agent_map[tool_use_id] = (meta, child_path)
+            elif child_path.exists():
+                workflow_files.append(child_path)
+        # Catch workflow jsonl files whose .meta.json was absent.
+        wf_dir = sub_dir / "workflows"
+        if wf_dir.is_dir():
+            mapped = {c for _, c in agent_map.values()}
+            for child_path in sorted(wf_dir.glob("*/agent-*.jsonl")):
+                if child_path not in mapped and child_path not in workflow_files:
+                    workflow_files.append(child_path)
+
+    tree = SessionTree(parent=parent, parent_records=parent_records)
+    visited: set[str] = set()
+    tree.subagents = _build_subagent_nodes(parent_records, agent_map, 0, visited)
+    for child_path in workflow_files:
+        if str(child_path) in visited:
+            continue
+        tree.subagents.append(_make_subagent_node(child_path, {}, None, 0, agent_map, visited))
+    return tree

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -917,3 +917,94 @@ def test_codex_malformed_lines_skipped(tmp_path: Path) -> None:
     p = tmp_path / "rollout-bad.jsonl"
     p.write_text('not json\n{}\n{"type": "event_msg"}\n')
     assert extract_spans_from_codex_jsonl(p) == []
+
+
+# ── subagent traversal (items 1a + 1b) ────────────────────────────────────────
+
+
+def _make_subagent_tree(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a parent JSONL with one subagent (CC layout).
+
+    Returns (parent_path, child_path).
+    """
+    parent_session_id = "parent-session-abc1"
+    child_session_id = "agent-child001"
+
+    # Parent: one Bash call
+    parent_records = [
+        _cc_assistant("Bash", "tid-p1", "ls /", "2026-09-01T10:00:00+00:00"),
+        _cc_result("tid-p1", "bin\nusr\n", "2026-09-01T10:00:02+00:00"),
+    ]
+    parent_path = _write_jsonl(tmp_path, parent_records, name=f"{parent_session_id}.jsonl")
+
+    # Subagents directory (CC convention: <stem>/subagents/)
+    subagents_dir = tmp_path / parent_session_id / "subagents"
+    subagents_dir.mkdir(parents=True)
+
+    # Child: one Read call
+    child_records = [
+        _cc_assistant("Read", "tid-c1", "/etc/hosts", "2026-09-01T10:00:05+00:00"),
+        _cc_result("tid-c1", "127.0.0.1 localhost\n", "2026-09-01T10:00:06+00:00"),
+    ]
+    child_path = _write_jsonl(subagents_dir, child_records, name=f"{child_session_id}.jsonl")
+
+    # Meta sidecar
+    meta = {"spawnDepth": 1, "agentType": "general-purpose", "toolUseId": "tid-agent-1"}
+    (subagents_dir / f"{child_session_id}.meta.json").write_text(json.dumps(meta))
+
+    return parent_path, child_path
+
+
+def test_subagent_spans_included_by_default(tmp_path: Path) -> None:
+    """extract_spans_from_cc_jsonl includes subagent spans with include_subagents=True."""
+    parent_path, _ = _make_subagent_tree(tmp_path)
+    spans = extract_spans_from_cc_jsonl(parent_path)
+    tool_names = [s.tool_name for s in spans]
+    assert "Bash" in tool_names, "parent span missing"
+    assert "Read" in tool_names, "child span missing"
+    assert len(spans) == 2
+
+
+def test_subagent_spans_excluded_when_disabled(tmp_path: Path) -> None:
+    """include_subagents=False returns only parent spans."""
+    parent_path, _ = _make_subagent_tree(tmp_path)
+    spans = extract_spans_from_cc_jsonl(parent_path, include_subagents=False)
+    assert len(spans) == 1
+    assert spans[0].tool_name == "Bash"
+
+
+def test_subagent_spans_have_depth_and_type_tags(tmp_path: Path) -> None:
+    """Subagent spans carry spawn_depth and agent_type from the .meta.json."""
+    parent_path, _ = _make_subagent_tree(tmp_path)
+    spans = extract_spans_from_cc_jsonl(parent_path)
+
+    parent_spans = [s for s in spans if s.spawn_depth == 0]
+    child_spans = [s for s in spans if s.spawn_depth == 1]
+
+    assert len(parent_spans) == 1
+    assert parent_spans[0].agent_type is None  # parent carries no agent_type
+
+    assert len(child_spans) == 1
+    assert child_spans[0].tool_name == "Read"
+    assert child_spans[0].agent_type == "general-purpose"
+
+
+def test_subagent_spans_attributed_to_parent_session(tmp_path: Path) -> None:
+    """Both parent and child spans carry the parent's session_id."""
+    parent_path, _ = _make_subagent_tree(tmp_path)
+    spans = extract_spans_from_cc_jsonl(parent_path)
+    parent_session_id = parent_path.stem
+    assert all(s.session_id == parent_session_id for s in spans)
+
+
+def test_no_subagents_directory_returns_only_parent(tmp_path: Path) -> None:
+    """Sessions without a subagents/ dir return only parent spans (no crash)."""
+    records = [
+        _cc_assistant("Bash", "tid1", "echo hello", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "hello\n", "2026-04-21T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+    assert len(spans) == 1
+    assert spans[0].spawn_depth == 0
+    assert spans[0].agent_type is None

--- a/packages/gptme-sessions/tests/test_transcript_tree.py
+++ b/packages/gptme-sessions/tests/test_transcript_tree.py
@@ -194,3 +194,92 @@ def test_extract_from_path_counts_subagent_tool_calls(tmp_path: Path) -> None:
     # a1/a2's writes are included too.
     tool_calls = result.get("tool_calls", {})
     assert tool_calls.get("Write") == 3  # parent + a1 + a2
+
+
+def test_extract_from_path_deduplicates_echoed_parent_tool_call(tmp_path: Path) -> None:
+    session = tmp_path / "echo.jsonl"
+    spawn = _cc_assistant_with_agent("tool_agent_echo")
+    _write_jsonl(session, [spawn])
+
+    sub = tmp_path / "echo" / "subagents"
+    _write_jsonl(
+        sub / "agent-echo.jsonl",
+        [spawn, _cc_write_record("tool_write_child", "child.py")],
+    )
+    _write_jsonl(
+        sub / "agent-echo.meta.json",
+        [_meta("tool_agent_echo", "Explore", 1, "echo")],
+    )
+
+    result = extract_from_path(session)
+    assert result["tool_calls"]["Agent"] == 1
+    assert result["tool_calls"]["Write"] == 1
+    assert result["steps"] == 2
+
+
+def _cc_usage_record(input_tokens: int, output_tokens: int) -> dict:
+    """A complete durable CC assistant turn with token usage."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-03-01T10:00:02.000Z",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4-6",
+            "content": [],
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        },
+    }
+
+
+def test_extract_from_path_adds_subagent_usage_to_parent_result(tmp_path: Path) -> None:
+    """A parent's stream result must not replace a durable child's usage."""
+    session = tmp_path / "usage.jsonl"
+    _write_jsonl(
+        session,
+        [
+            _cc_usage_record(1, 1),
+            {
+                "type": "result",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+            _cc_assistant_with_agent("tool_agent_usage"),
+        ],
+    )
+    sub = tmp_path / "usage" / "subagents"
+    _write_jsonl(sub / "agent-usage.jsonl", [_cc_usage_record(20, 10)])
+    _write_jsonl(
+        sub / "agent-usage.meta.json",
+        [_meta("tool_agent_usage", "Explore", 1, "usage")],
+    )
+
+    usage = extract_from_path(session)["usage"]
+    assert usage["input_tokens"] == 120
+    assert usage["output_tokens"] == 60
+
+
+def test_read_session_tree_skips_meta_for_missing_jsonl(tmp_path: Path) -> None:
+    session = tmp_path / "missing.jsonl"
+    _write_jsonl(session, [_cc_assistant_with_agent("tool_missing")])
+    sub = tmp_path / "missing" / "subagents"
+    _write_jsonl(
+        sub / "agent-missing.meta.json",
+        [_meta("tool_missing", "Explore", 1, "missing")],
+    )
+
+    tree = read_session_tree(session)
+    assert tree.total_subagents == 0
+
+
+def test_read_session_tree_includes_flat_jsonl_without_meta(tmp_path: Path) -> None:
+    session = tmp_path / "unmapped.jsonl"
+    _write_jsonl(session, [_cc_write_record("tool_parent", "parent.py")])
+    sub = tmp_path / "unmapped" / "subagents"
+    _write_jsonl(sub / "agent-unmapped.jsonl", [_cc_write_record("tool_child", "child.py")])
+
+    tree = read_session_tree(session)
+    assert tree.total_subagents == 1
+    assert tree.subagents[0].session_id == "agent-unmapped"
+    assert tree.subagents[0].tool_use_id is None

--- a/packages/gptme-sessions/tests/test_transcript_tree.py
+++ b/packages/gptme-sessions/tests/test_transcript_tree.py
@@ -1,0 +1,196 @@
+"""Tests for subagent tree resolution (read_session_tree)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from gptme_sessions.signals import extract_from_path
+from gptme_sessions.transcript import (
+    SessionTree,
+    SubagentNode,
+    read_session_tree,
+    subagent_record_files,
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+def _cc_assistant_with_agent(tool_use_id: str, subagent_type: str = "Explore") -> dict:
+    """An assistant CC record carrying one ``Agent`` tool use."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-03-01T10:00:00.000Z",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4-6",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": "Agent",
+                    "input": {
+                        "description": f"spawn {tool_use_id}",
+                        "subagent_type": subagent_type,
+                        "prompt": "do work",
+                    },
+                },
+            ],
+        },
+    }
+
+
+def _cc_write_record(tool_use_id: str, path: str) -> dict:
+    """An assistant CC record with a plain ``Write`` tool use."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-03-01T10:00:01.000Z",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4-6",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": "Write",
+                    "input": {"file_path": path, "content": "# x"},
+                },
+            ],
+        },
+    }
+
+
+def _meta(tool_use_id: str, agent_type: str, spawn_depth: int, description: str) -> dict:
+    return {
+        "agentType": agent_type,
+        "description": description,
+        "toolUseId": tool_use_id,
+        "spawnDepth": spawn_depth,
+    }
+
+
+def _build_session(tmp_path: Path) -> Path:
+    """Build a CC session with one direct subagent and one nested subagent.
+
+    Layout (Claude Code convention):
+        sess-1.jsonl
+        sess-1/subagents/agent-a1.jsonl (+ .meta.json)   -> spawned by tool_agent_1
+        sess-1/subagents/agent-a2.jsonl (+ .meta.json)   -> spawned by a1 (tool_agent_2)
+    """
+    session = tmp_path / "sess-1.jsonl"
+    parent_records = [
+        _cc_assistant_with_agent("tool_agent_1"),
+        _cc_write_record("tool_write_parent", "parent.py"),
+    ]
+    _write_jsonl(session, parent_records)
+
+    sub = tmp_path / "sess-1" / "subagents"
+    # a1: direct child, spawns a2 via its own Agent call.
+    a1_records = [
+        _cc_assistant_with_agent("tool_agent_2"),
+        _cc_write_record("tool_write_a1", "a1.py"),
+    ]
+    _write_jsonl(sub / "agent-a1.jsonl", a1_records)
+    _write_jsonl(sub / "agent-a1.meta.json", [_meta("tool_agent_1", "Explore", 1, "top")])
+
+    # a2: nested child (depth 2), no further spawns.
+    a2_records = [_cc_write_record("tool_write_a2", "a2.py")]
+    _write_jsonl(sub / "agent-a2.jsonl", a2_records)
+    _write_jsonl(sub / "agent-a2.meta.json", [_meta("tool_agent_2", "Explore", 2, "nested")])
+
+    return session
+
+
+def test_read_session_tree_resolves_nested_subagents(tmp_path: Path) -> None:
+    session = _build_session(tmp_path)
+    tree = read_session_tree(session)
+
+    assert isinstance(tree, SessionTree)
+    assert tree.parent.session_id == "sess-1"
+    assert tree.total_subagents == 2
+
+    assert len(tree.subagents) == 1
+    a1 = tree.subagents[0]
+    assert isinstance(a1, SubagentNode)
+    assert a1.session_id == "agent-a1"
+    assert a1.agent_type == "Explore"
+    assert a1.spawn_depth == 1
+    assert a1.tool_use_id == "tool_agent_1"
+
+    assert len(a1.children) == 1
+    a2 = a1.children[0]
+    assert a2.session_id == "agent-a2"
+    assert a2.spawn_depth == 2
+    assert a2.tool_use_id == "tool_agent_2"
+    assert a2.children == []
+
+
+def test_flatten_records_includes_subagents(tmp_path: Path) -> None:
+    session = _build_session(tmp_path)
+    tree = read_session_tree(session)
+
+    flat = tree.flatten_records()
+    # parent (2) + a1 (2) + a2 (1) = 5 records
+    assert len(flat) == 5
+    # all child tool writes present
+    write_ids = {
+        b.get("id")
+        for r in flat
+        if r.get("type") == "assistant"
+        for b in r.get("message", {}).get("content", [])
+        if isinstance(b, dict) and b.get("type") == "tool_use"
+    }
+    assert {"tool_write_parent", "tool_write_a1", "tool_write_a2"} <= write_ids
+
+
+def test_flatten_messages_is_superset_of_parent(tmp_path: Path) -> None:
+    session = _build_session(tmp_path)
+    tree = read_session_tree(session)
+    assert len(tree.flatten_messages()) > len(tree.parent.messages)
+
+
+def test_no_subagents_is_byte_identical(tmp_path: Path) -> None:
+    session = tmp_path / "solo.jsonl"
+    records = [_cc_write_record("tool_write_1", "solo.py")]
+    _write_jsonl(session, records)
+
+    tree = read_session_tree(session)
+    assert tree.total_subagents == 0
+    assert tree.flatten_records() == tree.parent_records
+    assert tree.flatten_messages() == tree.parent.messages
+    assert subagent_record_files(session) == []
+
+
+def test_self_loop_does_not_recurse_infinitely(tmp_path: Path) -> None:
+    """A subagent whose own jsonl carries its own spawn tool-use must not loop."""
+    session = tmp_path / "loop.jsonl"
+    _write_jsonl(session, [_cc_assistant_with_agent("tool_loop")])
+
+    sub = tmp_path / "loop" / "subagents"
+    # The child's records re-include the parent's Agent call as context, so its
+    # own toolUseId matches itself.
+    child_records = [_cc_assistant_with_agent("tool_loop")]
+    _write_jsonl(sub / "agent-loop.jsonl", child_records)
+    _write_jsonl(
+        sub / "agent-loop.meta.json",
+        [_meta("tool_loop", "Explore", 1, "self-loop")],
+    )
+
+    tree = read_session_tree(session)
+    # The child resolves once, but its self-reference is skipped.
+    assert tree.total_subagents == 1
+    assert tree.subagents[0].children == []
+
+
+def test_extract_from_path_counts_subagent_tool_calls(tmp_path: Path) -> None:
+    session = _build_session(tmp_path)
+    result = extract_from_path(session)
+    # Without subagent routing, only the parent's Write would count; with it,
+    # a1/a2's writes are included too.
+    tool_calls = result.get("tool_calls", {})
+    assert tool_calls.get("Write") == 3  # parent + a1 + a2


### PR DESCRIPTION
## Summary

Implements **item 1** of the session-attribution work: a subagent-aware reader
so a session's subagents count toward its own signals (tool calls, tokens,
file writes, commits) instead of being orphaned.

`gptme_sessions.transcript` gains:

- `read_session_tree(path) -> SessionTree` — resolves every `Agent`-tool
  subagent (flat `agent-*.jsonl` and workflow agents under `workflows/*/`,
  nested by `spawnDepth`) into a tree via `.meta.json` `toolUseId` joins.
- `SessionTree` / `SubagentNode` dataclasses with `flatten_records()` and
  `flatten_messages()`.
- `subagent_record_files(path)` — the lightweight file-discovery primitive.

`extract_from_path` now routes through `subagent_record_files`, so subagent
tool calls / tokens / writes count toward the parent. A session with no
subagents is byte-identical (verified).

## Motivation

Erik (2026-09-03): "picker takes newest file in directory is never an
acceptable heuristic … we should be able to accurately attribute." Subagent
outputs should roll up to their parent session so interactive sessions (many
subagents) can be judged on the same footing as autonomous ones.

Previously zero code read `subagents/` — `agent_count` counted spawns but
never the children's work. This closes the read side.

## Verification

- `python3 -m pytest packages/gptme-sessions/tests/` → 1378 passed
  (incl. 6 new `test_transcript_tree.py` cases: nested resolution, flatten
  superset, byte-identical no-subagent, self-loop cycle guard, `extract_from_path`
  subagent counting).
- Real-session smoke: session `ddc0c98d…` (110 Agent calls) resolves 166
  subagents (123 depth-1 / 40 depth-2 / 3 depth-3) and its `extract_from_path`
  now reports tool calls / tokens from children.

## Notes

- Cycle guard: a subagent's own JSONL carries the parent `Agent` tool-use as
  context, so its `toolUseId` re-matches itself — a `visited` set breaks that loop.
- Remaining attribution items (interactive-session grading, parent links for
  out-of-process children) are follow-ups in the tracking task, not this PR.
