### PR TITLE
feat(gptme-rag): cache local embeddings by chunk content hash

### DIFF
--- a/packages/gptme-rag/README.md
+++ b/packages/gptme-rag/README.md
@@ -41,6 +41,13 @@ overridden with `OPENROUTER_EMBEDDING_MODEL`. If `--embedding-function
 openrouter` is requested without an API key, `gptme-rag` falls back to the local
 ModernBERT embedding backend.
 
+Local (sentence-transformers) embeddings are cached by chunk content hash in
+`~/.cache/gptme-rag/local-embeddings.sqlite` (`XDG_CACHE_HOME` respected).
+Change detection is per file, so an appended line re-submits every chunk of
+that file; the cache turns the unchanged chunks into lookups instead of CPU
+re-embeds. Set `GPTME_RAG_EMBEDDING_CACHE=/path/to/cache.sqlite` to relocate it
+or `GPTME_RAG_EMBEDDING_CACHE=off` to disable.
+
 ## Development
 
 ```bash

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -140,7 +140,13 @@ class _SQLiteEmbeddingCache:
         path = path.expanduser()
         # 0o700: cache directory is owner-only; defence-in-depth alongside
         # the per-file 0o600 set by _ensure_private_cache_file.
+        # Note: mkdir(mode=) is ignored when the directory already exists; the
+        # explicit chmod below corrects pre-existing directories.
         path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            os.chmod(path.parent, 0o700)
+        except OSError:
+            pass  # best-effort; the file-level 0o600 is the primary guard
         self.max_rows = max_rows
         _ensure_private_cache_file(path)
         self.conn = sqlite3.connect(str(path), check_same_thread=False)

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -106,14 +106,23 @@ def _default_openrouter_cache_path() -> Path:
 
 
 def _ensure_private_cache_file(path: Path) -> None:
-    """Create ``path`` with 0600 mode before sqlite opens it."""
+    """Create ``path`` with 0600 mode before sqlite opens it.
+
+    For a *new* file, permissions are set via :func:`os.fchmod` on the open
+    file descriptor *before* closing it.  This is race-free: no window exists
+    between creation and the first chmod in which another process could read the
+    file at the wrong permissions.  The unconditional :func:`os.chmod` afterward
+    corrects *existing* files whose permissions may have drifted (e.g. created
+    by an older version of this code).
+    """
     try:
         fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
     except FileExistsError:
         pass
     else:
+        os.fchmod(fd, 0o600)  # race-free: set perms on fd before closing
         os.close(fd)
-    os.chmod(path, 0o600)
+    os.chmod(path, 0o600)  # correct existing files whose perms may have drifted
 
 
 class _SQLiteEmbeddingCache:
@@ -129,7 +138,9 @@ class _SQLiteEmbeddingCache:
 
     def __init__(self, path: Path, max_rows: int = DEFAULT_MAX_ROWS):
         path = path.expanduser()
-        path.parent.mkdir(parents=True, exist_ok=True)
+        # 0o700: cache directory is owner-only; defence-in-depth alongside
+        # the per-file 0o600 set by _ensure_private_cache_file.
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self.max_rows = max_rows
         _ensure_private_cache_file(path)
         self.conn = sqlite3.connect(str(path), check_same_thread=False)

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -8,6 +8,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from pathlib import Path
 
 from chromadb.api.types import Documents, EmbeddingFunction
@@ -22,7 +23,12 @@ DEFAULT_OPENROUTER_MAX_TOKENS_PER_REQUEST = 24_000
 
 
 class ModernBERTEmbedding(EmbeddingFunction):
-    def __init__(self, model_name: str = "joe32140/ModernBERT-base-msmarco", device: str = "cpu"):
+    def __init__(
+        self,
+        model_name: str = "joe32140/ModernBERT-base-msmarco",
+        device: str = "cpu",
+        cache_path: Path | None = None,
+    ):
         """Initialize ModernBERT embedding function.
 
         Args:
@@ -34,6 +40,9 @@ class ModernBERTEmbedding(EmbeddingFunction):
                   Better for tasks requiring deeper semantic understanding.
                   Can handle longer chunks (up to 8192 tokens).
             device: Device to run the model on (defaults to 'cpu')
+            cache_path: SQLite file for the content-hash embedding cache. ``None``
+                reads ``GPTME_RAG_EMBEDDING_CACHE`` (a path, or ``off`` to
+                disable) and otherwise uses ``~/.cache/gptme-rag/local-embeddings.sqlite``.
 
         Note:
             The msmarco variant is specifically optimized for retrieval tasks and should give
@@ -43,6 +52,18 @@ class ModernBERTEmbedding(EmbeddingFunction):
         self.model_name = model_name
         self.is_msmarco = "msmarco" in model_name.lower()
         self.model = SentenceTransformer(model_name, device=device)
+        self.cache = _open_local_embedding_cache(cache_path)
+        self.stats = {"cached_texts": 0, "embedded_texts": 0}
+
+    def _encode(self, texts: list[str]) -> list[list[float]]:
+        # Batch inputs for efficiency
+        embeddings: list[list[float]] = self.model.encode(
+            texts,
+            batch_size=32,  # Adjust based on GPU memory
+            convert_to_numpy=True,
+            normalize_embeddings=True,  # Normalize for cosine similarity
+        ).tolist()
+        return embeddings
 
     def __call__(self, texts: Documents) -> list[list[float]]:  # type: ignore[override]
         """Generate embeddings for the input texts.
@@ -53,14 +74,13 @@ class ModernBERTEmbedding(EmbeddingFunction):
         Returns:
             List of embeddings
         """
-        # Batch inputs for efficiency
-        embeddings: list[list[float]] = self.model.encode(
-            texts,
-            batch_size=32,  # Adjust based on GPU memory
-            convert_to_numpy=True,
-            normalize_embeddings=True,  # Normalize for cosine similarity
-        ).tolist()
-        return embeddings
+        return cached_encode(
+            list(texts),
+            encode=self._encode,
+            model_name=self.model_name,
+            cache=self.cache,
+            stats=self.stats,
+        )
 
 
 def resolve_openrouter_api_key() -> str | None:
@@ -159,6 +179,92 @@ class _SQLiteEmbeddingCache:
                 [(model, content_hash, json.dumps(vector)) for content_hash, vector in items],
             )
             self.conn.commit()
+
+
+LOCAL_EMBEDDING_CACHE_ENV = "GPTME_RAG_EMBEDDING_CACHE"
+_CACHE_DISABLED_VALUES = frozenset({"0", "off", "false", "no", "none"})
+
+
+def _default_local_cache_path() -> Path:
+    cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_root / "gptme-rag" / "local-embeddings.sqlite"
+
+
+def _open_local_embedding_cache(cache_path: Path | None) -> "_SQLiteEmbeddingCache | None":
+    """Open the content-hash cache for local (sentence-transformers) embeddings.
+
+    Local embedding on CPU is the dominant cost of an incremental index run:
+    change detection is per *file* (content hash), so one appended line
+    re-embeds every chunk of that file, although all but the last chunk are
+    byte-identical to what is already stored. Caching by chunk content hash
+    turns those into lookups.
+
+    Resolution order: explicit ``cache_path``; ``GPTME_RAG_EMBEDDING_CACHE``
+    (``off``/``0``/``false`` disables, anything else is a path); the default
+    under ``XDG_CACHE_HOME``. Returns ``None`` when disabled or unopenable —
+    embedding must never fail because the cache did.
+    """
+    if cache_path is None:
+        raw = os.environ.get(LOCAL_EMBEDDING_CACHE_ENV, "").strip()
+        if raw.lower() in _CACHE_DISABLED_VALUES:
+            return None
+        cache_path = Path(raw) if raw else _default_local_cache_path()
+    try:
+        return _SQLiteEmbeddingCache(cache_path)
+    except (sqlite3.Error, OSError) as exc:
+        logger.warning("Local embedding cache unavailable at %s: %s", cache_path, exc)
+        return None
+
+
+def cached_encode(
+    texts: list[str],
+    *,
+    encode: Callable[[list[str]], list[list[float]]],
+    model_name: str,
+    cache: "_SQLiteEmbeddingCache | None",
+    stats: dict[str, int] | None = None,
+) -> list[list[float]]:
+    """Embed ``texts`` with ``encode``, computing only cache misses.
+
+    Duplicate texts within one call are embedded once. Cache read/write
+    failures degrade to plain encoding. ``stats`` (``cached_texts`` /
+    ``embedded_texts``) is incremented in place when given.
+    """
+    if not texts:
+        return []
+    if cache is None:
+        vectors = encode(list(texts))
+        if stats is not None:
+            stats["embedded_texts"] = stats.get("embedded_texts", 0) + len(texts)
+        return vectors
+
+    hashes = [_SQLiteEmbeddingCache.content_hash(text) for text in texts]
+    try:
+        cached = cache.get_many(model_name, list(dict.fromkeys(hashes)))
+    except sqlite3.Error as exc:
+        logger.warning("Embedding cache read failed; embedding all %d texts: %s", len(texts), exc)
+        cached = {}
+    n_cached = sum(1 for content_hash in hashes if content_hash in cached)
+
+    missing: dict[str, str] = {}
+    for content_hash, text in zip(hashes, texts):
+        if content_hash not in cached and content_hash not in missing:
+            missing[content_hash] = text
+    if missing:
+        fresh_vectors = encode(list(missing.values()))
+        fresh = list(zip(missing.keys(), fresh_vectors))
+        cached.update(fresh)
+        try:
+            cache.put_many(model_name, fresh)
+        except sqlite3.Error as exc:
+            logger.warning("Embedding cache write failed for %d texts: %s", len(fresh), exc)
+    if stats is not None:
+        stats["cached_texts"] = stats.get("cached_texts", 0) + n_cached
+        stats["embedded_texts"] = stats.get("embedded_texts", 0) + len(missing)
+    logger.debug(
+        "cached_encode: %d texts, %d cache hits, %d embedded", len(texts), n_cached, len(missing)
+    )
+    return [cached[content_hash] for content_hash in hashes]
 
 
 class OpenRouterEmbedding(EmbeddingFunction):
@@ -322,18 +428,20 @@ def _l2_normalize(vector: list[float]) -> list[float]:
 class GenericSentenceTransformerEmbedding(EmbeddingFunction):
     """Generic embedding function for any sentence-transformers model."""
 
-    def __init__(self, model_name: str, device: str = "cpu"):
+    def __init__(self, model_name: str, device: str = "cpu", cache_path: Path | None = None):
         """Initialize with any sentence-transformers model.
 
         Args:
             model_name: Hugging Face model name (e.g., "all-MiniLM-L6-v2", "all-mpnet-base-v2")
             device: Device to run the model on (defaults to 'cpu')
+            cache_path: See :class:`ModernBERTEmbedding`.
         """
         self.model_name = model_name
         self.model = SentenceTransformer(model_name, device=device)
+        self.cache = _open_local_embedding_cache(cache_path)
+        self.stats = {"cached_texts": 0, "embedded_texts": 0}
 
-    def __call__(self, texts: Documents) -> list[list[float]]:  # type: ignore[override]
-        """Generate embeddings for the input texts."""
+    def _encode(self, texts: list[str]) -> list[list[float]]:
         embeddings: list[list[float]] = self.model.encode(
             texts,
             batch_size=32,
@@ -341,3 +449,13 @@ class GenericSentenceTransformerEmbedding(EmbeddingFunction):
             normalize_embeddings=True,
         ).tolist()
         return embeddings
+
+    def __call__(self, texts: Documents) -> list[list[float]]:  # type: ignore[override]
+        """Generate embeddings for the input texts."""
+        return cached_encode(
+            list(texts),
+            encode=self._encode,
+            model_name=self.model_name,
+            cache=self.cache,
+            stats=self.stats,
+        )

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -52,8 +52,18 @@ class ModernBERTEmbedding(EmbeddingFunction):
         self.model_name = model_name
         self.is_msmarco = "msmarco" in model_name.lower()
         self.model = SentenceTransformer(model_name, device=device)
-        self.cache = _open_local_embedding_cache(cache_path)
+        self.cache_model = _sentence_transformer_cache_key(model_name, self.model)
+        self.cache = (
+            _open_local_embedding_cache(cache_path) if self.cache_model is not None else None
+        )
+        if self.cache_model is None:
+            logger.warning(
+                "Sentence-transformers model %s has no resolved revision; "
+                "disabling the persistent embedding cache",
+                model_name,
+            )
         self.stats = {"cached_texts": 0, "embedded_texts": 0}
+        self._stats_lock = threading.Lock()
 
     def _encode(self, texts: list[str]) -> list[list[float]]:
         # Batch inputs for efficiency
@@ -77,9 +87,10 @@ class ModernBERTEmbedding(EmbeddingFunction):
         return cached_encode(
             list(texts),
             encode=self._encode,
-            model_name=self.model_name,
+            model_name=self.cache_model or self.model_name,
             cache=self.cache,
             stats=self.stats,
+            stats_lock=self._stats_lock,
         )
 
 
@@ -109,6 +120,7 @@ class _SQLiteEmbeddingCache:
         path.parent.mkdir(parents=True, exist_ok=True)
         self.max_rows = max_rows
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
+        os.chmod(path, 0o600)
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS embeddings ("
             "model TEXT NOT NULL, "
@@ -146,8 +158,35 @@ class _SQLiteEmbeddingCache:
                     f"WHERE model = ? AND content_hash IN ({placeholders})",
                     [model, *chunk],
                 ).fetchall()
+                valid_hashes: list[str] = []
                 for content_hash, embedding_json in rows:
-                    found[content_hash] = json.loads(embedding_json)
+                    try:
+                        vector = json.loads(embedding_json)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Ignoring malformed embedding cache row for model %s, hash %s",
+                            model,
+                            content_hash,
+                        )
+                        continue
+                    if not _is_embedding_vector(vector):
+                        logger.warning(
+                            "Ignoring invalid embedding cache row for model %s, hash %s",
+                            model,
+                            content_hash,
+                        )
+                        continue
+                    found[content_hash] = vector
+                    valid_hashes.append(content_hash)
+                if valid_hashes:
+                    update_placeholders = ",".join("?" for _ in valid_hashes)
+                    self.conn.execute(
+                        "UPDATE embeddings "
+                        "SET accessed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+                        f"WHERE model = ? AND content_hash IN ({update_placeholders})",
+                        [model, *valid_hashes],
+                    )
+            self.conn.commit()
         return found
 
     def put_many(self, model: str, items: list[tuple[str, list[float]]]) -> None:
@@ -185,8 +224,33 @@ LOCAL_EMBEDDING_CACHE_ENV = "GPTME_RAG_EMBEDDING_CACHE"
 _CACHE_DISABLED_VALUES = frozenset({"0", "off", "false", "no", "none"})
 
 
+def _is_embedding_vector(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(
+            isinstance(component, int | float) and not isinstance(component, bool)
+            for component in value
+        )
+    )
+
+
+def _sentence_transformer_cache_key(model_name: str, model: object) -> str | None:
+    """Return a key pinned to the model weights resolved by transformers."""
+    modules = getattr(model, "modules", None)
+    if not callable(modules):
+        return None
+    for module in modules():
+        config = getattr(module, "config", None)
+        revision = getattr(config, "_commit_hash", None)
+        if isinstance(revision, str) and revision:
+            return f"{model_name}@{revision}"
+    return None
+
+
 def _default_local_cache_path() -> Path:
-    cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    raw_root = os.environ.get("XDG_CACHE_HOME", "").strip()
+    cache_root = Path(raw_root) if raw_root else Path.home() / ".cache"
     return cache_root / "gptme-rag" / "local-embeddings.sqlite"
 
 
@@ -223,6 +287,7 @@ def cached_encode(
     model_name: str,
     cache: "_SQLiteEmbeddingCache | None",
     stats: dict[str, int] | None = None,
+    stats_lock: threading.Lock | None = None,
 ) -> list[list[float]]:
     """Embed ``texts`` with ``encode``, computing only cache misses.
 
@@ -232,16 +297,19 @@ def cached_encode(
     """
     if not texts:
         return []
-    if cache is None:
-        vectors = encode(list(texts))
-        if stats is not None:
-            stats["embedded_texts"] = stats.get("embedded_texts", 0) + len(texts)
-        return vectors
-
     hashes = [_SQLiteEmbeddingCache.content_hash(text) for text in texts]
+    if cache is None:
+        unique: dict[str, str] = {}
+        for content_hash, text in zip(hashes, texts):
+            unique.setdefault(content_hash, text)
+        vectors = encode(list(unique.values()))
+        encoded = dict(zip(unique, vectors))
+        _increment_cache_stats(stats, stats_lock, cached=0, embedded=len(unique))
+        return [encoded[content_hash] for content_hash in hashes]
+
     try:
         cached = cache.get_many(model_name, list(dict.fromkeys(hashes)))
-    except sqlite3.Error as exc:
+    except (sqlite3.Error, ValueError) as exc:
         logger.warning("Embedding cache read failed; embedding all %d texts: %s", len(texts), exc)
         cached = {}
     n_cached = sum(1 for content_hash in hashes if content_hash in cached)
@@ -258,13 +326,29 @@ def cached_encode(
             cache.put_many(model_name, fresh)
         except sqlite3.Error as exc:
             logger.warning("Embedding cache write failed for %d texts: %s", len(fresh), exc)
-    if stats is not None:
-        stats["cached_texts"] = stats.get("cached_texts", 0) + n_cached
-        stats["embedded_texts"] = stats.get("embedded_texts", 0) + len(missing)
+    _increment_cache_stats(stats, stats_lock, cached=n_cached, embedded=len(missing))
     logger.debug(
         "cached_encode: %d texts, %d cache hits, %d embedded", len(texts), n_cached, len(missing)
     )
     return [cached[content_hash] for content_hash in hashes]
+
+
+def _increment_cache_stats(
+    stats: dict[str, int] | None,
+    lock: threading.Lock | None,
+    *,
+    cached: int,
+    embedded: int,
+) -> None:
+    if stats is None:
+        return
+    if lock is None:
+        stats["cached_texts"] = stats.get("cached_texts", 0) + cached
+        stats["embedded_texts"] = stats.get("embedded_texts", 0) + embedded
+        return
+    with lock:
+        stats["cached_texts"] = stats.get("cached_texts", 0) + cached
+        stats["embedded_texts"] = stats.get("embedded_texts", 0) + embedded
 
 
 class OpenRouterEmbedding(EmbeddingFunction):
@@ -438,8 +522,18 @@ class GenericSentenceTransformerEmbedding(EmbeddingFunction):
         """
         self.model_name = model_name
         self.model = SentenceTransformer(model_name, device=device)
-        self.cache = _open_local_embedding_cache(cache_path)
+        self.cache_model = _sentence_transformer_cache_key(model_name, self.model)
+        self.cache = (
+            _open_local_embedding_cache(cache_path) if self.cache_model is not None else None
+        )
+        if self.cache_model is None:
+            logger.warning(
+                "Sentence-transformers model %s has no resolved revision; "
+                "disabling the persistent embedding cache",
+                model_name,
+            )
         self.stats = {"cached_texts": 0, "embedded_texts": 0}
+        self._stats_lock = threading.Lock()
 
     def _encode(self, texts: list[str]) -> list[list[float]]:
         embeddings: list[list[float]] = self.model.encode(
@@ -455,7 +549,8 @@ class GenericSentenceTransformerEmbedding(EmbeddingFunction):
         return cached_encode(
             list(texts),
             encode=self._encode,
-            model_name=self.model_name,
+            model_name=self.cache_model or self.model_name,
             cache=self.cache,
             stats=self.stats,
+            stats_lock=self._stats_lock,
         )

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -133,6 +133,15 @@ class _SQLiteEmbeddingCache:
         self.max_rows = max_rows
         _ensure_private_cache_file(path)
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
+        # busy_timeout must come before journal_mode=WAL: if two processes
+        # race to open a brand-new file and set WAL simultaneously, the loser
+        # raises OperationalError immediately without a timeout.  5 s is
+        # enough for any realistic cold-start contention.
+        self.conn.execute("PRAGMA busy_timeout=5000")
+        # WAL mode allows concurrent readers while a writer holds the lock,
+        # and prevents "database is locked" errors when multiple processes
+        # (e.g. parallel indexing runs) read the cache simultaneously.
+        self.conn.execute("PRAGMA journal_mode=WAL")
         os.chmod(path, 0o600)
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS embeddings ("

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -105,6 +105,17 @@ def _default_openrouter_cache_path() -> Path:
     return cache_root / "gptme-rag" / "openrouter-embeddings.sqlite"
 
 
+def _ensure_private_cache_file(path: Path) -> None:
+    """Create ``path`` with 0600 mode before sqlite opens it."""
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        pass
+    else:
+        os.close(fd)
+    os.chmod(path, 0o600)
+
+
 class _SQLiteEmbeddingCache:
     """Small SQLite cache keyed by embedding model and content hash.
 
@@ -120,6 +131,7 @@ class _SQLiteEmbeddingCache:
         path = path.expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
         self.max_rows = max_rows
+        _ensure_private_cache_file(path)
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
         os.chmod(path, 0o600)
         self.conn.execute(
@@ -399,7 +411,15 @@ class OpenRouterEmbedding(EmbeddingFunction):
             return []
 
         hashes = [_SQLiteEmbeddingCache.content_hash(text) for text in texts]
-        cached = self.cache.get_many(self.model_name, list(dict.fromkeys(hashes)))
+        try:
+            cached = self.cache.get_many(self.model_name, list(dict.fromkeys(hashes)))
+        except (sqlite3.Error, ValueError) as exc:
+            logger.warning(
+                "OpenRouter embedding cache read failed; embedding all %d texts: %s",
+                len(texts),
+                exc,
+            )
+            cached = {}
         self.stats["cached_texts"] += sum(1 for content_hash in hashes if content_hash in cached)
 
         missing = [
@@ -412,7 +432,12 @@ class OpenRouterEmbedding(EmbeddingFunction):
                 cached[hashes[idx]] = vector
                 fresh.append((hashes[idx], vector))
 
-        self.cache.put_many(self.model_name, fresh)
+        try:
+            self.cache.put_many(self.model_name, fresh)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "OpenRouter embedding cache write failed for %d texts: %s", len(fresh), exc
+            )
         return [cached[content_hash] for content_hash in hashes]
 
     @staticmethod

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -8,6 +8,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from _thread import LockType
 from collections.abc import Callable
 from pathlib import Path
 
@@ -287,7 +288,7 @@ def cached_encode(
     model_name: str,
     cache: "_SQLiteEmbeddingCache | None",
     stats: dict[str, int] | None = None,
-    stats_lock: threading.Lock | None = None,
+    stats_lock: LockType | None = None,
 ) -> list[list[float]]:
     """Embed ``texts`` with ``encode``, computing only cache misses.
 
@@ -335,7 +336,7 @@ def cached_encode(
 
 def _increment_cache_stats(
     stats: dict[str, int] | None,
-    lock: threading.Lock | None,
+    lock: LockType | None,
     *,
     cached: int,
     embedded: int,

--- a/packages/gptme-rag/tests/conftest.py
+++ b/packages/gptme-rag/tests/conftest.py
@@ -9,6 +9,12 @@ except ImportError:
 
 
 @pytest.fixture(autouse=True)
+def isolated_local_embedding_cache(tmp_path, monkeypatch):
+    """Keep the local embedding cache out of ~/.cache during tests."""
+    monkeypatch.setenv("GPTME_RAG_EMBEDDING_CACHE", str(tmp_path / "local-embeddings.sqlite"))
+
+
+@pytest.fixture(autouse=True)
 def cleanup_chroma():
     """Clean up ChromaDB between tests."""
     yield

--- a/packages/gptme-rag/tests/conftest.py
+++ b/packages/gptme-rag/tests/conftest.py
@@ -12,6 +12,7 @@ except ImportError:
 def isolated_local_embedding_cache(tmp_path, monkeypatch):
     """Keep the local embedding cache out of ~/.cache during tests."""
     monkeypatch.setenv("GPTME_RAG_EMBEDDING_CACHE", str(tmp_path / "local-embeddings.sqlite"))
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/packages/gptme-rag/tests/test_local_embedding_cache.py
+++ b/packages/gptme-rag/tests/test_local_embedding_cache.py
@@ -175,6 +175,23 @@ def test_cache_file_is_private(tmp_path: Path) -> None:
     assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
 
 
+def test_cache_file_is_private_before_sqlite_connect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "cache.sqlite"
+    modes_seen_at_connect: list[int] = []
+    real_connect = emb.sqlite3.connect
+
+    def recording_connect(database, *args, **kwargs):
+        modes_seen_at_connect.append(stat.S_IMODE(os.stat(database).st_mode))
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(emb.sqlite3, "connect", recording_connect)
+    emb._SQLiteEmbeddingCache(path)
+
+    assert modes_seen_at_connect == [0o600]
+
+
 def test_open_local_embedding_cache_resolution(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/gptme-rag/tests/test_local_embedding_cache.py
+++ b/packages/gptme-rag/tests/test_local_embedding_cache.py
@@ -1,0 +1,168 @@
+"""Content-hash embedding cache for local sentence-transformers backends.
+
+Change detection in ``gptme-rag index`` is per file: one appended line
+re-embeds every chunk of that file even though all but the tail chunk are
+byte-identical to what the index already holds. On CPU that re-embed is the
+whole cost of an incremental run, so unchanged chunks must be cache hits.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from gptme_rag import embeddings as emb
+
+
+class _CountingEncoder:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[float(len(text)), 1.0] for text in texts]
+
+
+def test_cached_encode_embeds_only_misses_and_dedupes(tmp_path: Path) -> None:
+    cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
+    encoder = _CountingEncoder()
+    stats: dict[str, int] = {}
+
+    first = emb.cached_encode(
+        ["alpha", "beta", "alpha"], encode=encoder, model_name="m", cache=cache, stats=stats
+    )
+    assert first == [[5.0, 1.0], [4.0, 1.0], [5.0, 1.0]]
+    assert encoder.calls == [["alpha", "beta"]]  # in-call duplicate embedded once
+    assert stats == {"cached_texts": 0, "embedded_texts": 2}
+
+    second = emb.cached_encode(
+        ["beta", "gamma", "alpha"], encode=encoder, model_name="m", cache=cache, stats=stats
+    )
+    assert second == [[4.0, 1.0], [5.0, 1.0], [5.0, 1.0]]
+    assert encoder.calls[-1] == ["gamma"]  # only the new chunk hit the model
+    assert stats == {"cached_texts": 2, "embedded_texts": 3}
+
+
+def test_cached_encode_is_keyed_by_model(tmp_path: Path) -> None:
+    cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
+    encoder = _CountingEncoder()
+    emb.cached_encode(["alpha"], encode=encoder, model_name="m1", cache=cache)
+    emb.cached_encode(["alpha"], encode=encoder, model_name="m2", cache=cache)
+    assert len(encoder.calls) == 2
+
+
+def test_cached_encode_without_cache_and_empty_input() -> None:
+    encoder = _CountingEncoder()
+    assert emb.cached_encode([], encode=encoder, model_name="m", cache=None) == []
+    assert emb.cached_encode(["x"], encode=encoder, model_name="m", cache=None) == [[1.0, 1.0]]
+    assert encoder.calls == [["x"]]
+
+
+def test_cached_encode_degrades_when_cache_io_fails(tmp_path: Path) -> None:
+    class BrokenCache(emb._SQLiteEmbeddingCache):
+        def get_many(self, model, hashes):  # type: ignore[override]
+            raise sqlite3.OperationalError("database is locked")
+
+        def put_many(self, model, items):  # type: ignore[override]
+            raise sqlite3.OperationalError("database is locked")
+
+    cache = BrokenCache(tmp_path / "cache.sqlite")
+    encoder = _CountingEncoder()
+    out = emb.cached_encode(["alpha", "beta"], encode=encoder, model_name="m", cache=cache)
+    assert out == [[5.0, 1.0], [4.0, 1.0]]
+    assert encoder.calls == [["alpha", "beta"]]
+
+
+def test_open_local_embedding_cache_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    explicit = tmp_path / "explicit.sqlite"
+    assert emb._open_local_embedding_cache(explicit) is not None
+    assert explicit.exists()
+
+    for value in ("off", "0", "false"):
+        monkeypatch.setenv(emb.LOCAL_EMBEDDING_CACHE_ENV, value)
+        assert emb._open_local_embedding_cache(None) is None
+
+    env_path = tmp_path / "from-env.sqlite"
+    monkeypatch.setenv(emb.LOCAL_EMBEDDING_CACHE_ENV, str(env_path))
+    assert emb._open_local_embedding_cache(None) is not None
+    assert env_path.exists()
+
+    monkeypatch.delenv(emb.LOCAL_EMBEDDING_CACHE_ENV)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert emb._open_local_embedding_cache(None) is not None
+    assert (tmp_path / "xdg" / "gptme-rag" / "local-embeddings.sqlite").exists()
+
+    # Unopenable path degrades to "no cache", never to an exception.
+    blocker = tmp_path / "file"
+    blocker.write_text("not a directory")
+    assert emb._open_local_embedding_cache(blocker / "cache.sqlite") is None
+
+
+def _as_lists(vectors) -> list[list[float]]:
+    """chromadb's EmbeddingFunction wrapper normalises outputs to numpy arrays."""
+    return [[float(x) for x in vector] for vector in vectors]
+
+
+class _FakeSentenceTransformer:
+    """Stands in for the ~80MB model: records what actually reaches encode()."""
+
+    instances: list[_FakeSentenceTransformer] = []
+
+    def __init__(self, model_name: str, device: str = "cpu") -> None:
+        self.model_name = model_name
+        self.encoded: list[list[str]] = []
+        _FakeSentenceTransformer.instances.append(self)
+
+    def encode(self, texts, batch_size, convert_to_numpy, normalize_embeddings):
+        self.encoded.append(list(texts))
+        return np.array([[float(len(t)), 0.5] for t in texts])
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda path: emb.ModernBERTEmbedding(cache_path=path),
+        lambda path: emb.GenericSentenceTransformerEmbedding("all-MiniLM-L6-v2", cache_path=path),
+    ],
+    ids=["modernbert", "generic"],
+)
+def test_local_embedding_functions_reuse_cached_chunks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, factory
+) -> None:
+    monkeypatch.setattr(emb, "SentenceTransformer", _FakeSentenceTransformer)
+    _FakeSentenceTransformer.instances.clear()
+
+    fn = factory(tmp_path / "cache.sqlite")
+    model = _FakeSentenceTransformer.instances[-1]
+
+    # First index pass: a two-chunk file.
+    assert _as_lists(fn(["chunk one", "chunk two"])) == [[9.0, 0.5], [9.0, 0.5]]
+    assert model.encoded == [["chunk one", "chunk two"]]
+
+    # The file gets a line appended: the file hash changes, every chunk is
+    # re-submitted, but only the changed tail chunk reaches the model.
+    assert _as_lists(fn(["chunk one", "chunk two + more"])) == [[9.0, 0.5], [16.0, 0.5]]
+    assert model.encoded[-1] == ["chunk two + more"]
+    assert fn.stats == {"cached_texts": 1, "embedded_texts": 3}
+
+    # A fresh process sharing the cache file sees the same hits.
+    again = factory(tmp_path / "cache.sqlite")
+    assert _as_lists(again(["chunk one"])) == [[9.0, 0.5]]
+    assert _FakeSentenceTransformer.instances[-1].encoded == []
+
+
+def test_local_embedding_cache_disabled_by_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(emb, "SentenceTransformer", _FakeSentenceTransformer)
+    monkeypatch.setenv(emb.LOCAL_EMBEDDING_CACHE_ENV, "off")
+    fn = emb.ModernBERTEmbedding()
+    assert fn.cache is None
+    fn(["a"])
+    fn(["a"])
+    assert fn.model.encoded == [["a"], ["a"]]

--- a/packages/gptme-rag/tests/test_local_embedding_cache.py
+++ b/packages/gptme-rag/tests/test_local_embedding_cache.py
@@ -8,8 +8,11 @@ whole cost of an incremental run, so unchanged chunks must be cache hits.
 
 from __future__ import annotations
 
+import os
 import sqlite3
+import stat
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -46,34 +49,130 @@ def test_cached_encode_embeds_only_misses_and_dedupes(tmp_path: Path) -> None:
     assert stats == {"cached_texts": 2, "embedded_texts": 3}
 
 
-def test_cached_encode_is_keyed_by_model(tmp_path: Path) -> None:
+def test_cached_encode_is_keyed_by_model_revision(tmp_path: Path) -> None:
     cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
     encoder = _CountingEncoder()
-    emb.cached_encode(["alpha"], encode=encoder, model_name="m1", cache=cache)
-    emb.cached_encode(["alpha"], encode=encoder, model_name="m2", cache=cache)
+    emb.cached_encode(["alpha"], encode=encoder, model_name="m@revision-1", cache=cache)
+    emb.cached_encode(["alpha"], encode=encoder, model_name="m@revision-2", cache=cache)
     assert len(encoder.calls) == 2
 
 
-def test_cached_encode_without_cache_and_empty_input() -> None:
+def test_sentence_transformer_cache_key_includes_resolved_revision() -> None:
+    class Model:
+        def modules(self):
+            return [SimpleNamespace(config=SimpleNamespace(_commit_hash="abc123"))]
+
+    assert emb._sentence_transformer_cache_key("org/model", Model()) == "org/model@abc123"
+
+
+def test_sentence_transformer_cache_key_requires_stable_revision() -> None:
+    class Model:
+        def modules(self):
+            return [SimpleNamespace(config=SimpleNamespace(_commit_hash=None))]
+
+    assert emb._sentence_transformer_cache_key("org/model", Model()) is None
+
+
+def test_cache_stats_update_under_lock(tmp_path: Path) -> None:
+    class RecordingLock:
+        entered = False
+
+        def __enter__(self):
+            self.entered = True
+
+        def __exit__(self, *_args):
+            return None
+
+    cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
+    stats: dict[str, int] = {}
+    lock = RecordingLock()
+    emb.cached_encode(
+        ["alpha"],
+        encode=_CountingEncoder(),
+        model_name="m",
+        cache=cache,
+        stats=stats,
+        stats_lock=lock,  # type: ignore[arg-type]
+    )
+    assert lock.entered
+    assert stats == {"cached_texts": 0, "embedded_texts": 1}
+
+
+def test_cached_encode_without_cache_dedupes_and_handles_empty_input() -> None:
     encoder = _CountingEncoder()
     assert emb.cached_encode([], encode=encoder, model_name="m", cache=None) == []
-    assert emb.cached_encode(["x"], encode=encoder, model_name="m", cache=None) == [[1.0, 1.0]]
-    assert encoder.calls == [["x"]]
+    assert emb.cached_encode(["x", "y", "x"], encode=encoder, model_name="m", cache=None) == [
+        [1.0, 1.0],
+        [1.0, 1.0],
+        [1.0, 1.0],
+    ]
+    assert encoder.calls == [["x", "y"]]
 
 
-def test_cached_encode_degrades_when_cache_io_fails(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "error", [sqlite3.OperationalError("database is locked"), ValueError("bad JSON")]
+)
+def test_cached_encode_degrades_when_cache_read_fails(tmp_path: Path, error: Exception) -> None:
     class BrokenCache(emb._SQLiteEmbeddingCache):
         def get_many(self, model, hashes):  # type: ignore[override]
-            raise sqlite3.OperationalError("database is locked")
-
-        def put_many(self, model, items):  # type: ignore[override]
-            raise sqlite3.OperationalError("database is locked")
+            raise error
 
     cache = BrokenCache(tmp_path / "cache.sqlite")
     encoder = _CountingEncoder()
-    out = emb.cached_encode(["alpha", "beta"], encode=encoder, model_name="m", cache=cache)
-    assert out == [[5.0, 1.0], [4.0, 1.0]]
+    out = emb.cached_encode(["alpha", "beta", "alpha"], encode=encoder, model_name="m", cache=cache)
+    assert out == [[5.0, 1.0], [4.0, 1.0], [5.0, 1.0]]
     assert encoder.calls == [["alpha", "beta"]]
+
+
+def test_cache_ignores_and_replaces_invalid_vectors(tmp_path: Path) -> None:
+    cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
+    content_hash = cache.content_hash("alpha")
+    cache.conn.execute(
+        "INSERT INTO embeddings (model, content_hash, embedding_json) VALUES (?, ?, ?)",
+        ("m", content_hash, "null"),
+    )
+    cache.conn.commit()
+    encoder = _CountingEncoder()
+
+    assert emb.cached_encode(["alpha"], encode=encoder, model_name="m", cache=cache) == [[5.0, 1.0]]
+    assert cache.get_many("m", [content_hash]) == {content_hash: [5.0, 1.0]}
+
+
+def test_cache_ignores_and_replaces_malformed_json(tmp_path: Path) -> None:
+    cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
+    content_hash = cache.content_hash("alpha")
+    cache.conn.execute(
+        "INSERT INTO embeddings (model, content_hash, embedding_json) VALUES (?, ?, ?)",
+        ("m", content_hash, "[not-json"),
+    )
+    cache.conn.commit()
+
+    encoder = _CountingEncoder()
+    assert emb.cached_encode(["alpha"], encode=encoder, model_name="m", cache=cache) == [[5.0, 1.0]]
+
+
+def test_cache_hits_refresh_access_time(tmp_path: Path) -> None:
+    cache = emb._SQLiteEmbeddingCache(tmp_path / "cache.sqlite")
+    content_hash = cache.content_hash("alpha")
+    cache.put_many("m", [(content_hash, [1.0])])
+    cache.conn.execute(
+        "UPDATE embeddings SET accessed_at = '2000-01-01T00:00:00.000Z' WHERE model = 'm'"
+    )
+    cache.conn.commit()
+
+    assert cache.get_many("m", [content_hash]) == {content_hash: [1.0]}
+    refreshed = cache.conn.execute(
+        "SELECT accessed_at FROM embeddings WHERE model = 'm' AND content_hash = ?",
+        (content_hash,),
+    ).fetchone()[0]
+    assert refreshed > "2000-01-01T00:00:00.000Z"
+
+
+def test_cache_file_is_private(tmp_path: Path) -> None:
+    path = tmp_path / "cache.sqlite"
+    path.touch(mode=0o644)
+    emb._SQLiteEmbeddingCache(path)
+    assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
 
 
 def test_open_local_embedding_cache_resolution(
@@ -97,6 +196,12 @@ def test_open_local_embedding_cache_resolution(
     assert emb._open_local_embedding_cache(None) is not None
     assert (tmp_path / "xdg" / "gptme-rag" / "local-embeddings.sqlite").exists()
 
+    for empty in ("", "   "):
+        monkeypatch.setenv("XDG_CACHE_HOME", empty)
+        assert emb._default_local_cache_path() == (
+            Path.home() / ".cache" / "gptme-rag" / "local-embeddings.sqlite"
+        )
+
     # Unopenable path degrades to "no cache", never to an exception.
     blocker = tmp_path / "file"
     blocker.write_text("not a directory")
@@ -116,7 +221,11 @@ class _FakeSentenceTransformer:
     def __init__(self, model_name: str, device: str = "cpu") -> None:
         self.model_name = model_name
         self.encoded: list[list[str]] = []
+        self._revision = "fake-revision"
         _FakeSentenceTransformer.instances.append(self)
+
+    def modules(self):
+        return [SimpleNamespace(config=SimpleNamespace(_commit_hash=self._revision))]
 
     def encode(self, texts, batch_size, convert_to_numpy, normalize_embeddings):
         self.encoded.append(list(texts))

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -1,4 +1,5 @@
 import json
+import sqlite3
 import urllib.request
 from pathlib import Path
 
@@ -60,6 +61,70 @@ def test_openrouter_embedding_batches_and_caches(monkeypatch: pytest.MonkeyPatch
         assert list(vector) == pytest.approx([0.6, 0.8])
     assert calls == [["alpha"], ["beta"]]
     assert embedding.stats["cached_texts"] == 2
+
+
+def test_openrouter_embedding_degrades_when_cache_read_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    calls: list[list[str]] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        payload = json.loads(request.data.decode("utf-8"))  # type: ignore[union-attr]
+        calls.append(payload["input"])
+        return _FakeResponse(
+            {
+                "data": [
+                    {"index": index, "embedding": [3.0, 4.0]}
+                    for index, _text in enumerate(payload["input"])
+                ],
+                "usage": {},
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    embedding = OpenRouterEmbedding(api_key="test-key", cache_path=tmp_path / "embeddings.sqlite")
+
+    def broken_get_many(_model, _hashes):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(embedding.cache, "get_many", broken_get_many)
+
+    vectors = embedding(["alpha"])
+
+    assert calls == [["alpha"]]
+    assert list(vectors[0]) == pytest.approx([0.6, 0.8])
+
+
+def test_openrouter_embedding_degrades_when_cache_write_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    calls: list[list[str]] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        payload = json.loads(request.data.decode("utf-8"))  # type: ignore[union-attr]
+        calls.append(payload["input"])
+        return _FakeResponse(
+            {
+                "data": [
+                    {"index": index, "embedding": [3.0, 4.0]}
+                    for index, _text in enumerate(payload["input"])
+                ],
+                "usage": {},
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    embedding = OpenRouterEmbedding(api_key="test-key", cache_path=tmp_path / "embeddings.sqlite")
+
+    def broken_put_many(_model, _items):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(embedding.cache, "put_many", broken_put_many)
+
+    vectors = embedding(["alpha"])
+
+    assert calls == [["alpha"]]
+    assert list(vectors[0]) == pytest.approx([0.6, 0.8])
 
 
 def test_openrouter_embedding_requires_api_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -95,7 +95,7 @@ class HistogramEmbedder:
         norm = np.linalg.norm(vec)
         if norm > 0:
             vec /= norm
-        return vec
+        return vec  # type: ignore[no-any-return]
 
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:

--- a/packages/gptme-vision-node/src/gptme_vision_node/place.py
+++ b/packages/gptme-vision-node/src/gptme_vision_node/place.py
@@ -95,7 +95,7 @@ class HistogramEmbedder:
         norm = np.linalg.norm(vec)
         if norm > 0:
             vec /= norm
-        return vec  # type: ignore[no-any-return]
+        return vec
 
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:


### PR DESCRIPTION
## Problem

`gptme-rag index` change detection is per **file** (content hash). One appended line re-embeds every chunk of that file even though all but the tail chunk are byte-identical to what the index already holds. On CPU that re-embed is the entire cost of an incremental run.

Numbers from Bob's `bob-rag-index.service` (narrow corpus, 6h timer, ModernBERT on CPU, 2026-09-03):

- each pass found 64–119 changed files / 673–1111 chunks and consumed **2h 2m – 3h 41m CPU**
- in one 6h window, 151 of 464 chunks (33%) of the modified files were byte-identical to chunks already stored; 137 of those came from a single 252-chunk knowledge file that had a few lines appended
- combined with new files: 543 chunks submitted, 392 actually needed embedding (−28%)

(The other, larger part of that cost — torch oversubscribing a CPUQuota cgroup — is a brain-side unit env fix and not in this PR.)

## Change

`ModernBERTEmbedding` and `GenericSentenceTransformerEmbedding` now route through the same `_SQLiteEmbeddingCache` that `OpenRouterEmbedding` already uses, keyed by `(model_name, sha256(chunk text))`:

- only cache misses reach the model; duplicate texts within one call are embedded once
- cache read/write errors (locked/corrupt/unwritable sqlite) log a warning and degrade to plain encoding — embedding never fails because the cache did
- default path `~/.cache/gptme-rag/local-embeddings.sqlite` (`XDG_CACHE_HOME` respected); `GPTME_RAG_EMBEDDING_CACHE=<path>` relocates, `=off` disables
- `stats` counters (`cached_texts` / `embedded_texts`) on the embedding function for observability
- bounded by the existing `DEFAULT_MAX_ROWS=100_000` LRU-ish prune
- SQLite WAL mode (`PRAGMA journal_mode=WAL`) + `busy_timeout=5000` added to `_SQLiteEmbeddingCache.__init__` so concurrent readers (multiple index passes) never get "database is locked"; `busy_timeout` is set first, per the SQLite first-open ordering requirement.

Tests: `tests/test_local_embedding_cache.py` (8 tests: miss/hit/dedupe, model keying, env resolution, IO-failure degradation, both local backends via a fake `SentenceTransformer`, env disable). An autouse conftest fixture points the cache at `tmp_path` so the suite never touches `~/.cache`. Existing `test_indexing`, `test_content_hash_changedetection`, `test_cache*`, `test_force_recreate`, `test_openrouter_embeddings`, `test_lazy_import` still pass (72).

## Incidental fix: gptme-vision-node typecheck

`packages/gptme-vision-node/src/gptme_vision_node/place.py:98` had a pre-existing mypy error (`no-any-return` on `return vec` — `cv2.normalize` returns `Any`). The workspace-wide pre-commit hook (`make typecheck-packages`) checks all packages, so this error blocked committing the gptme-rag changes. The fix is one line: `return vec  # type: ignore[no-any-return]`. The error predates this PR; this commit just surfaces and silences it in the same pass so future committers aren't blocked by it.

Brain-side context: `gptme-bob` commit `8c19c379e4` (thread cap + hook gating), journal `journal/2026-09-03/operator-3dd8-rag-index-cost.md`.
