### PR TITLE
feat(voice): drive a /local realtime turn with text

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -39,6 +39,9 @@ _MAX_INSTRUCTIONS_LEN = 4096
 # than enough for any realistic session-handshake delay while still capping
 # memory growth if the provider never confirms the session.
 _MAX_PENDING_AUDIO_CHUNKS = 500
+# A provider handshake should normally complete in under a second. Bound text
+# turns so a missing ready event cannot pin a /local connection forever.
+_SESSION_READY_TIMEOUT_SECONDS = 10.0
 # OpenAI's model catalog currently markets `gpt-realtime-2`, while the
 # Realtime API reference may still enumerate the older generic alias instead.
 # Keep the newer default, but retry once with the generic alias if the
@@ -655,7 +658,13 @@ class OpenAIRealtimeClient:
         """
         if self._session_ready is None:
             raise RuntimeError("Not connected to OpenAI Realtime API")
-        await self._session_ready.wait()
+        try:
+            await asyncio.wait_for(
+                self._session_ready.wait(),
+                timeout=_SESSION_READY_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError("Realtime session was not ready in time") from exc
 
         logger.info("Sending text message: %s...", text[:100])
         await self._send_event(

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -653,6 +653,10 @@ class OpenAIRealtimeClient:
         a headless client can drive a full turn — including tool calls — without
         a microphone.
         """
+        if self._session_ready is None:
+            raise RuntimeError("Not connected to OpenAI Realtime API")
+        await self._session_ready.wait()
+
         logger.info("Sending text message: %s...", text[:100])
         await self._send_event(
             "conversation.item.create",

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -644,6 +644,28 @@ class OpenAIRealtimeClient:
         # Start receiving messages
         self._receive_task = asyncio.create_task(self._receive_loop())
 
+    async def send_text_message(self, text: str) -> None:
+        """Send a caller utterance as text and trigger a response.
+
+        Text equivalent of a spoken turn: unlike :meth:`inject_message` (which
+        tags the content as an async subagent result), this delivers ``text``
+        verbatim as the user's own turn. Used by the ``/local`` test endpoint so
+        a headless client can drive a full turn — including tool calls — without
+        a microphone.
+        """
+        logger.info("Sending text message: %s...", text[:100])
+        await self._send_event(
+            "conversation.item.create",
+            {
+                "item": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}],
+                }
+            },
+        )
+        await self._send_event("response.create", {})
+
     async def inject_message(self, text: str) -> None:
         """Inject a message into the conversation and trigger a response.
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import contextlib
 import hashlib
+import ipaddress
 import json
 import logging
 import os
@@ -72,6 +73,20 @@ def _websocket_peer_host(websocket) -> str | None:
         if isinstance(first, str) and first:
             return first
     return None
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    """Whether a peer host is loopback, including IPv4-mapped IPv6."""
+    if host == "localhost":
+        return True
+    if host is None:
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    mapped = getattr(address, "ipv4_mapped", None)
+    return address.is_loopback or (mapped is not None and mapped.is_loopback)
 
 
 def _websocket_has_vision(websocket) -> bool:
@@ -1093,7 +1108,7 @@ class VoiceServer:
             )
             return None
         host = _websocket_peer_host(websocket)
-        if host in {"127.0.0.1", "::1", "localhost"}:
+        if _is_loopback_host(host):
             return self.body_adapter
         logger.warning(
             "Body tools disabled for unauthenticated %s client %s",
@@ -2758,7 +2773,7 @@ class VoiceServer:
         or test client.
         """
         peer_host = _websocket_peer_host(websocket)
-        if peer_host not in {"127.0.0.1", "::1", "localhost"}:
+        if not _is_loopback_host(peer_host):
             logger.warning(
                 "Rejecting unauthenticated /local client %s",
                 peer_host or "unknown",
@@ -2843,7 +2858,17 @@ class VoiceServer:
                     # (including tool calls) without sending audio.
                     text = data.get("text", "")
                     if isinstance(text, str) and text.strip():
-                        await realtime_client.send_text_message(text)
+                        try:
+                            await realtime_client.send_text_message(text)
+                        except RuntimeError as exc:
+                            logger.warning("Text turn failed: %s", exc)
+                            continue
+                        _append_transcript_turn(
+                            transcript,
+                            "user",
+                            text,
+                            allow_continuation=False,
+                        )
 
         except WebSocketDisconnect:
             pass  # Normal path when _schedule_hangup closes the WebSocket

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -2757,6 +2757,15 @@ class VoiceServer:
         Allows testing without Twilio by connecting directly from a browser
         or test client.
         """
+        peer_host = _websocket_peer_host(websocket)
+        if peer_host not in {"127.0.0.1", "::1", "localhost"}:
+            logger.warning(
+                "Rejecting unauthenticated /local client %s",
+                peer_host or "unknown",
+            )
+            await websocket.close(code=1008)
+            return
+
         await websocket.accept()
 
         caller_id = self._get_local_caller_id(websocket)

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -2829,6 +2829,13 @@ class VoiceServer:
                 elif data.get("type") == "commit":
                     await realtime_client.commit_audio()
 
+                elif data.get("type") == "text":
+                    # Headless text turn: drive a full conversation turn
+                    # (including tool calls) without sending audio.
+                    text = data.get("text", "")
+                    if isinstance(text, str) and text.strip():
+                        await realtime_client.send_text_message(text)
+
         except WebSocketDisconnect:
             pass  # Normal path when _schedule_hangup closes the WebSocket
         except RuntimeError as exc:

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -1225,3 +1225,48 @@ def test_non_introspectable_two_arg_internal_typeerror_propagates_when_fallback_
     asyncio.run(_run())
     # Callback must NOT have run with incomplete data.
     assert calls == []
+
+
+def test_send_text_message_delivers_verbatim_user_turn() -> None:
+    """A text turn must arrive as the caller's own words, not a subagent result.
+
+    ``inject_message`` prefixes ``[Subagent result]:`` because it delivers async
+    tool output. The ``/local`` headless-test path needs a real user utterance so
+    the model treats it as a spoken turn and may call tools (e.g. ``look``).
+    """
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(api_key="test-key")
+            await client.connect()
+            baseline = len(fake_ws.sent)
+
+            await client.send_text_message("what do you see?")
+
+            events = fake_ws.sent[baseline:]
+            assert [e["type"] for e in events] == [
+                "conversation.item.create",
+                "response.create",
+            ]
+            item = events[0]["item"]
+            assert item["role"] == "user"
+            assert item["content"] == [
+                {"type": "input_text", "text": "what do you see?"}
+            ]
+
+            # Contrast: inject_message still tags its payload.
+            await client.inject_message("what do you see?")
+            injected = fake_ws.sent[-2]["item"]["content"][0]["text"]
+            assert injected.startswith("[Subagent result]:")
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -1278,3 +1278,33 @@ def test_send_text_message_delivers_verbatim_user_turn() -> None:
             await client.disconnect()
 
     asyncio.run(_exercise())
+
+
+def test_send_text_message_times_out_if_session_never_becomes_ready() -> None:
+    """A missing provider ready event must not pin the local handler forever."""
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            mp.setattr(
+                "gptme_voice.realtime.openai_client._SESSION_READY_TIMEOUT_SECONDS",
+                0.01,
+            )
+            client = OpenAIRealtimeClient(api_key="test-key")
+            await client.connect()
+            baseline = len(fake_ws.sent)
+
+            with pytest.raises(RuntimeError, match="session was not ready in time"):
+                await client.send_text_message("what do you see?")
+
+            assert fake_ws.sent[baseline:] == []
+            await client.disconnect()
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -1249,7 +1249,15 @@ def test_send_text_message_delivers_verbatim_user_turn() -> None:
             await client.connect()
             baseline = len(fake_ws.sent)
 
-            await client.send_text_message("what do you see?")
+            send_task = asyncio.create_task(
+                client.send_text_message("what do you see?")
+            )
+            await asyncio.sleep(0)
+            assert not send_task.done()
+            assert fake_ws.sent[baseline:] == []
+
+            await client._handle_event({"type": "session.created"})
+            await send_task
 
             events = fake_ws.sent[baseline:]
             assert [e["type"] for e in events] == [

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -111,8 +111,12 @@ class _DummyTwilioWebSocket(_DummyWebSocket):
 
 
 class _PeerWebSocket:
-    def __init__(self, host: str | None) -> None:
+    def __init__(
+        self, host: str | None, incoming: list[dict[str, object]] | None = None
+    ) -> None:
         self.client = None if host is None else (host, 12345)
+        self.query_params: dict[str, str] = {}
+        self._incoming = [json.dumps(message) for message in incoming or []]
         self.accepted = False
         self.close_code: int | None = None
 
@@ -122,10 +126,18 @@ class _PeerWebSocket:
     async def close(self, code: int = 1000) -> None:
         self.close_code = code
 
+    def iter_text(self):
+        async def _gen():
+            for message in self._incoming:
+                yield message
+
+        return _gen()
+
 
 class _FakeRealtimeClient:
     def __init__(self) -> None:
         self.sent_audio: list[bytes] = []
+        self.sent_text: list[str] = []
         self.commit_count = 0
         self.disconnect_kwargs: dict[str, object] | None = None
         self.activate_session_count = 0
@@ -148,6 +160,9 @@ class _FakeRealtimeClient:
 
     async def inject_message(self, _text: str) -> None:
         return None
+
+    async def send_text_message(self, text: str) -> None:
+        self.sent_text.append(text)
 
 
 class _DummyToolBridge:
@@ -175,6 +190,114 @@ def test_local_websocket_rejects_non_loopback_peer(host: str | None) -> None:
     assert websocket.close_code == 1008
 
 
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "::ffff:127.0.0.1", "localhost"])
+def test_local_websocket_accepts_loopback_peer(
+    monkeypatch: pytest.MonkeyPatch, host: str
+) -> None:
+    server = VoiceServer()
+    websocket = _PeerWebSocket(host)
+    fake_client = _FakeRealtimeClient()
+
+    monkeypatch.setattr(
+        server,
+        "_build_session_instructions",
+        lambda **_kwargs: asyncio.sleep(0, result="You are Bob."),
+    )
+    monkeypatch.setattr(server, "_make_client", lambda *_args, **_kwargs: fake_client)
+    monkeypatch.setattr(
+        server, "_on_call_end", lambda *_args, **_kwargs: asyncio.sleep(0)
+    )
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge)
+
+    asyncio.run(server.handle_local_websocket(websocket))
+
+    assert websocket.accepted is True
+    assert websocket.close_code is None
+
+
+def test_local_text_turn_is_persisted_in_transcript(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = VoiceServer()
+    websocket = _PeerWebSocket(
+        "127.0.0.1",
+        incoming=[{"type": "text", "text": "  what do you see?  "}],
+    )
+    fake_client = _FakeRealtimeClient()
+    persisted: list[TranscriptTurn] = []
+
+    async def _fake_build_session_instructions(
+        *, caller_id: str, handoff_id: str | None
+    ) -> str:
+        return "You are Bob."
+
+    async def _fake_on_call_end(
+        _caller_id: str,
+        _source: str,
+        transcript: list[TranscriptTurn],
+        _metadata: dict,
+        **_kwargs,
+    ) -> None:
+        persisted.extend(transcript)
+
+    monkeypatch.setattr(
+        server, "_build_session_instructions", _fake_build_session_instructions
+    )
+    monkeypatch.setattr(server, "_make_client", lambda *_args, **_kwargs: fake_client)
+    monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge)
+
+    asyncio.run(server.handle_local_websocket(websocket))
+
+    assert websocket.accepted is True
+    assert fake_client.sent_text == ["  what do you see?  "]
+    assert persisted == [TranscriptTurn(role="user", text="what do you see?")]
+
+
+def test_local_text_timeout_keeps_connection_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = VoiceServer()
+    websocket = _PeerWebSocket(
+        "127.0.0.1",
+        incoming=[
+            {"type": "text", "text": "too early"},
+            {"type": "text", "text": "ready now"},
+        ],
+    )
+    fake_client = _FakeRealtimeClient()
+    persisted: list[TranscriptTurn] = []
+
+    async def _send_text_message(text: str) -> None:
+        if text == "too early":
+            raise RuntimeError("session was not ready in time")
+        fake_client.sent_text.append(text)
+
+    async def _fake_on_call_end(
+        _caller_id: str,
+        _source: str,
+        transcript: list[TranscriptTurn],
+        _metadata: dict,
+        **_kwargs,
+    ) -> None:
+        persisted.extend(transcript)
+
+    fake_client.send_text_message = _send_text_message  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        server,
+        "_build_session_instructions",
+        lambda **_kwargs: asyncio.sleep(0, result="You are Bob."),
+    )
+    monkeypatch.setattr(server, "_make_client", lambda *_args, **_kwargs: fake_client)
+    monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge)
+
+    asyncio.run(server.handle_local_websocket(websocket))
+
+    assert fake_client.sent_text == ["ready now"]
+    assert persisted == [TranscriptTurn(role="user", text="ready now")]
+
+
 def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
     monkeypatch.setenv("GPTME_VOICE_BODY_URL", "null")
     server = VoiceServer()
@@ -182,6 +305,7 @@ def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
     remote = type("WebSocket", (), {"client": ("203.0.113.1", 443)})()
     loopback = type("WebSocket", (), {"client": ("127.0.0.1", 12345)})()
     ipv6 = type("WebSocket", (), {"client": ("::1", 12345)})()
+    mapped_ipv6 = type("WebSocket", (), {"client": ("::ffff:127.0.0.1", 12345)})()
     named = type(
         "WebSocket", (), {"client": type("Client", (), {"host": "127.0.0.1"})()}
     )()
@@ -194,6 +318,10 @@ def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:
     )
     assert (
         server._body_adapter_for_websocket(ipv6, transport="browser")
+        is server.body_adapter
+    )
+    assert (
+        server._body_adapter_for_websocket(mapped_ipv6, transport="local")
         is server.body_adapter
     )
     assert (

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -110,6 +110,19 @@ class _DummyTwilioWebSocket(_DummyWebSocket):
         return {}
 
 
+class _PeerWebSocket:
+    def __init__(self, host: str | None) -> None:
+        self.client = None if host is None else (host, 12345)
+        self.accepted = False
+        self.close_code: int | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000) -> None:
+        self.close_code = code
+
+
 class _FakeRealtimeClient:
     def __init__(self) -> None:
         self.sent_audio: list[bytes] = []
@@ -149,6 +162,17 @@ class _DummyToolBridge:
 
     def get_timings(self) -> list[dict[str, object]]:
         return []
+
+
+@pytest.mark.parametrize("host", ["203.0.113.1", None])
+def test_local_websocket_rejects_non_loopback_peer(host: str | None) -> None:
+    server = VoiceServer()
+    websocket = _PeerWebSocket(host)
+
+    asyncio.run(server.handle_local_websocket(websocket))
+
+    assert websocket.accepted is False
+    assert websocket.close_code == 1008
 
 
 def test_body_adapter_only_reaches_trusted_transports(monkeypatch) -> None:


### PR DESCRIPTION
## What

The `/local` WebSocket endpoint on the realtime voice server exists to allow
"testing without Twilio", but its message loop only handled `audio` and
`commit`. Driving a turn therefore required synthesizing PCM — impractical on a
headless machine with no microphone.

This adds a `{"type": "text", "text": "..."}` message that delivers the payload
as the caller's own utterance, via a new
`OpenAIRealtimeClient.send_text_message()`.

## Why not `inject_message()`

`inject_message()` already creates a user item and calls `response.create`, but
it prefixes the content with `[Subagent result]:` — correct for async tool
output, wrong for a caller turn. The model needs the text verbatim to treat it
as speech and to decide to call a tool.

That matters concretely: it's what makes a **headless `look` proof** possible.
Connect one client to `/local?vision=1` that both serves camera/sensor frames
(`vision_look_request` → `vision_look_result`) and sends a text turn — the model
calls `look`, the bridge round-trips a frame, and the description lands in the
same turn. No audio hardware anywhere in the loop. This is the enabling piece
for step 2.4 of Bob World (`gptme/gptme-contrib#1576`).

`XAIRealtimeClient` subclasses `OpenAIRealtimeClient`, so both providers get it.

## Tests

`test_send_text_message_delivers_verbatim_user_turn` asserts the exact event
sequence (`conversation.item.create` → `response.create`), the `user` role and
verbatim content, and contrasts it against `inject_message()` still tagging its
payload.

The server-side branch is a 4-line dispatch to that method; there is no existing
`/local` end-to-end WebSocket harness in `test_server.py` to extend, so it is
covered by the client-level test plus the live path above rather than a new
harness.