### PR TITLE
fix(write-loss-scan): git --since=@<n> silently falls back to now for small timestamps

### DIFF
--- a/scripts/agent-write-loss-scan.py
+++ b/scripts/agent-write-loss-scan.py
@@ -211,6 +211,21 @@ def parse_conversation_jsonl(
 # ---------------------------------------------------------------------------
 
 
+def _git_since(write_ts: float) -> str:
+    """Format a Unix timestamp for ``git log --since``.
+
+    Do NOT use git's ``@<seconds>`` form here: git parses it with approxidate,
+    which rejects values too small to look like a real date (anything below
+    roughly 1e8) and then silently falls back to *now*. A bogus cutoff of "now"
+    filters out every commit, so writes carrying a missing or zero timestamp
+    would all be misreported as LOST. An explicit ISO-8601 instant parses
+    correctly across the whole range.
+    """
+    return datetime.fromtimestamp(max(0, int(write_ts)), timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S%z"
+    )
+
+
 def _post_write_blobs(
     repo_root: Path, rel_path: str, write_ts: float
 ) -> list[tuple[str, int]]:
@@ -222,7 +237,7 @@ def _post_write_blobs(
             "--format=C|%ct",
             "--raw",
             "--no-abbrev",
-            f"--since=@{int(write_ts)}",
+            f"--since={_git_since(write_ts)}",
             "--",
             rel_path,
         ],

--- a/tests/test_agent_write_loss_scan.py
+++ b/tests/test_agent_write_loss_scan.py
@@ -182,6 +182,31 @@ def test_classify_write_persisted(tmp_path: Path) -> None:
     assert result.outcome == "PERSISTED"
 
 
+def test_classify_write_persisted_for_old_commit_with_epoch_write_ts(
+    tmp_path: Path,
+) -> None:
+    """A write_ts too small for git's date parser must not swallow the commit.
+
+    ``git log --since=@<n>`` silently falls back to *now* when ``<n>`` is too
+    small to look like a real date (anything under roughly 1e8). That made every
+    write with a missing/zero timestamp classify as LOST, and made the
+    ``write_ts=0.0`` case above a second-boundary coin flip.
+    """
+    repo = _init_repo(tmp_path)
+    content = "old committed content"
+    _commit_file(repo, "old.txt", content + "\n", timestamp=1_600_000_000)
+
+    ev = WriteEvent(
+        session_id="sess-epoch",
+        tool="save",
+        rel_path="old.txt",
+        write_ts=0.0,
+        written_blob=_git_blob_sha((content + "\n").encode()),
+    )
+    result = classify_write(ev, repo)
+    assert result.outcome == "PERSISTED"
+
+
 def test_classify_write_lost_when_only_commit_predates_write(tmp_path: Path) -> None:
     """A pre-write commit must not make a later lost save look superseded."""
     repo = _init_repo(tmp_path)


### PR DESCRIPTION
## Problem

`_post_write_blobs()` builds its git cutoff as:

```python
f"--since=@{int(write_ts)}"
```

git parses `--since` with **approxidate**, which rejects `@<seconds>` values too small to look like a real date and then **silently falls back to *now***. Measured on git 2.43:

| `--since` | commits matched (repo with a 2020 commit) |
|---|---|
| `@0`, `@1`, `@100`, `@100000`, `@1000000` | **0** |
| `@100000000`, `@1500000000`, `@1600000000` | 2 |
| `1970-01-01` (ISO) | 2 |

So the cutoff becomes "now", nothing matches, and `classify_write()` falls through to `outcome = "LOST"`.

## Impact

1. **Correctness**: any write event carrying a missing/zero/garbage `write_ts` is misreported as `LOST`, inflating the write-loss rate this tool exists to measure.
2. **Flaky CI**: `test_classify_write_persisted` commits at *now* and scans with `write_ts=0.0`. Against the bogus "now" cutoff, the commit only survives if `git log` happens to run inside the same second as the commit — a second-boundary coin flip. It lost that flip in [run 33799085708](https://github.com/gptme/gptme-contrib/actions/runs/33799085708) on an unrelated PR (gptme/gptme-contrib#1604, which only touches `packages/gptme-voice/*`). A rerun of the same commit went green, confirming nondeterminism rather than a code difference.

## Fix

Format the cutoff as an explicit ISO-8601 instant via a new `_git_since()` helper. Verified to parse correctly across the whole range, including `ts=0`.

## Test

Adds `test_classify_write_persisted_for_old_commit_with_epoch_write_ts` — an old commit at a *fixed* timestamp plus `write_ts=0.0`. This reproduces the exact CI symptom (`assert 'LOST' == 'PERSISTED'`) **deterministically**, with no reliance on the race:

- Before the fix: `1 failed, 13 passed`
- After the fix: `14 passed`
- Original flaky test run 15x post-fix: 15/15 pass

`ruff format`/`check` and `mypy` clean. `grep` confirms no other `--since=@` usages in this repo or Bob's workspace.