### PR TITLE
feat(gptme-sessions): record out-of-process dispatch lineage

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2818,6 +2818,11 @@ def repair_grades(ctx: click.Context, dry_run: bool) -> None:
     type=click.Choice(sorted(DISPATCH_KINDS)),
     help="How this session was spawned (default: $BOB_DISPATCH_KIND)",
 )
+@click.option(
+    "--dispatch-id",
+    default=None,
+    help="Run-id of the dispatcher (e.g. PM slot unit name; default: $PM_DISPATCH_ID)",
+)
 @click.option("--category", default=None, help="Work category (code, triage, ...)")
 @click.option(
     "--recommended-category",
@@ -2875,6 +2880,7 @@ def post_session_cmd(
     trigger: str | None,
     parent_session_id: str | None,
     dispatch_kind: str | None,
+    dispatch_id: str | None,
     category: str | None,
     recommended_category: str | None,
     selector_mode: str | None,
@@ -2902,6 +2908,7 @@ def post_session_cmd(
         trigger=trigger,
         parent_session_id=parent_session_id,
         dispatch_kind=dispatch_kind,
+        dispatch_id=dispatch_id,
         category=category,
         recommended_category=recommended_category,
         selector_mode=selector_mode,

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -38,6 +38,7 @@ from .replay import (
 from .record import (
     ANNOTATABLE_FIELDS,
     ATTEMPT_KINDS,
+    DISPATCH_KINDS,
     SessionRecord,
     normalize_run_type,
     trajectory_revision_for,
@@ -2806,6 +2807,17 @@ def repair_grades(ctx: click.Context, dry_run: bool) -> None:
 @click.option("--model", default="unknown", help="Model name")
 @click.option("--run-type", default="unknown", help="Run type (autonomous, etc.)")
 @click.option("--trigger", default=None, help="Session trigger: timer, dispatch, manual, spawn")
+@click.option(
+    "--parent-session-id",
+    default=None,
+    help="session_id of the session that spawned this one (default: $BOB_PARENT_SESSION_ID)",
+)
+@click.option(
+    "--dispatch-kind",
+    default=None,
+    type=click.Choice(sorted(DISPATCH_KINDS)),
+    help="How this session was spawned (default: $BOB_DISPATCH_KIND)",
+)
 @click.option("--category", default=None, help="Work category (code, triage, ...)")
 @click.option(
     "--recommended-category",
@@ -2861,6 +2873,8 @@ def post_session_cmd(
     model: str,
     run_type: str,
     trigger: str | None,
+    parent_session_id: str | None,
+    dispatch_kind: str | None,
     category: str | None,
     recommended_category: str | None,
     selector_mode: str | None,
@@ -2886,6 +2900,8 @@ def post_session_cmd(
         model=model,
         run_type=run_type,
         trigger=trigger,
+        parent_session_id=parent_session_id,
+        dispatch_kind=dispatch_kind,
         category=category,
         recommended_category=recommended_category,
         selector_mode=selector_mode,

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -296,6 +296,7 @@ def post_session(
     trigger: str | None = None,
     parent_session_id: str | None = None,
     dispatch_kind: str | None = None,
+    dispatch_id: str | None = None,
     category: str | None = None,
     recommended_category: str | None = None,
     selector_mode: str | None = None,
@@ -339,6 +340,11 @@ def post_session(
         How this session was spawned — one of
         :data:`~gptme_sessions.record.DISPATCH_KINDS`.  Defaults to the
         ``BOB_DISPATCH_KIND`` environment variable.
+    dispatch_id:
+        Run-id of the dispatcher when the dispatcher is not itself a recorded
+        session (e.g. project-monitoring slot unit name from ``PM_DISPATCH_ID``).
+        Complements ``parent_session_id``; use for dispatcher-run→child joins.
+        Defaults to the ``PM_DISPATCH_ID`` environment variable.
     run_type:
         Pipeline / trigger name (e.g. ``"autonomous"``, ``"monitoring"``).
         Kept for backward compatibility; prefer ``trigger`` going forward.
@@ -903,6 +909,12 @@ def post_session(
     resolved_dispatch_kind = dispatch_kind or os.environ.get("BOB_DISPATCH_KIND") or None
     if resolved_dispatch_kind is not None:
         record_kwargs["dispatch_kind"] = resolved_dispatch_kind
+    # dispatch_id: the run-id of a dispatcher that is not itself a session
+    # (e.g. PM slot unit name from PM_DISPATCH_ID).  Distinct from
+    # parent_session_id which links session→session.
+    resolved_dispatch_id = dispatch_id or os.environ.get("PM_DISPATCH_ID") or None
+    if resolved_dispatch_id is not None:
+        record_kwargs["dispatch_id"] = resolved_dispatch_id
     if actual_category is not None:
         record_kwargs["category"] = actual_category
     if recommended_category is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -294,6 +294,8 @@ def post_session(
     tier_version: str | None = None,
     run_type: str | None = None,
     trigger: str | None = None,
+    parent_session_id: str | None = None,
+    dispatch_kind: str | None = None,
     category: str | None = None,
     recommended_category: str | None = None,
     selector_mode: str | None = None,
@@ -329,6 +331,14 @@ def post_session(
         A/B group assignment for this session (e.g. ``"treatment"`` or ``"control"``).
     tier_version:
         Version of the context tier configuration used for this session.
+    parent_session_id:
+        ``session_id`` of the session that spawned this one.  Defaults to the
+        ``BOB_PARENT_SESSION_ID`` environment variable so spawners only have to
+        export it once.  Ignored when it equals this session's own id.
+    dispatch_kind:
+        How this session was spawned — one of
+        :data:`~gptme_sessions.record.DISPATCH_KINDS`.  Defaults to the
+        ``BOB_DISPATCH_KIND`` environment variable.
     run_type:
         Pipeline / trigger name (e.g. ``"autonomous"``, ``"monitoring"``).
         Kept for backward compatibility; prefer ``trigger`` going forward.
@@ -885,6 +895,14 @@ def post_session(
         record_kwargs["tier_version"] = tier_version
     if trigger is not None:
         record_kwargs["trigger"] = trigger
+    # Dispatch lineage: explicit argument wins, else the spawner's environment.
+    # SessionRecord validates both (unknown kind -> None, self-parent -> None).
+    resolved_parent = parent_session_id or os.environ.get("BOB_PARENT_SESSION_ID") or None
+    if resolved_parent is not None:
+        record_kwargs["parent_session_id"] = resolved_parent
+    resolved_dispatch_kind = dispatch_kind or os.environ.get("BOB_DISPATCH_KIND") or None
+    if resolved_dispatch_kind is not None:
+        record_kwargs["dispatch_kind"] = resolved_dispatch_kind
     if actual_category is not None:
         record_kwargs["category"] = actual_category
     if recommended_category is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -360,6 +360,11 @@ class SessionRecord:
     # directed join instead of timestamp-proximity guessing.
     parent_session_id: str | None = None
     dispatch_kind: str | None = None
+    # Dispatcher-run id for dispatchers that are not recorded sessions themselves
+    # (e.g. project-monitoring slots: PM_DISPATCH_ID = the slot unit name).
+    # Complements ``parent_session_id``; use for dispatcher-run→child joins when
+    # the dispatcher has no session_id of its own.
+    dispatch_id: str | None = None
 
     # Work classification
     category: str | None = None  # inferred from commits/files (what actually happened)

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -41,6 +41,21 @@ ATTEMPT_KINDS: frozenset[str] = frozenset(["repetition", "infra_retry", "unknown
 # Valid values for the dropout_depth field.
 DROPOUT_DEPTH_VALUES: frozenset[str] = frozenset(["shallow", "deep"])
 
+# How a child session was spawned by its parent.  These are NOT
+# interchangeable in analysis: an ``agent-tool`` subagent shares the parent's
+# context window and token budget, while every other kind is a separate process
+# with its own.  ``None`` means the session has no recorded parent (a top-level
+# run, or a spawner that predates the field).
+DISPATCH_KINDS: frozenset[str] = frozenset(
+    [
+        "agent-tool",  # in-session Claude Code Agent tool subagent
+        "worker",  # spawn-workers.sh child
+        "gptodo-spawn",  # gptodo spawn / delegate child
+        "pm-dispatch",  # project-monitoring runloops dispatch
+        "fanout",  # autonomous-fanout.sh child
+    ]
+)
+
 # Scalar fields the ``annotate`` CLI can explicitly override. Persisting this
 # provenance lets later source extraction distinguish operator decisions from
 # values it owns and may refresh.
@@ -339,6 +354,13 @@ class SessionRecord:
     run_type: str | None = "unknown"  # deprecated: use trigger instead
     trigger: str | None = None  # how session started: timer, dispatch, manual, spawn
 
+    # Out-of-process dispatch lineage.  ``parent_session_id`` is the session_id
+    # of the session that spawned this one; ``dispatch_kind`` names the spawn
+    # mechanism (see DISPATCH_KINDS).  Together they give product roll-ups a
+    # directed join instead of timestamp-proximity guessing.
+    parent_session_id: str | None = None
+    dispatch_kind: str | None = None
+
     # Work classification
     category: str | None = None  # inferred from commits/files (what actually happened)
     recommended_category: str | None = None  # from Thompson sampling / CASCADE (what was intended)
@@ -531,6 +553,16 @@ class SessionRecord:
         # cannot persist an invalid value that consumers would silently misclassify.
         if self.attempt_kind is not None and self.attempt_kind not in ATTEMPT_KINDS:
             self.attempt_kind = None
+        # Discard unrecognized dispatch_kind values for the same reason.
+        if self.dispatch_kind is not None and self.dispatch_kind not in DISPATCH_KINDS:
+            self.dispatch_kind = None
+        # A session cannot be its own parent.  A spawner that leaks its own id
+        # into the child environment would otherwise create a self-loop that
+        # silently breaks every lineage walk.
+        if self.parent_session_id is not None and (
+            not self.parent_session_id.strip() or self.parent_session_id == self.session_id
+        ):
+            self.parent_session_id = None
         # Cross-field consistency: when explicitly not selected (False), the detail fields
         # have no meaning — clear them to prevent downstream consumers from reading an
         # inconsistent combination (e.g. dropout_selected=False, dropout_depth="deep").

--- a/packages/gptme-sessions/tests/test_dispatch_lineage.py
+++ b/packages/gptme-sessions/tests/test_dispatch_lineage.py
@@ -130,3 +130,91 @@ def test_stale_env_parent_matching_own_id_is_dropped(tmp_path: Path, monkeypatch
         duration_seconds=10,
     )
     assert result.record.parent_session_id is None
+
+
+# --- dispatch_id (PM slot unit name, non-session dispatcher) ----------------
+
+
+def test_record_keeps_dispatch_id():
+    """dispatch_id is stored as-is (no validation, any non-empty string is valid)."""
+    record = SessionRecord(session_id="child1", dispatch_id="bob-pm-gptme-gptme-slot-0")
+    assert record.dispatch_id == "bob-pm-gptme-gptme-slot-0"
+
+
+def test_record_dispatch_id_default_none():
+    record = SessionRecord(session_id="child1")
+    assert record.dispatch_id is None
+
+
+def test_post_session_records_dispatch_id_from_argument(tmp_path: Path):
+    """Explicit dispatch_id argument is stored in the session record."""
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        session_id="pm-child",
+        dispatch_kind="pm-dispatch",
+        dispatch_id="bob-pm-gptme-gptme-slot-3",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "bob-pm-gptme-gptme-slot-3"
+
+
+def test_post_session_reads_dispatch_id_from_env(tmp_path: Path, monkeypatch):
+    """PM_DISPATCH_ID env var is the fallback when no explicit dispatch_id given."""
+    monkeypatch.setenv("PM_DISPATCH_ID", "bob-pm-activitywatch-aw-webui-slot-1")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="pm-child2",
+        dispatch_kind="pm-dispatch",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "bob-pm-activitywatch-aw-webui-slot-1"
+
+
+def test_explicit_dispatch_id_beats_env(tmp_path: Path, monkeypatch):
+    """Explicit argument takes priority over the PM_DISPATCH_ID env var."""
+    monkeypatch.setenv("PM_DISPATCH_ID", "env-value")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="pm-child3",
+        dispatch_id="explicit-value",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "explicit-value"
+
+
+def test_no_dispatch_id_without_env_or_argument(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("PM_DISPATCH_ID", raising=False)
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        session_id="top-level",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id is None
+
+
+def test_dispatch_id_roundtrips_through_store(tmp_path: Path):
+    """dispatch_id survives serialization to JSONL and back."""
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="pm-child4",
+        dispatch_id="bob-pm-gptme-gptme-slot-7",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "bob-pm-gptme-gptme-slot-7"
+    reloaded = store.load_all()
+    assert any(r.dispatch_id == "bob-pm-gptme-gptme-slot-7" for r in reloaded)

--- a/packages/gptme-sessions/tests/test_dispatch_lineage.py
+++ b/packages/gptme-sessions/tests/test_dispatch_lineage.py
@@ -1,0 +1,132 @@
+"""Tests for out-of-process dispatch lineage (parent_session_id / dispatch_kind).
+
+A spawned session (worker, fanout child, PM dispatch, gptodo spawn) has to carry
+a *directed* link back to the session that spawned it.  Before this, the only
+join between a parent and its out-of-process children was timestamp proximity,
+which is exactly the mtime-class heuristic these records exist to replace.
+"""
+
+from pathlib import Path
+
+from gptme_sessions.post_session import post_session
+from gptme_sessions.record import DISPATCH_KINDS, SessionRecord
+from gptme_sessions.store import SessionStore
+
+
+def test_record_keeps_valid_lineage():
+    record = SessionRecord(
+        session_id="child123", parent_session_id="parent99", dispatch_kind="worker"
+    )
+    assert record.parent_session_id == "parent99"
+    assert record.dispatch_kind == "worker"
+
+
+def test_record_drops_unknown_dispatch_kind():
+    """A typo or a hand-edited row must not reach consumers as a real kind."""
+    record = SessionRecord(session_id="child123", dispatch_kind="subprocess")
+    assert record.dispatch_kind is None
+
+
+def test_record_drops_self_parent():
+    """A spawner leaking its own id into the child env would create a self-loop."""
+    record = SessionRecord(session_id="same", parent_session_id="same")
+    assert record.parent_session_id is None
+
+
+def test_record_drops_blank_parent():
+    record = SessionRecord(session_id="child", parent_session_id="   ")
+    assert record.parent_session_id is None
+
+
+def test_lineage_defaults_to_none():
+    record = SessionRecord(session_id="child")
+    assert record.parent_session_id is None
+    assert record.dispatch_kind is None
+
+
+def test_all_documented_kinds_are_accepted():
+    for kind in DISPATCH_KINDS:
+        assert SessionRecord(session_id="c", dispatch_kind=kind).dispatch_kind == kind
+
+
+def test_post_session_persists_lineage(tmp_path: Path):
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        run_type="worker",
+        session_id="child-abc",
+        parent_session_id="parent-xyz",
+        dispatch_kind="worker",
+        duration_seconds=30,
+    )
+    assert result.record.parent_session_id == "parent-xyz"
+    assert result.record.dispatch_kind == "worker"
+
+    reloaded = SessionStore(sessions_dir=tmp_path).load_all()
+    assert len(reloaded) == 1
+    assert reloaded[0].parent_session_id == "parent-xyz"
+    assert reloaded[0].dispatch_kind == "worker"
+
+
+def test_post_session_reads_lineage_from_environment(tmp_path: Path, monkeypatch):
+    """Spawners export the env once; every recorder inherits it for free."""
+    monkeypatch.setenv("BOB_PARENT_SESSION_ID", "parent-env")
+    monkeypatch.setenv("BOB_DISPATCH_KIND", "fanout")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="child-env",
+        duration_seconds=10,
+    )
+    assert result.record.parent_session_id == "parent-env"
+    assert result.record.dispatch_kind == "fanout"
+
+
+def test_explicit_argument_beats_environment(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("BOB_PARENT_SESSION_ID", "stale-env")
+    monkeypatch.setenv("BOB_DISPATCH_KIND", "fanout")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="child-explicit",
+        parent_session_id="real-parent",
+        dispatch_kind="pm-dispatch",
+        duration_seconds=10,
+    )
+    assert result.record.parent_session_id == "real-parent"
+    assert result.record.dispatch_kind == "pm-dispatch"
+
+
+def test_no_lineage_without_env_or_argument(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("BOB_PARENT_SESSION_ID", raising=False)
+    monkeypatch.delenv("BOB_DISPATCH_KIND", raising=False)
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        session_id="top-level",
+        duration_seconds=10,
+    )
+    assert result.record.parent_session_id is None
+    assert result.record.dispatch_kind is None
+
+
+def test_stale_env_parent_matching_own_id_is_dropped(tmp_path: Path, monkeypatch):
+    """A child that reuses the parent's session id is not its own parent."""
+    monkeypatch.setenv("BOB_PARENT_SESSION_ID", "same-id")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="same-id",
+        duration_seconds=10,
+    )
+    assert result.record.parent_session_id is None


### PR DESCRIPTION
## Problem

Out-of-process children — `spawn-workers.sh` workers, `autonomous-fanout.sh`
sessions, project-monitoring dispatches, `gptodo spawn` children — carry no
directed link back to what spawned them. The only join available to analysis
today is timestamp proximity plus duration (`pm-executor-ab-report.py` does
exactly this), which is the same mtime-class heuristic that trajectory
attribution has been removing everywhere else.

A related symptom: "was this session a fanout child?" is currently answered by
string-matching `cascade_intent.reasons` for the substring `fanout`, which
mislabels category-preset pilot runs. That question deserves a structural field.

## Change

Two additive `SessionRecord` fields:

- `parent_session_id` — `session_id` of the spawning session
- `dispatch_kind` — one of `DISPATCH_KINDS`: `agent-tool`, `worker`,
  `gptodo-spawn`, `pm-dispatch`, `fanout`

The kinds stay distinct deliberately: an in-session Agent-tool subagent shares
the parent's context window and token budget; a dispatched worker does not, so
they must not be pooled in any per-session cost or productivity metric.

`post_session()` accepts both explicitly and otherwise falls back to
`BOB_PARENT_SESSION_ID` / `BOB_DISPATCH_KIND` in the environment, so a spawner
exports them once and every recorder downstream inherits them without a CLI
change. `post-session` also grows `--parent-session-id` / `--dispatch-kind`.

Two guards in `__post_init__`, matching the existing `attempt_kind` /
`dropout_depth` treatment:

- an unrecognized `dispatch_kind` is dropped rather than reaching consumers as
  if it were a real kind
- a `parent_session_id` equal to the record's own `session_id` is dropped — a
  spawner leaking its own id into the child environment would otherwise create
  a self-loop that breaks every lineage walk

## Tests

`tests/test_dispatch_lineage.py`, 11 cases: valid lineage, unknown-kind drop,
self-parent drop, blank-parent drop, defaults, every documented kind accepted,
persistence through a store round-trip, environment fallback, explicit-argument
precedence, no-lineage default, and the stale-env self-parent case.

```
tests/test_dispatch_lineage.py                    11 passed
tests/test_record.py test_post_session.py test_cli.py   302 passed
```

## Scope

Schema and recorder only. Wiring the individual spawners is Bob-side and lands
separately; `gptodo spawn` children still write no session record at all, which
is tracked in the originating task.

Refs `ErikBjare/bob` `tasks/trajectory-attribution-and-subagent-reader.md` item 6.