### PR TITLE
fix(gptme-sessions): blame no longer crashes on uncommitted lines

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -160,10 +160,50 @@ def commits_for_path(path: str, limit: int = 10) -> list[Attribution]:
     return result
 
 
+#: ``git blame`` reports this sentinel sha for lines that exist only in the
+#: working tree (not yet committed).
+_UNCOMMITTED_SHA = "0" * 40
+
+
+def _uncommitted_attribution(porcelain: str) -> Attribution:
+    """Build an Attribution for a working-tree line from ``git blame`` porcelain.
+
+    ``git blame`` still emits ``author-time``/``author-tz`` for uncommitted
+    lines, so the edit can be placed on the session timeline even though no
+    commit exists to attribute it to.
+    """
+    fields: dict[str, str] = {}
+    for raw in porcelain.split("\n")[1:]:
+        if raw.startswith("\t"):
+            break
+        key, _, value = raw.partition(" ")
+        fields.setdefault(key, value)
+
+    try:
+        when = datetime.fromtimestamp(int(fields.get("author-time", "")), tz=timezone.utc)
+    except ValueError:
+        when = datetime.now(tz=timezone.utc)
+
+    return Attribution(
+        sha=_UNCOMMITTED_SHA,
+        when=when,
+        author=fields.get("author") or "Not Committed Yet",
+        subject="(uncommitted change in working tree)",
+        trailer_session_id=None,
+    )
+
+
 def commit_for_line(path: str, line: int) -> list[Attribution]:
-    """Return the single commit that last touched ``path`` line ``line``."""
+    """Return the single commit that last touched ``path`` line ``line``.
+
+    A line that is only in the working tree has no commit; it is returned as an
+    uncommitted Attribution timestamped from the blame porcelain so window
+    attribution still works.
+    """
     out = _run(["git", "blame", "-L", f"{line},{line}", "--porcelain", "--", path])
-    sha = out.splitlines()[0].split(" ", 1)[0]
+    sha = out.split("\n", 1)[0].split(" ", 1)[0]
+    if sha == _UNCOMMITTED_SHA:
+        return [_uncommitted_attribution(out)]
     meta = _run(
         [
             "git",

--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -160,12 +160,7 @@ def commits_for_path(path: str, limit: int = 10) -> list[Attribution]:
     return result
 
 
-#: ``git blame`` reports this sentinel sha for lines that exist only in the
-#: working tree (not yet committed).
-_UNCOMMITTED_SHA = "0" * 40
-
-
-def _uncommitted_attribution(porcelain: str) -> Attribution:
+def _uncommitted_attribution(porcelain: str, sha: str) -> Attribution:
     """Build an Attribution for a working-tree line from ``git blame`` porcelain.
 
     ``git blame`` still emits ``author-time``/``author-tz`` for uncommitted
@@ -185,7 +180,7 @@ def _uncommitted_attribution(porcelain: str) -> Attribution:
         when = datetime.now(tz=timezone.utc)
 
     return Attribution(
-        sha=_UNCOMMITTED_SHA,
+        sha=sha,
         when=when,
         author=fields.get("author") or "Not Committed Yet",
         subject="(uncommitted change in working tree)",
@@ -202,8 +197,8 @@ def commit_for_line(path: str, line: int) -> list[Attribution]:
     """
     out = _run(["git", "blame", "-L", f"{line},{line}", "--porcelain", "--", path])
     sha = out.split("\n", 1)[0].split(" ", 1)[0]
-    if sha == _UNCOMMITTED_SHA:
-        return [_uncommitted_attribution(out)]
+    if sha and set(sha) == {"0"}:
+        return [_uncommitted_attribution(out, sha)]
     meta = _run(
         [
             "git",

--- a/packages/gptme-sessions/tests/test_blame.py
+++ b/packages/gptme-sessions/tests/test_blame.py
@@ -406,10 +406,11 @@ def test_commit_for_line_duplicate_trailers(monkeypatch):
     assert atts[0].trailer_session_id == "sess-first"
 
 
-def test_commit_for_line_uncommitted(monkeypatch):
+@pytest.mark.parametrize("null_sha", ["0" * 40, "0" * 64])
+def test_commit_for_line_uncommitted(monkeypatch, null_sha):
     """A working-tree-only line returns an uncommitted Attribution, not a crash."""
     porcelain = (
-        "0000000000000000000000000000000000000000 84 84 1\n"
+        f"{null_sha} 84 84 1\n"
         "author Not Committed Yet\n"
         "author-mail <not.committed.yet>\n"
         "author-time 1788472197\n"
@@ -430,10 +431,10 @@ def test_commit_for_line_uncommitted(monkeypatch):
     monkeypatch.setattr(subprocess, "run", _fake)
     atts = commit_for_line("SOUL.md", 84)
 
-    # `git show` must not be invoked for the all-zeros sentinel sha.
+    # `git show` must not be invoked for either Git object format's null sha.
     assert len(calls) == 1
     assert len(atts) == 1
-    assert atts[0].sha == "0" * 40
+    assert atts[0].sha == null_sha
     assert atts[0].author == "Not Committed Yet"
     assert atts[0].when == datetime(2026, 9, 3, 21, 49, 57, tzinfo=timezone.utc)
     assert atts[0].trailer_session_id is None

--- a/packages/gptme-sessions/tests/test_blame.py
+++ b/packages/gptme-sessions/tests/test_blame.py
@@ -406,6 +406,39 @@ def test_commit_for_line_duplicate_trailers(monkeypatch):
     assert atts[0].trailer_session_id == "sess-first"
 
 
+def test_commit_for_line_uncommitted(monkeypatch):
+    """A working-tree-only line returns an uncommitted Attribution, not a crash."""
+    porcelain = (
+        "0000000000000000000000000000000000000000 84 84 1\n"
+        "author Not Committed Yet\n"
+        "author-mail <not.committed.yet>\n"
+        "author-time 1788472197\n"
+        "author-tz +0000\n"
+        "summary Version of SOUL.md from SOUL.md\n"
+        "filename SOUL.md\n"
+        "\t<!-- Trace test -->"
+    )
+
+    calls = []
+
+    def _fake(args, **kwargs):
+        calls.append(args)
+        result = MagicMock()
+        result.stdout = porcelain
+        return result
+
+    monkeypatch.setattr(subprocess, "run", _fake)
+    atts = commit_for_line("SOUL.md", 84)
+
+    # `git show` must not be invoked for the all-zeros sentinel sha.
+    assert len(calls) == 1
+    assert len(atts) == 1
+    assert atts[0].sha == "0" * 40
+    assert atts[0].author == "Not Committed Yet"
+    assert atts[0].when == datetime(2026, 9, 3, 21, 49, 57, tzinfo=timezone.utc)
+    assert atts[0].trailer_session_id is None
+
+
 # ---------------------------------------------------------------------------
 # render_text / render_json
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`sessions-blame.py <file> --line N` crashed with an unhandled `CalledProcessError` whenever the target line existed only in the working tree.

```
subprocess.CalledProcessError: Command '['git', 'show', '-s', '--format=...', '0000000000000000000000000000000000000000']' returned non-zero exit status 128.
```

`git blame --porcelain` reports the all-zeros sentinel sha for uncommitted lines; `commit_for_line` passed it straight to `git show`.

## Fix

Detect the sentinel and return an uncommitted `Attribution` instead, timestamped from the blame porcelain's `author-time`/`author-tz` — so `attribute_all` window matching and the trajectory-enrichment fallback still run on it. That is the case that matters most for incident response: *which session made this working-tree edit?* was previously the one question the attribution path could not answer.

## Verification

```
$ uv run pytest packages/gptme-sessions/tests/test_blame.py -q
52 passed
```

New test `test_commit_for_line_uncommitted` asserts `git show` is not invoked for the sentinel sha and that the timestamp is parsed from the porcelain.

End-to-end against a real uncommitted line (previously a traceback):

```
Attribution(sha='000...000', when=2026-09-03 23:18:31+00:00,
            author='Not Committed Yet',
            subject='(uncommitted change in working tree)')
```

Found while attributing an uncommitted trace-test marker that a timed-out session left appended to `SOUL.md` in Bob's brain repo.