### PR TITLE
fix(gptodo): write waiting_spell_count and first_waiting_since live

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3024,17 +3024,42 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
             op == "set" and field == "waiting_for" and value is not None
             for op, field, value in changes
         )
-        if (
-            transitioning_to_waiting
-            and waiting_for_present
-            and not post.metadata.get("waiting_since")
-        ):
+        if transitioning_to_waiting and waiting_for_present:
             from datetime import datetime as _dt, timezone as _tz
 
             # Full ISO datetime for intra-day resolution (ErikBjare request, 2026-06-16).
             # validate_task_frontmatter.py's validate_timestamp() accepts both YYYY-MM-DD
             # and full ISO datetime via datetime.fromisoformat().
-            post.metadata["waiting_since"] = _dt.now(_tz.utc).isoformat(timespec="seconds")
+            _now_iso = _dt.now(_tz.utc).isoformat(timespec="seconds")
+            if not post.metadata.get("waiting_since"):
+                post.metadata["waiting_since"] = _now_iso
+
+            # Cumulative waiting history (TASKS.md schema), written here so it can
+            # never disagree with waiting_since. Both fields were documented but
+            # had no live writer until 2026-09-03 — the only writer was a one-shot
+            # git-history backfill with no caller, so every value in the tree was
+            # frozen at whenever someone last ran it by hand.
+            #
+            # The discriminator is the *prior* state, not a missing waiting_since:
+            # leaving waiting does not clear waiting_since, so its absence would
+            # miss exactly the re-parks these fields exist to count.
+            if _prior_state != "waiting":
+                # first_waiting_since is stamped once and never overwritten — it
+                # is the cumulative blocker age that survives re-parks.
+                _since = post.metadata.get("waiting_since")
+                post.metadata.setdefault(
+                    "first_waiting_since", str(_since) if _since is not None else _now_iso
+                )
+
+                # waiting_spell_count counts distinct waiting spells; >= 3 is the
+                # re-park signal read by task_metadata_hygiene_audit check 16.
+                # Absent (or hand-corrupted) means "no spells recorded yet", so
+                # the post-increment value is 1.
+                try:
+                    _prior_spells = int(post.metadata.get("waiting_spell_count") or 0)
+                except (TypeError, ValueError):
+                    _prior_spells = 0
+                post.metadata["waiting_spell_count"] = max(_prior_spells, 0) + 1
 
         # Strip now-stale actionable/blocker metadata when the edit lands the task
         # in a terminal state (TASKS.md best-practice #7: terminal tasks must not

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -166,6 +166,14 @@ KNOWN_FRONTMATTER_FIELDS: set[str] = {
     "next_action",
     "waiting_for",
     "waiting_since",
+    # Cumulative waiting history (TASKS.md schema). `waiting_since` is reset on
+    # every re-park, so it cannot answer "how long has this really been stuck?".
+    # `first_waiting_since` is stamped on the first waiting entry and never
+    # overwritten; `waiting_spell_count` counts distinct waiting entries and is
+    # the re-park signal read by task_metadata_hygiene_audit check 16. Both are
+    # written by `gptodo edit --set state waiting` alongside `waiting_since`.
+    "first_waiting_since",
+    "waiting_spell_count",
     "depends",  # deprecated alias for requires, but still accepted
     "requires",
     "blocks",  # deprecated (inverse semantics), still accepted

--- a/packages/gptodo/tests/test_edit_state_waiting.py
+++ b/packages/gptodo/tests/test_edit_state_waiting.py
@@ -206,3 +206,119 @@ def test_edit_clearing_waiting_for_does_not_inject_waiting_since(
     assert (
         "waiting_since" not in tasks[0].metadata
     ), "clearing waiting_for must not trigger waiting_since injection"
+
+
+# ---------------------------------------------------------------------------
+# Cumulative waiting history: first_waiting_since + waiting_spell_count
+#
+# TASKS.md documents both fields, but until 2026-09-03 nothing wrote them live:
+# the only writer was a one-shot git-history backfill script with no caller, so
+# every value in the tree was frozen at whenever someone last ran it by hand.
+# task_metadata_hygiene_audit check 16 (erik_gate_repark) reads
+# waiting_spell_count >= 3, so a frozen counter under-reports exactly the tasks
+# that are being repeatedly re-parked.
+# ---------------------------------------------------------------------------
+
+
+def test_edit_state_waiting_initialises_cumulative_waiting_fields(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A first waiting entry stamps first_waiting_since and sets the spell count to 1."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting", "--set", "waiting_for", "some-blocker"],
+    )
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["waiting_spell_count"] == 1
+    # Stamped in the same branch as waiting_since, so the two agree exactly.
+    assert task.metadata["first_waiting_since"] == task.metadata["waiting_since"]
+
+
+def test_two_waiting_entries_produce_spell_count_two(tmp_path: Path, monkeypatch) -> None:
+    """Re-parking a task after an un-park increments the spell count to 2.
+
+    first_waiting_since must NOT move: it is the cumulative blocker age that
+    survives re-parks (waiting_since is reset on every entry).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    first = runner.invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting", "--set", "waiting_for", "blocker-one"],
+    )
+    assert first.exit_code == 0, f"first park failed: {first.output}"
+    first_stamp = load_tasks(tasks_dir)[0].metadata["first_waiting_since"]
+
+    unpark = runner.invoke(cli, ["edit", "my-task", "--set", "state", "todo"])
+    assert unpark.exit_code == 0, f"un-park failed: {unpark.output}"
+    unparked = load_tasks(tasks_dir)[0]
+    assert unpark.exit_code == 0
+    # Un-parking does NOT clear waiting_since, which is why the spell counter
+    # keys off the prior state instead of treating a missing waiting_since as
+    # the "new spell" signal — that would miss every re-park of this shape.
+    assert "waiting_since" in unparked.metadata
+    assert unparked.metadata["waiting_spell_count"] == 1
+
+    second = runner.invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting", "--set", "waiting_for", "blocker-two"],
+    )
+    assert second.exit_code == 0, f"re-park failed: {second.output}"
+
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["waiting_spell_count"] == 2
+    assert task.metadata["first_waiting_since"] == first_stamp
+
+
+def test_re_setting_waiting_on_an_already_waiting_task_does_not_increment(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`--set state waiting` on a task already waiting is not a new spell."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ALREADY_WAITING_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "waiting"])
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    task = load_tasks(tasks_dir)[0]
+    # waiting_since survived, so no spell was recorded.
+    assert "waiting_spell_count" not in task.metadata
+
+
+def test_waiting_spell_count_recovers_from_a_non_numeric_value(tmp_path: Path, monkeypatch) -> None:
+    """A hand-corrupted counter must not crash the edit; it restarts at 1."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(
+        "---\nstate: active\ncreated: 2026-06-16T00:00:00+00:00\n"
+        "waiting_spell_count: not-a-number\n---\n# Corrupted Counter\n"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting", "--set", "waiting_for", "some-blocker"],
+    )
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+    assert load_tasks(tasks_dir)[0].metadata["waiting_spell_count"] == 1
+
+
+def test_cumulative_waiting_fields_are_known_frontmatter(tmp_path: Path) -> None:
+    """Both fields must be registered, or `gptodo lint` warns on what gptodo writes."""
+    from gptodo.utils import KNOWN_FRONTMATTER_FIELDS
+
+    assert "first_waiting_since" in KNOWN_FRONTMATTER_FIELDS
+    assert "waiting_spell_count" in KNOWN_FRONTMATTER_FIELDS


### PR DESCRIPTION
## Problem

TASKS.md documents two cumulative waiting-history fields:

- `first_waiting_since` — stamped on the **first** waiting entry, never overwritten
- `waiting_spell_count` — "Count of distinct waiting spells. Incremented on every waiting entry."

Nothing implemented either. `gptodo edit <task> --set state waiting` auto-set
`waiting_since` and stopped there:

```
state: active -> waiting
waiting_since: None -> 2026-09-03T22:45:14+00:00
```

The only writer was `scripts/backfill-waiting-spell-count.py` in Bob's workspace — a
one-shot git-history derivation with **no timer and no caller**. So every value in the
tree is frozen at whenever someone last ran it by hand.

## Why it matters

`waiting_spell_count` is the re-park signal. `task_metadata_hygiene_audit.py` check 16
(`erik_gate_repark`) treats `>= 3` as "read the blocker, don't extend it", and the
erik-gate audit taxonomy uses the same threshold. A counter that only moves on a manual
backfill reads **systematically low**, so the check under-reports exactly the tasks that
are being repeatedly re-parked. Sessions that hand-bump it make the data less uniform,
not more.

`first_waiting_since` is the cumulative blocker age that survives re-parks —
`scripts/current-constraint.py` prefers it over `waiting_since` for exactly that reason,
and gets a stale or missing value today.

## Change

Both fields are now written in the same branch that auto-sets `waiting_since`, so the
three can never disagree.

The new-spell discriminator is the **prior state**, not a missing `waiting_since`.
Leaving `waiting` does not clear `waiting_since` (verified by
`test_two_waiting_entries_produce_spell_count_two`), so keying off its absence would
miss precisely the re-parks these fields exist to count.

Also registers both fields in `KNOWN_FRONTMATTER_FIELDS`. They were absent, so
`gptodo lint` warned on frontmatter gptodo itself now writes.

## Tests

Five new tests in `packages/gptodo/tests/test_edit_state_waiting.py`:

- first waiting entry stamps `first_waiting_since` and sets the count to 1
- a re-park after un-park gives count 2 while `first_waiting_since` does **not** move
- `--set state waiting` on an already-waiting task is not a new spell
- a hand-corrupted non-numeric counter recovers to 1 instead of crashing the edit
- both fields are registered in `KNOWN_FRONTMATTER_FIELDS`

`610 passed` across the full `packages/gptodo/tests/` suite; ruff clean.