### PR TITLE
feat(gptme-sessions): add SessionStore.rotate() to cap store rewrite cost

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -873,7 +873,7 @@ def cli(ctx: click.Context, sessions_dir: Path | None) -> None:
         _unsync_window = 14  # days to scan for unsynced sessions
         _default_since = 30  # default stats window
         store = SessionStore(sessions_dir=sessions_dir)
-        records = store.load_all()
+        records = store.load_all(include_archives=True)
 
         # Default to last 30 days for top-level stats
         recent = store.query(since_days=_default_since)
@@ -1138,7 +1138,7 @@ def show(ctx: click.Context, session_id: str, as_json: bool) -> None:
         raise click.UsageError("Session ID must not be empty.")
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
     try:
-        record = resolve_session_record_prefix(store.load_all(), session_id)
+        record = resolve_session_record_prefix(store.load_all(include_archives=True), session_id)
     except ValueError as exc:
         raise click.ClickException(str(exc))
 
@@ -1227,7 +1227,7 @@ def stats(
         has_filters = any([model, run_type, category, harness, outcome, project, since])
         if has_filters:
             click.echo("No records match your filters.")
-        elif store.load_all():
+        elif store.load_all(include_archives=True):
             # Records exist but all fall outside the implicit 30-day window
             click.echo(
                 f"No records in the last {_fmt_since(since_days)}. Use --since all for all-time data."
@@ -2654,6 +2654,7 @@ def regrade(
         harness=harness,
         outcome=effective_outcome,
         since_days=since_days,
+        include_archives=False,
     )
 
     if not candidates:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -3691,6 +3691,69 @@ def stamp_attempt_kind(ctx: click.Context, session_id: str, attempt_kind: str) -
         raise click.ClickException(f"no session record found for session_id={full_id!r}")
 
 
+@cli.command("rotate")
+@click.option(
+    "--keep-days",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Keep records newer than this many days in the active file.",
+)
+@click.option("--dry-run", is_flag=True, help="Report what would move; change nothing.")
+@click.option("--json", "as_json", is_flag=True, help="Emit the counts as JSON.")
+@click.pass_context
+def rotate(ctx: click.Context, keep_days: int, dry_run: bool, as_json: bool) -> None:
+    """Move records older than --keep-days into monthly archive files.
+
+    Every per-session field update rewrites the whole active store, so an
+    unbounded ledger turns a ~2 KB update into a multi-megabyte read+write.
+    Rotation caps that cost. Records are *moved*, never deleted: archives are
+    appended and fsynced before the active file is replaced, and re-running is
+    idempotent.
+
+    History consumers should read active + archives together (``load_all(
+    include_archives=True)``) — check yours before scheduling this.
+
+    \b
+        gptme-sessions rotate --keep-days 30 --dry-run
+    """
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    by_month: dict[str, int] = {}
+    result: dict[str, object]
+    if dry_run:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=keep_days)
+        kept = 0
+        if store.path.exists():
+            with open(store.path, encoding="utf-8") as f:
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    month = SessionStore._archive_month(raw, cutoff)
+                    if month is None:
+                        kept += 1
+                    else:
+                        by_month[month] = by_month.get(month, 0) + 1
+        result = {
+            "dry_run": True,
+            "archived": sum(by_month.values()),
+            "kept": kept,
+            "by_month": by_month,
+        }
+    else:
+        result = {"dry_run": False, **store.rotate(keep_days=keep_days)}
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        prefix = "would archive" if dry_run else "archived"
+        click.echo(f"{prefix} {result['archived']} record(s); kept {result['kept']} active")
+        if result.get("skipped_duplicate"):
+            click.echo(f"skipped {result['skipped_duplicate']} already-archived record(s)")
+        for month, count in sorted(by_month.items()):
+            click.echo(f"  {month}: {count}")
+
+
 def main() -> int:
     """Entry point for console_scripts (backward-compatible wrapper).
 

--- a/packages/gptme-sessions/src/gptme_sessions/harm_detect.py
+++ b/packages/gptme-sessions/src/gptme_sessions/harm_detect.py
@@ -294,7 +294,7 @@ def detect_harm_revert(
             deliverables = []
         else:
             store = SessionStore(resolved_store)
-            records = {r.session_id: r for r in store.load_all()}
+            records = {r.session_id: r for r in store.load_all(include_archives=True)}
             record = records.get(session_id)
             if record is None:
                 logger.debug("Session %s not found in store", session_id)
@@ -346,7 +346,11 @@ def batch_detect_harm_revert(
         if resolved_store is not None and resolved_store.exists()
         else None
     )
-    records = {r.session_id: r for r in store.load_all()} if store is not None else {}
+    records = (
+        {r.session_id: r for r in store.load_all(include_archives=True)}
+        if store is not None
+        else {}
+    )
     resolved_repos = _resolve_repos(repos)
 
     results: dict[str, float] = {}

--- a/packages/gptme-sessions/src/gptme_sessions/replay.py
+++ b/packages/gptme-sessions/src/gptme_sessions/replay.py
@@ -51,7 +51,7 @@ def resolve_replay_target(target: str, *, sessions_dir: Path) -> SessionTranscri
         return read_transcript(path)
 
     store = SessionStore(sessions_dir=sessions_dir)
-    record = resolve_session_record_prefix(store.load_all(), target)
+    record = resolve_session_record_prefix(store.load_all(include_archives=True), target)
     if not record.trajectory_path:
         raise ValueError(f"Session '{record.session_id}' has no trajectory_path; cannot replay it.")
     return read_transcript(Path(record.trajectory_path).expanduser())

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -9,7 +9,7 @@ import sys
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TextIO
 
@@ -171,12 +171,28 @@ class SessionStore:
                 os.fsync(f.fileno())
         return self.path
 
-    def load_all(self) -> list[SessionRecord]:
-        """Load all session records from the JSONL store."""
-        if not self.path.exists():
+    def archive_paths(self) -> list[Path]:
+        """Rotated archive files for this store, oldest name first.
+
+        Named ``<stem>-archive-*.jsonl`` next to the active file (e.g.
+        ``session-records-archive-2026-07.jsonl``).  Archives are append-only:
+        ``rotate()`` writes to them and nothing ever rewrites them, which is
+        the whole point — the active file stays small enough that a
+        read-modify-write cycle is cheap.
+        """
+        stem = (
+            self.path.name[: -len(".jsonl")]
+            if self.path.name.endswith(".jsonl")
+            else self.path.stem
+        )
+        return sorted(self.sessions_dir.glob(f"{stem}-archive-*.jsonl"))
+
+    def _load_path(self, path: Path) -> list[SessionRecord]:
+        """Parse one JSONL file, skipping malformed lines."""
+        if not path.exists():
             return []
         records = []
-        with open(self.path, encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if line:
@@ -184,6 +200,28 @@ class SessionStore:
                         records.append(SessionRecord.from_dict(json.loads(line)))
                     except (json.JSONDecodeError, TypeError, AttributeError):
                         continue
+        return records
+
+    def load_all(self, include_archives: bool = False) -> list[SessionRecord]:
+        """Load session records from the JSONL store.
+
+        Defaults to the **active file only**.  That default is load-bearing:
+        every mutation path is ``load_all()`` → mutate → ``rewrite()``, and
+        ``rewrite()`` has upsert semantics, so pulling archived records into
+        that list would re-inject the entire history back into the active file
+        on the next field update — exactly the write amplification rotation
+        exists to remove.
+
+        Pass ``include_archives=True`` for read-only history consumers
+        (analytics, blame, LOO). Archived records come first, so the result
+        stays roughly chronological.
+        """
+        if not include_archives:
+            return self._load_path(self.path)
+        records: list[SessionRecord] = []
+        for archive in self.archive_paths():
+            records.extend(self._load_path(archive))
+        records.extend(self._load_path(self.path))
         return records
 
     def rewrite(self, records: list[SessionRecord]) -> Path:
@@ -253,6 +291,145 @@ class SessionStore:
                 tmp_path.unlink(missing_ok=True)
                 raise
         return self.path
+
+    def rotate(self, keep_days: int = 30, now: datetime | None = None) -> dict[str, int]:
+        """Move records older than ``keep_days`` out of the active file.
+
+        Why this exists: every per-session field update (grade write-back,
+        ``stamp_attempt_kind``, alignment, bandit stamp) is a full
+        ``rewrite()`` of the active file.  With an unbounded ledger that is a
+        multi-megabyte read **and** write per update, several times per
+        session — measured at 90-150 GB/day of logical writes against a
+        ledger that only grows ~2 KB per session.  Rotation caps the cost of
+        a rewrite at ``keep_days`` worth of records.
+
+        **Move, never delete.**  Archives are appended and fsynced *before*
+        the active file is replaced, so a crash at any point leaves records
+        duplicated (recoverable) rather than lost.  Re-running is safe:
+        records whose ``session_id`` is already present in the target archive
+        are not appended twice.
+
+        Records with a missing or unparseable ``timestamp`` are **kept
+        active** — guessing an age for them risks archiving something a
+        mutation path still needs.  Malformed JSONL lines are likewise
+        preserved in place.
+
+        Returns counts: ``archived``, ``kept``, ``skipped_duplicate``.
+        """
+        if keep_days < 0:
+            raise ValueError("keep_days must be >= 0")
+        now = now or datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=keep_days)
+
+        with self.lock():
+            if not self.path.exists():
+                return {"archived": 0, "kept": 0, "skipped_duplicate": 0}
+
+            keep_lines: list[str] = []
+            by_month: dict[str, list[tuple[str, str]]] = {}  # month -> [(session_id, raw)]
+            with open(self.path, encoding="utf-8") as f:
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    month = self._archive_month(raw, cutoff)
+                    if month is None:
+                        keep_lines.append(raw)
+                        continue
+                    try:
+                        session_id = str(json.loads(raw).get("session_id", ""))
+                    except (json.JSONDecodeError, TypeError, AttributeError):
+                        keep_lines.append(raw)
+                        continue
+                    by_month.setdefault(month, []).append((session_id, raw))
+
+            if not by_month:
+                return {"archived": 0, "kept": len(keep_lines), "skipped_duplicate": 0}
+
+            archived = 0
+            skipped = 0
+            for month, entries in sorted(by_month.items()):
+                archive_path = (
+                    self.sessions_dir / f"{self.path.name[: -len('.jsonl')]}-archive-{month}.jsonl"
+                )
+                existing = self._archive_session_ids(archive_path)
+                # Append first, fsync, and only then drop from the active file.
+                with open(archive_path, "a", encoding="utf-8") as af:
+                    for session_id, raw in entries:
+                        if session_id and session_id in existing:
+                            skipped += 1
+                            continue
+                        af.write(raw + "\n")
+                        if session_id:
+                            existing.add(session_id)
+                        archived += 1
+                    af.flush()
+                    os.fsync(af.fileno())
+
+            tmp_path = self.path.with_name(
+                f"{self.path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+            )
+            try:
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    for line in keep_lines:
+                        f.write(line + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+                tmp_path.replace(self.path)
+            except BaseException:
+                tmp_path.unlink(missing_ok=True)
+                raise
+
+        logger.info(
+            "rotated session store: archived=%d kept=%d skipped_duplicate=%d (keep_days=%d)",
+            archived,
+            len(keep_lines),
+            skipped,
+            keep_days,
+        )
+        return {"archived": archived, "kept": len(keep_lines), "skipped_duplicate": skipped}
+
+    @staticmethod
+    def _archive_month(raw: str, cutoff: datetime) -> str | None:
+        """Return the ``YYYY-MM`` archive bucket for a raw line, or None to keep it.
+
+        Keeps anything it cannot confidently age out: malformed JSON, a
+        missing/unparseable timestamp, or a timestamp at-or-after the cutoff.
+        """
+        try:
+            ts = json.loads(raw).get("timestamp")
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            return None
+        if not isinstance(ts, str) or not ts:
+            return None
+        try:
+            parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        if parsed >= cutoff:
+            return None
+        return parsed.strftime("%Y-%m")
+
+    @staticmethod
+    def _archive_session_ids(archive_path: Path) -> set[str]:
+        """session_ids already present in an archive file (for idempotent rotation)."""
+        ids: set[str] = set()
+        if not archive_path.exists():
+            return ids
+        with open(archive_path, encoding="utf-8") as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    sid = json.loads(raw).get("session_id")
+                except (json.JSONDecodeError, TypeError, AttributeError):
+                    continue
+                if sid:
+                    ids.add(str(sid))
+        return ids
 
     def stamp_attempt_kind(self, session_id: str, attempt_kind: str) -> bool:
         """Stamp the eval attempt classification onto an already-written record.

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -305,9 +306,10 @@ class SessionStore:
 
         **Move, never delete.**  Archives are appended and fsynced *before*
         the active file is replaced, so a crash at any point leaves records
-        duplicated (recoverable) rather than lost.  Re-running is safe:
-        records whose ``session_id`` is already present in the target archive
-        are not appended twice.
+        duplicated (recoverable) rather than lost. Re-running is safe: exact
+        JSONL lines already present in the target archive are not appended
+        twice. Distinct rows are preserved even when they share a
+        ``session_id``.
 
         Records with a missing or unparseable ``timestamp`` are **kept
         active** — guessing an age for them risks archiving something a
@@ -326,7 +328,7 @@ class SessionStore:
                 return {"archived": 0, "kept": 0, "skipped_duplicate": 0}
 
             keep_lines: list[str] = []
-            by_month: dict[str, list[tuple[str, str]]] = {}  # month -> [(session_id, raw)]
+            by_month: dict[str, list[str]] = {}
             with open(self.path, encoding="utf-8") as f:
                 for raw in f:
                     raw = raw.strip()
@@ -336,12 +338,7 @@ class SessionStore:
                     if month is None:
                         keep_lines.append(raw)
                         continue
-                    try:
-                        session_id = str(json.loads(raw).get("session_id", ""))
-                    except (json.JSONDecodeError, TypeError, AttributeError):
-                        keep_lines.append(raw)
-                        continue
-                    by_month.setdefault(month, []).append((session_id, raw))
+                    by_month.setdefault(month, []).append(raw)
 
             if not by_month:
                 return {"archived": 0, "kept": len(keep_lines), "skipped_duplicate": 0}
@@ -352,16 +349,17 @@ class SessionStore:
                 archive_path = (
                     self.sessions_dir / f"{self.path.name[: -len('.jsonl')]}-archive-{month}.jsonl"
                 )
-                existing = self._archive_session_ids(archive_path)
+                existing = self._archive_line_hashes(archive_path)
                 # Append first, fsync, and only then drop from the active file.
+                # Do not add this batch's hashes to ``existing``: duplicate
+                # active rows are distinct historical records and must survive.
                 with open(archive_path, "a", encoding="utf-8") as af:
-                    for session_id, raw in entries:
-                        if session_id and session_id in existing:
+                    for raw in entries:
+                        line_hash = hashlib.sha256(raw.encode()).digest()
+                        if line_hash in existing:
                             skipped += 1
                             continue
                         af.write(raw + "\n")
-                        if session_id:
-                            existing.add(session_id)
                         archived += 1
                     af.flush()
                     os.fsync(af.fileno())
@@ -371,8 +369,7 @@ class SessionStore:
             )
             try:
                 with open(tmp_path, "w", encoding="utf-8") as f:
-                    for line in keep_lines:
-                        f.write(line + "\n")
+                    f.writelines(f"{line}\n" for line in keep_lines)
                     f.flush()
                     os.fsync(f.fileno())
                 tmp_path.replace(self.path)
@@ -413,23 +410,23 @@ class SessionStore:
         return parsed.strftime("%Y-%m")
 
     @staticmethod
-    def _archive_session_ids(archive_path: Path) -> set[str]:
-        """session_ids already present in an archive file (for idempotent rotation)."""
-        ids: set[str] = set()
+    def _archive_line_hashes(archive_path: Path) -> set[bytes]:
+        """Hashes of raw records already archived, for crash-safe idempotency.
+
+        A ``session_id`` is not a unique row identity: stores can legitimately
+        contain duplicate IDs, and an updated record can reuse an archived ID.
+        Hashing the raw JSONL text skips only an exact copy left active after a
+        crash between archive fsync and active-file replacement.
+        """
+        hashes: set[bytes] = set()
         if not archive_path.exists():
-            return ids
+            return hashes
         with open(archive_path, encoding="utf-8") as f:
             for raw in f:
                 raw = raw.strip()
-                if not raw:
-                    continue
-                try:
-                    sid = json.loads(raw).get("session_id")
-                except (json.JSONDecodeError, TypeError, AttributeError):
-                    continue
-                if sid:
-                    ids.add(str(sid))
-        return ids
+                if raw:
+                    hashes.add(hashlib.sha256(raw.encode()).digest())
+        return hashes
 
     def stamp_attempt_kind(self, session_id: str, attempt_kind: str) -> bool:
         """Stamp the eval attempt classification onto an already-written record.
@@ -478,9 +475,15 @@ class SessionStore:
         outcome: str | None = None,
         since_days: float | None = None,
         project: str | None = None,
+        include_archives: bool = True,
     ) -> list[SessionRecord]:
-        """Filter session records by criteria."""
-        records = self.load_all()
+        """Filter session records by criteria.
+
+        Queries are read-only history consumers, so they include archives by
+        default. Mutation paths must pass ``include_archives=False`` to keep
+        archived records out of active-file rewrites.
+        """
+        records = self.load_all(include_archives=include_archives)
         if model:
             records = [r for r in records if r.model_normalized == model or r.model == model]
         if run_type:
@@ -512,7 +515,7 @@ class SessionStore:
     ) -> dict:
         """Compute summary statistics from session records."""
         if records is None:
-            records = self.load_all()
+            records = self.load_all(include_archives=True)
         if not records:
             return {"total": 0}
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -163,6 +163,21 @@ class TestQueryCommand:
         assert len(data) == 1
         assert data[0]["outcome"] == "productive"
 
+    def test_query_includes_rotated_records(self, tmp_path: Path):
+        """Read-only queries retain all-time visibility after rotation."""
+        store = SessionStore(sessions_dir=tmp_path)
+        archived = SessionRecord(
+            session_id="archived-session",
+            timestamp="2026-01-01T00:00:00+00:00",
+        )
+        store.append(archived)
+        store.rotate(keep_days=30, now=datetime(2026, 9, 3, tzinfo=timezone.utc))
+
+        rc, out = _invoke(["query", "--json"], tmp_path)
+
+        assert rc == 0
+        assert [row["session_id"] for row in json.loads(out)] == [archived.session_id]
+
 
 # -- export ------------------------------------------------------------------
 
@@ -344,6 +359,21 @@ class TestExportCommand:
         assert rc != 0
         assert "invalid choice" in out.lower() or "xml" in out.lower()
 
+    def test_export_includes_rotated_records(self, tmp_path: Path):
+        """Backups and audits include archived records by default."""
+        store = SessionStore(sessions_dir=tmp_path)
+        archived = SessionRecord(
+            session_id="archived-session",
+            timestamp="2026-01-01T00:00:00+00:00",
+        )
+        store.append(archived)
+        store.rotate(keep_days=30, now=datetime(2026, 9, 3, tzinfo=timezone.utc))
+
+        rc, out = _invoke(["export", "--format", "json"], tmp_path)
+
+        assert rc == 0
+        assert [row["session_id"] for row in json.loads(out)] == [archived.session_id]
+
 
 # -- cost --------------------------------------------------------------------
 
@@ -407,8 +437,23 @@ class TestShowCommand:
     def test_show_not_found(self, tmp_path: Path):
         """show with unknown ID exits with error."""
         _seed_store(tmp_path)
-        rc, out = _invoke(["show", "nonexistent000"], tmp_path)
+        rc, _out = _invoke(["show", "nonexistent000"], tmp_path)
         assert rc != 0
+
+    def test_show_finds_a_rotated_record(self, tmp_path: Path):
+        """A session ID remains addressable after its record is archived."""
+        store = SessionStore(sessions_dir=tmp_path)
+        archived = SessionRecord(
+            session_id="archived-session",
+            timestamp="2026-01-01T00:00:00+00:00",
+        )
+        store.append(archived)
+        store.rotate(keep_days=30, now=datetime(2026, 9, 3, tzinfo=timezone.utc))
+
+        rc, out = _invoke(["show", archived.session_id], tmp_path)
+
+        assert rc == 0
+        assert archived.session_id in out
 
     def test_show_displays_deliverables(self, tmp_path: Path):
         """show includes deliverables in output."""

--- a/packages/gptme-sessions/tests/test_store_rotation.py
+++ b/packages/gptme-sessions/tests/test_store_rotation.py
@@ -66,11 +66,11 @@ def test_rotate_is_idempotent(store):
     assert len(archive.read_text().strip().splitlines()) == 1
 
 
-def test_rotate_re_archives_a_reappended_session_without_duplicating(store):
-    """A record re-added to the active file after rotation must not double in the archive."""
+def test_rotate_skips_an_identical_reappended_record(store):
+    """Crash recovery may leave an exact copy active; do not archive it twice."""
     store.append(_rec("old", 60))
     store.rotate(keep_days=30, now=NOW)
-    store.append(_rec("old", 60))  # e.g. an upsert that resurrected it
+    store.append(_rec("old", 60))
 
     stats = store.rotate(keep_days=30, now=NOW)
 
@@ -78,6 +78,37 @@ def test_rotate_re_archives_a_reappended_session_without_duplicating(store):
     assert stats["skipped_duplicate"] == 1
     archive = store.archive_paths()[0]
     assert len(archive.read_text().strip().splitlines()) == 1
+
+
+def test_rotate_preserves_distinct_records_with_the_same_session_id(store):
+    """Deduplication must never discard changed or genuinely duplicate rows."""
+    first = _rec("old", 60)
+    second = _rec("old", 59)
+    store.append(first)
+    store.rotate(keep_days=30, now=NOW)
+    store.append(second)
+
+    stats = store.rotate(keep_days=30, now=NOW)
+
+    assert stats["archived"] == 1
+    assert stats["skipped_duplicate"] == 0
+    archived = store.load_all(include_archives=True)
+    assert [(r.session_id, r.timestamp) for r in archived] == [
+        ("old", first.timestamp),
+        ("old", second.timestamp),
+    ]
+
+    # Identical rows in one active batch represent two historical events. They
+    # are both retained on the first rotation; hash dedup only suppresses lines
+    # already durable in the archive from a previous partial rotation.
+    twin = _rec("twin", 58)
+    store.append(twin)
+    store.append(twin)
+    stats = store.rotate(keep_days=30, now=NOW)
+
+    assert stats["archived"] == 2
+    assert stats["skipped_duplicate"] == 0
+    assert [r.session_id for r in store.load_all(include_archives=True)].count("twin") == 2
 
 
 def test_rotate_keeps_records_without_a_usable_timestamp(store):

--- a/packages/gptme-sessions/tests/test_store_rotation.py
+++ b/packages/gptme-sessions/tests/test_store_rotation.py
@@ -1,0 +1,138 @@
+"""Rotation of the session-records store: move old records into monthly archives."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gptme_sessions.record import SessionRecord
+from gptme_sessions.store import SessionStore
+
+NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
+
+
+def _rec(session_id: str, days_ago: int) -> SessionRecord:
+    return SessionRecord(
+        session_id=session_id,
+        timestamp=(NOW - timedelta(days=days_ago)).isoformat(),
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    return SessionStore(sessions_dir=tmp_path)
+
+
+def test_rotate_moves_old_records_into_monthly_archives(store):
+    store.append(_rec("old-jul", 60))  # 2026-07
+    store.append(_rec("old-aug", 33))  # 2026-08-01
+    store.append(_rec("recent", 3))
+
+    stats = store.rotate(keep_days=30, now=NOW)
+
+    assert stats == {"archived": 2, "kept": 1, "skipped_duplicate": 0}
+    assert [r.session_id for r in store.load_all()] == ["recent"]
+    names = [p.name for p in store.archive_paths()]
+    assert names == [
+        "session-records-archive-2026-07.jsonl",
+        "session-records-archive-2026-08.jsonl",
+    ]
+
+
+def test_rotate_preserves_every_record_via_include_archives(store):
+    for i, days in enumerate([90, 60, 40, 10, 1]):
+        store.append(_rec(f"s{i}", days))
+
+    store.rotate(keep_days=30, now=NOW)
+
+    all_ids = {r.session_id for r in store.load_all(include_archives=True)}
+    assert all_ids == {"s0", "s1", "s2", "s3", "s4"}
+    # Default stays active-only so mutation paths don't re-inject history.
+    assert {r.session_id for r in store.load_all()} == {"s3", "s4"}
+
+
+def test_rotate_is_idempotent(store):
+    store.append(_rec("old", 60))
+    store.append(_rec("new", 1))
+
+    first = store.rotate(keep_days=30, now=NOW)
+    second = store.rotate(keep_days=30, now=NOW)
+
+    assert first["archived"] == 1
+    assert second == {"archived": 0, "kept": 1, "skipped_duplicate": 0}
+    archive = store.archive_paths()[0]
+    assert len(archive.read_text().strip().splitlines()) == 1
+
+
+def test_rotate_re_archives_a_reappended_session_without_duplicating(store):
+    """A record re-added to the active file after rotation must not double in the archive."""
+    store.append(_rec("old", 60))
+    store.rotate(keep_days=30, now=NOW)
+    store.append(_rec("old", 60))  # e.g. an upsert that resurrected it
+
+    stats = store.rotate(keep_days=30, now=NOW)
+
+    assert stats["archived"] == 0
+    assert stats["skipped_duplicate"] == 1
+    archive = store.archive_paths()[0]
+    assert len(archive.read_text().strip().splitlines()) == 1
+
+
+def test_rotate_keeps_records_without_a_usable_timestamp(store):
+    store.append(_rec("dated", 60))
+    with open(store.path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"session_id": "no-ts", "timestamp": ""}) + "\n")
+        f.write(json.dumps({"session_id": "bad-ts", "timestamp": "not-a-date"}) + "\n")
+        f.write("{not json at all\n")
+
+    stats = store.rotate(keep_days=30, now=NOW)
+
+    assert stats["archived"] == 1
+    assert stats["kept"] == 3
+    kept = store.path.read_text()
+    assert "no-ts" in kept and "bad-ts" in kept and "{not json at all" in kept
+
+
+def test_rotate_no_op_when_nothing_is_old_enough(store):
+    store.append(_rec("a", 1))
+    store.append(_rec("b", 2))
+
+    assert store.rotate(keep_days=30, now=NOW) == {
+        "archived": 0,
+        "kept": 2,
+        "skipped_duplicate": 0,
+    }
+    assert store.archive_paths() == []
+
+
+def test_rotate_on_missing_store_is_a_no_op(store):
+    assert not store.path.exists()
+    assert store.rotate(keep_days=30, now=NOW) == {
+        "archived": 0,
+        "kept": 0,
+        "skipped_duplicate": 0,
+    }
+
+
+def test_rotate_rejects_negative_keep_days(store):
+    with pytest.raises(ValueError, match="keep_days"):
+        store.rotate(keep_days=-1, now=NOW)
+
+
+def test_rewrite_after_rotation_does_not_resurrect_archived_records(store):
+    """The write-amplification fix: a post-rotation field update stays small."""
+    store.append(_rec("old", 60))
+    store.append(_rec("recent", 1))
+    store.rotate(keep_days=30, now=NOW)
+
+    records = store.load_all()
+    records[0].attempt_kind = "real"
+    store.rewrite(records)
+
+    assert [r.session_id for r in store.load_all()] == ["recent"]
+    assert {r.session_id for r in store.load_all(include_archives=True)} == {
+        "old",
+        "recent",
+    }


### PR DESCRIPTION
## Problem

Every per-session field update — judge grade write-back, `stamp_attempt_kind`, alignment, bandit stamp — is a full `rewrite()` of `session-records.jsonl`. `rewrite()` re-reads the whole file and writes a fsynced temp copy. With an unbounded ledger that is a multi-megabyte read **and** write per update, several times per session, for a file that only grows ~2 KB per session.

Measured on Bob's store 2026-09-03 (NVMe wear investigation): **73 MB / 17k records**, ~90–150 GB/day of logical writes against a DRAM-less SSD.

## What this adds

- **`SessionStore.rotate(keep_days=30)`** — moves older records into monthly `session-records-archive-YYYY-MM.jsonl` files (the naming `blame.py` already documents).
  - Archives are appended and **fsynced before** the active file is replaced, so a crash at any point duplicates records rather than losing them.
  - Idempotent: `session_id`s already present in the target archive are skipped (`skipped_duplicate` in the returned counts).
  - Records with a missing/unparseable `timestamp`, and malformed JSONL lines, are **kept active** rather than aged out on a guess.
  - Retention rule: rotation **moves, never deletes**.
- **`SessionStore.archive_paths()`** and **`load_all(include_archives=False)`**.
  The default stays active-only on purpose: every mutation path is `load_all()` → mutate → `rewrite()`, and `rewrite()` has upsert semantics — pulling archives into that list would re-inject the entire history back into the active file on the next field update, which is exactly the amplification this removes. `test_rewrite_after_rotation_does_not_resurrect_archived_records` pins that.
- **`gptme-sessions rotate [--keep-days N] [--dry-run] [--json]`** so it is schedulable.

## Not scheduled here — on purpose

History consumers must become archive-aware first. In Bob's workspace ~15 scripts hardcode the literal `session-records-archive-pre-2026-04.jsonl` filename instead of globbing `session-records-archive-*.jsonl`; running rotation today would silently drop history from those readers. Migrating them is the follow-up.

## Verification

```
$ gptme-sessions rotate --keep-days 30 --dry-run   # against the real 73 MB store
would archive 5226 record(s); kept 11813 active
  2026-06: 59
  2026-07: 4161
  2026-08: 1006
```

- 9 new tests in `packages/gptme-sessions/tests/test_store_rotation.py` (monthly bucketing, round-trip preservation, idempotency, re-append dedup, undated/malformed records kept, no-op cases, negative `keep_days`, post-rotation rewrite).
- Full package suite: **1381 passed**.
- `ruff check` clean, `mypy src/` clean, `prek` hooks pass.