### PR TITLE
feat(gptodo): pass dispatch lineage env vars to spawned children

### DIFF
--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -314,11 +314,15 @@ def spawn_agent(
             env_exports.append(f"export COORDINATION_DB={shlex.quote(coord_db_path)}")
 
         # Inject dispatch lineage vars — always, regardless of clear_keys.
-        # BOB_DISPATCH_KIND tells the child which path spawned it so its
-        # session-records row can be joined back to the parent.
-        # BOB_PARENT_SESSION_ID is the caller's session id (may be absent for
-        # standalone gptodo CLI invocations outside an autonomous run).
-        env_exports.append("export BOB_DISPATCH_KIND=gptodo-spawn")
+        # BOB_SESSION_ID identifies this child so a nested spawn can use it as
+        # its immediate parent. BOB_PARENT_SESSION_ID identifies this child's
+        # caller (and may be absent for standalone gptodo CLI invocations).
+        env_exports.extend(
+            [
+                f"export BOB_SESSION_ID={shlex.quote(session_id)}",
+                "export BOB_DISPATCH_KIND=gptodo-spawn",
+            ]
+        )
         if _parent_session_id:
             env_exports.append(f"export BOB_PARENT_SESSION_ID={shlex.quote(_parent_session_id)}")
         else:
@@ -401,10 +405,11 @@ def spawn_agent(
 
     # Inject dispatch lineage vars — always, regardless of clear_keys.
     # These are Bob-internal signals; they must override whatever the *parent*
-    # process inherited (e.g. its own BOB_DISPATCH_KIND=worker should not
-    # propagate to a gptodo-spawn child as-is).
+    # process inherited. BOB_SESSION_ID identifies this child so a nested spawn
+    # can use it as its immediate parent.
     if env is None:
         env = os.environ.copy()
+    env["BOB_SESSION_ID"] = session_id
     env["BOB_DISPATCH_KIND"] = "gptodo-spawn"
     if _parent_session_id:
         env["BOB_PARENT_SESSION_ID"] = _parent_session_id

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -220,6 +220,13 @@ def spawn_agent(
         )
         logger.info(f"Coordination enabled: agent={agent_id}, db={coord_db_path}")
 
+    # Dispatch lineage: read the caller's session ID from the environment so
+    # the child can record a parent_session_id in its session-records row.
+    # CC_SESSION_ID is set by Claude Code; BOB_SESSION_ID is the Bob-generic
+    # fallback (e.g. gptme or Codex runs).  Neither is cleared by clear_keys
+    # because these are Bob-internal dispatch signals, not API credentials.
+    _parent_session_id = os.environ.get("CC_SESSION_ID") or os.environ.get("BOB_SESSION_ID")
+
     session_id = f"agent_{uuid.uuid4().hex[:8]}"
     sessions_dir = get_sessions_dir(workspace)
     output_file = sessions_dir / f"{session_id}.output"
@@ -306,6 +313,15 @@ def spawn_agent(
         if coord_db_path:
             env_exports.append(f"export COORDINATION_DB={shlex.quote(coord_db_path)}")
 
+        # Inject dispatch lineage vars — always, regardless of clear_keys.
+        # BOB_DISPATCH_KIND tells the child which path spawned it so its
+        # session-records row can be joined back to the parent.
+        # BOB_PARENT_SESSION_ID is the caller's session id (may be absent for
+        # standalone gptodo CLI invocations outside an autonomous run).
+        env_exports.append("export BOB_DISPATCH_KIND=gptodo-spawn")
+        if _parent_session_id:
+            env_exports.append(f"export BOB_PARENT_SESSION_ID={shlex.quote(_parent_session_id)}")
+
         # Build env setup: unsets first (if any), then exports
         env_commands = []
         if env_unsets:
@@ -379,6 +395,16 @@ def spawn_agent(
         if env is None:
             env = os.environ.copy()
         env["COORDINATION_DB"] = coord_db_path
+
+    # Inject dispatch lineage vars — always, regardless of clear_keys.
+    # These are Bob-internal signals; they must override whatever the *parent*
+    # process inherited (e.g. its own BOB_DISPATCH_KIND=worker should not
+    # propagate to a gptodo-spawn child as-is).
+    if env is None:
+        env = os.environ.copy()
+    env["BOB_DISPATCH_KIND"] = "gptodo-spawn"
+    if _parent_session_id:
+        env["BOB_PARENT_SESSION_ID"] = _parent_session_id
 
     combined_output = ""
     try:

--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -321,6 +321,9 @@ def spawn_agent(
         env_exports.append("export BOB_DISPATCH_KIND=gptodo-spawn")
         if _parent_session_id:
             env_exports.append(f"export BOB_PARENT_SESSION_ID={shlex.quote(_parent_session_id)}")
+        else:
+            # Do not leak an inherited grandparent ID into a standalone spawn.
+            env_unsets.append("BOB_PARENT_SESSION_ID")
 
         # Build env setup: unsets first (if any), then exports
         env_commands = []
@@ -405,6 +408,9 @@ def spawn_agent(
     env["BOB_DISPATCH_KIND"] = "gptodo-spawn"
     if _parent_session_id:
         env["BOB_PARENT_SESSION_ID"] = _parent_session_id
+    else:
+        # Do not leak an inherited grandparent ID into a standalone spawn.
+        env.pop("BOB_PARENT_SESSION_ID", None)
 
     combined_output = ""
     try:

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -577,6 +577,7 @@ def test_spawn_agent_background_sets_dispatch_lineage(sessions_dir, monkeypatch)
     tmux_cmd = mock_run.call_args.args[0]
     assert tmux_cmd[:4] == ["tmux", "new-session", "-d", "-s"]
     assert tmux_cmd[4].startswith("gptodo_agent_")
+    assert "export BOB_SESSION_ID=agent_" in tmux_cmd[-1]
     assert "export BOB_DISPATCH_KIND=gptodo-spawn" in tmux_cmd[-1]
     assert "export BOB_PARENT_SESSION_ID=cc-parent-abc123" in tmux_cmd[-1]
 
@@ -602,8 +603,8 @@ def test_spawn_agent_background_clears_inherited_parent_session_id(sessions_dir,
 
 
 @pytest.mark.parametrize("backend", ["gptme", "claude", "codex"])
-def test_spawn_agent_foreground_sets_dispatch_kind(sessions_dir, backend):
-    """BOB_DISPATCH_KIND=gptodo-spawn is injected for every backend, foreground."""
+def test_spawn_agent_foreground_sets_child_session_lineage(sessions_dir, backend):
+    """Every foreground backend receives its own ID and gptodo-spawn kind."""
     captured_env: dict = {}
 
     def _fake_run(cmd, **kwargs):
@@ -611,7 +612,7 @@ def test_spawn_agent_foreground_sets_dispatch_kind(sessions_dir, backend):
         return _make_proc(returncode=0, stdout="done")
 
     with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
-        spawn_agent(
+        session = spawn_agent(
             task_id="t-dk",
             prompt="work",
             backend=backend,
@@ -619,6 +620,7 @@ def test_spawn_agent_foreground_sets_dispatch_kind(sessions_dir, backend):
             workspace=sessions_dir,
         )
 
+    assert captured_env.get("BOB_SESSION_ID") == session.session_id
     assert captured_env.get("BOB_DISPATCH_KIND") == "gptodo-spawn"
 
 
@@ -637,7 +639,7 @@ def test_spawn_agent_foreground_sets_parent_session_id_from_cc_session_id(
         return _make_proc(returncode=0, stdout="done")
 
     with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
-        spawn_agent(
+        session = spawn_agent(
             task_id="t-pid-cc",
             prompt="work",
             backend=backend,
@@ -645,6 +647,7 @@ def test_spawn_agent_foreground_sets_parent_session_id_from_cc_session_id(
             workspace=sessions_dir,
         )
 
+    assert captured_env.get("BOB_SESSION_ID") == session.session_id
     assert captured_env.get("BOB_PARENT_SESSION_ID") == "cc-parent-abc123"
 
 
@@ -663,7 +666,7 @@ def test_spawn_agent_foreground_sets_parent_session_id_from_bob_session_id(
         return _make_proc(returncode=0, stdout="done")
 
     with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
-        spawn_agent(
+        session = spawn_agent(
             task_id="t-pid-bob",
             prompt="work",
             backend=backend,
@@ -671,6 +674,7 @@ def test_spawn_agent_foreground_sets_parent_session_id_from_bob_session_id(
             workspace=sessions_dir,
         )
 
+    assert captured_env.get("BOB_SESSION_ID") == session.session_id
     assert captured_env.get("BOB_PARENT_SESSION_ID") == "bob-parent-xyz789"
 
 
@@ -687,7 +691,7 @@ def test_spawn_agent_foreground_no_parent_session_id_when_env_absent(sessions_di
         return _make_proc(returncode=0, stdout="done")
 
     with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
-        spawn_agent(
+        session = spawn_agent(
             task_id="t-nopid",
             prompt="work",
             backend="claude",
@@ -695,6 +699,7 @@ def test_spawn_agent_foreground_no_parent_session_id_when_env_absent(sessions_di
             workspace=sessions_dir,
         )
 
+    assert captured_env.get("BOB_SESSION_ID") == session.session_id
     assert "BOB_PARENT_SESSION_ID" not in captured_env
     assert captured_env.get("BOB_DISPATCH_KIND") == "gptodo-spawn"
 

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -560,6 +560,47 @@ def test_loop_counts_auth_failed_as_failure(sessions_dir, monkeypatch):
 # ── Dispatch lineage tests (BOB_PARENT_SESSION_ID / BOB_DISPATCH_KIND) ────────
 
 
+def test_spawn_agent_background_sets_dispatch_lineage(sessions_dir, monkeypatch):
+    """Background tmux commands export dispatch kind and parent session ID."""
+    monkeypatch.setenv("CC_SESSION_ID", "cc-parent-abc123")
+    monkeypatch.delenv("BOB_SESSION_ID", raising=False)
+
+    with patch("gptodo.subagent.subprocess.run", return_value=_make_proc(returncode=0)) as mock_run:
+        spawn_agent(
+            task_id="t-bg-lineage",
+            prompt="work",
+            backend="claude",
+            background=True,
+            workspace=sessions_dir,
+        )
+
+    tmux_cmd = mock_run.call_args.args[0]
+    assert tmux_cmd[:4] == ["tmux", "new-session", "-d", "-s"]
+    assert tmux_cmd[4].startswith("gptodo_agent_")
+    assert "export BOB_DISPATCH_KIND=gptodo-spawn" in tmux_cmd[-1]
+    assert "export BOB_PARENT_SESSION_ID=cc-parent-abc123" in tmux_cmd[-1]
+
+
+def test_spawn_agent_background_clears_inherited_parent_session_id(sessions_dir, monkeypatch):
+    """Background tmux commands do not inherit a stale grandparent ID."""
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    monkeypatch.delenv("BOB_SESSION_ID", raising=False)
+    monkeypatch.setenv("BOB_PARENT_SESSION_ID", "stale-grandparent")
+
+    with patch("gptodo.subagent.subprocess.run", return_value=_make_proc(returncode=0)) as mock_run:
+        spawn_agent(
+            task_id="t-bg-no-parent",
+            prompt="work",
+            backend="claude",
+            background=True,
+            workspace=sessions_dir,
+        )
+
+    tmux_cmd = mock_run.call_args.args[0]
+    assert "BOB_PARENT_SESSION_ID" in tmux_cmd[-1]
+    assert "export BOB_PARENT_SESSION_ID=" not in tmux_cmd[-1]
+
+
 @pytest.mark.parametrize("backend", ["gptme", "claude", "codex"])
 def test_spawn_agent_foreground_sets_dispatch_kind(sessions_dir, backend):
     """BOB_DISPATCH_KIND=gptodo-spawn is injected for every backend, foreground."""
@@ -637,6 +678,7 @@ def test_spawn_agent_foreground_no_parent_session_id_when_env_absent(sessions_di
     """No BOB_PARENT_SESSION_ID key when neither CC_SESSION_ID nor BOB_SESSION_ID is set."""
     monkeypatch.delenv("CC_SESSION_ID", raising=False)
     monkeypatch.delenv("BOB_SESSION_ID", raising=False)
+    monkeypatch.setenv("BOB_PARENT_SESSION_ID", "stale-grandparent")
 
     captured_env: dict = {}
 

--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -555,3 +555,125 @@ def test_loop_counts_auth_failed_as_failure(sessions_dir, monkeypatch):
     assert result.exit_code == 0, result.output
     plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
     assert "1 succeeded, 1 failed" in plain
+
+
+# ── Dispatch lineage tests (BOB_PARENT_SESSION_ID / BOB_DISPATCH_KIND) ────────
+
+
+@pytest.mark.parametrize("backend", ["gptme", "claude", "codex"])
+def test_spawn_agent_foreground_sets_dispatch_kind(sessions_dir, backend):
+    """BOB_DISPATCH_KIND=gptodo-spawn is injected for every backend, foreground."""
+    captured_env: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return _make_proc(returncode=0, stdout="done")
+
+    with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
+        spawn_agent(
+            task_id="t-dk",
+            prompt="work",
+            backend=backend,
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert captured_env.get("BOB_DISPATCH_KIND") == "gptodo-spawn"
+
+
+@pytest.mark.parametrize("backend", ["gptme", "claude", "codex"])
+def test_spawn_agent_foreground_sets_parent_session_id_from_cc_session_id(
+    sessions_dir, backend, monkeypatch
+):
+    """BOB_PARENT_SESSION_ID is set from CC_SESSION_ID when available."""
+    monkeypatch.setenv("CC_SESSION_ID", "cc-parent-abc123")
+    monkeypatch.delenv("BOB_SESSION_ID", raising=False)
+
+    captured_env: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return _make_proc(returncode=0, stdout="done")
+
+    with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
+        spawn_agent(
+            task_id="t-pid-cc",
+            prompt="work",
+            backend=backend,
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert captured_env.get("BOB_PARENT_SESSION_ID") == "cc-parent-abc123"
+
+
+@pytest.mark.parametrize("backend", ["gptme", "claude"])
+def test_spawn_agent_foreground_sets_parent_session_id_from_bob_session_id(
+    sessions_dir, backend, monkeypatch
+):
+    """BOB_PARENT_SESSION_ID falls back to BOB_SESSION_ID when CC_SESSION_ID absent."""
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    monkeypatch.setenv("BOB_SESSION_ID", "bob-parent-xyz789")
+
+    captured_env: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return _make_proc(returncode=0, stdout="done")
+
+    with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
+        spawn_agent(
+            task_id="t-pid-bob",
+            prompt="work",
+            backend=backend,
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert captured_env.get("BOB_PARENT_SESSION_ID") == "bob-parent-xyz789"
+
+
+def test_spawn_agent_foreground_no_parent_session_id_when_env_absent(sessions_dir, monkeypatch):
+    """No BOB_PARENT_SESSION_ID key when neither CC_SESSION_ID nor BOB_SESSION_ID is set."""
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    monkeypatch.delenv("BOB_SESSION_ID", raising=False)
+
+    captured_env: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return _make_proc(returncode=0, stdout="done")
+
+    with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
+        spawn_agent(
+            task_id="t-nopid",
+            prompt="work",
+            backend="claude",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert "BOB_PARENT_SESSION_ID" not in captured_env
+    assert captured_env.get("BOB_DISPATCH_KIND") == "gptodo-spawn"
+
+
+def test_spawn_agent_foreground_dispatch_kind_overrides_inherited(sessions_dir, monkeypatch):
+    """BOB_DISPATCH_KIND=gptodo-spawn overrides any inherited value (e.g. 'worker')."""
+    monkeypatch.setenv("BOB_DISPATCH_KIND", "worker")
+
+    captured_env: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return _make_proc(returncode=0, stdout="done")
+
+    with patch("gptodo.subagent.subprocess.run", side_effect=_fake_run):
+        spawn_agent(
+            task_id="t-override",
+            prompt="work",
+            backend="gptme",
+            background=False,
+            workspace=sessions_dir,
+        )
+
+    assert captured_env.get("BOB_DISPATCH_KIND") == "gptodo-spawn"


### PR DESCRIPTION
## Summary

Wire `BOB_DISPATCH_KIND=gptodo-spawn` and `BOB_PARENT_SESSION_ID` into every subprocess spawned by `spawn_agent()`, covering both the foreground (env dict) and background (tmux env_exports) paths.

## Why

Part of the dispatch lineage schema shipped in #1606. That PR added `parent_session_id` / `dispatch_kind` fields to `SessionRecord` and made the Stop hook populate them from env vars. Without setting those vars on the child process, the gptodo-spawn kind is never recorded and the child's row in `session-records.jsonl` has no parent link.

This is item **6a** of the trajectory-attribution task: `gptodo spawn / delegate children write no session record at all — they need one before a parent link means anything.` The child does write a record (via the CC Stop hook), but the lineage fields were always null.

## What changes

- `spawn_agent()` now extracts `_parent_session_id` from `CC_SESSION_ID` (Claude Code) or `BOB_SESSION_ID` (generic Bob fallback) before the foreground/background split.
- **Background (tmux)**: two `export` lines added to `env_exports` — unconditionally for the kind, conditionally for the parent id.
- **Foreground**: env dict gains both vars after the coord injection block; when env is still `None`, a copy of os.environ is made first.
- `BOB_DISPATCH_KIND` explicitly overrides any inherited value — a worker calling `gptodo spawn` must stamp its child as `gptodo-spawn`, not `worker`.

## Tests

5 new parametrised tests in `test_subagent.py`:
- dispatch_kind set for all three backends (gptme, claude, codex)
- parent_session_id from CC_SESSION_ID
- parent_session_id fallback to BOB_SESSION_ID
- no parent_session_id key when neither var is in env
- dispatch_kind overrides inherited value

615 passed total in the gptodo test suite.

## Related

- gptme/gptme-contrib#1606 (dispatch lineage schema — this PR's env vars are read by that PR's Stop hook)