### PR TITLE
feat(pm_dispatch): redirect slot stdout/stderr to per-slot log files

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -697,6 +697,12 @@ class LaneDispatcher:
     slot_timeout_sec: int = 2400
     memory_max: str = "8G"
     cpu_quota: str = "80%"
+    #: Directory for per-slot log files. When set, slot stdout+stderr are
+    #: redirected here via ``StandardOutput=append:<dir>/<unit>.log`` instead
+    #: of streaming into the journal. Sequential file appends are orders of
+    #: magnitude cheaper than journald's mmap random-write pattern on DRAM-less
+    #: SSDs. Set to None to keep the journal-only behaviour (default).
+    slot_log_dir: Path | None = None
 
     def dispatch(
         self,
@@ -903,6 +909,18 @@ class LaneDispatcher:
             "--setenv=BOB_PM_BANDIT_SHADOW="
             + os.environ.get("BOB_PM_BANDIT_SHADOW", "0")
         )
+        # Route stdout+stderr to per-slot log files when slot_log_dir is set.
+        # Sequential file appends are much cheaper than journald's mmap
+        # random-write pattern on DRAM-less SSDs (~18 GB/day → target <3 GB).
+        if self.slot_log_dir is not None:
+            self.slot_log_dir.mkdir(parents=True, exist_ok=True)
+            log_file = self.slot_log_dir / f"{unit_name}.log"
+            cmd.extend(
+                [
+                    f"--property=StandardOutput=append:{log_file}",
+                    f"--property=StandardError=append:{log_file}",
+                ]
+            )
         cmd.extend(["--", "bash", script_path])
 
         try:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2503,3 +2503,111 @@ class TestRepoExclusionList:
         assert deferred == 0
         assert skipped_excluded == 1
         assert callback_calls == ["gptme/gptme"]
+
+
+# --- LaneDispatcher slot_log_dir ---
+
+
+class TestLaneDispatcherSlotLogDir:
+    """Verify slot_log_dir routes stdout+stderr to per-slot log files."""
+
+    def _make_script(self, tmp_path: Path) -> str:
+        """Create a trivial bash script for _launch_slot_unit to reference."""
+        script = tmp_path / "slot.sh"
+        script.write_text("#!/bin/bash\necho hello\n")
+        script.chmod(0o755)
+        return str(script)
+
+    def test_slot_log_dir_adds_output_properties(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When slot_log_dir is set, SystemOutput+StandardError appear in cmd."""
+        import subprocess
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            result = subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        log_dir = tmp_path / "pm-slot-logs"
+        mgr = SlotManager(
+            slot_cap=10,
+            count_running=lambda: 0,
+            count_running_lane=lambda lane: 0,
+            is_busy=lambda unit: False,
+        )
+        ld = LaneDispatcher(slot_manager=mgr, slot_log_dir=log_dir)
+
+        item = SlotItem("gptme/gptme", 1, ["notification"], "Test item")
+        script = self._make_script(tmp_path)
+        unit_name = "bob-pm-fast-slot-test"
+        ld._launch_unit(
+            unit_name,
+            unit_name,  # legacy_name same as unit_name for test
+            "gptme-gptme-1",
+            "fast",
+            item,
+            "claude-code",
+            "sonnet",
+            script,
+        )
+
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        # Log dir must be created
+        assert log_dir.is_dir()
+        # Expected log file path
+        log_file = log_dir / f"{unit_name}.log"
+        stdout_prop = f"--property=StandardOutput=append:{log_file}"
+        stderr_prop = f"--property=StandardError=append:{log_file}"
+        assert stdout_prop in cmd, f"StandardOutput property missing from cmd: {cmd}"
+        assert stderr_prop in cmd, f"StandardError property missing from cmd: {cmd}"
+
+    def test_no_slot_log_dir_omits_output_properties(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When slot_log_dir is None (default), no output redirect in cmd."""
+        import subprocess
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        mgr = SlotManager(
+            slot_cap=10,
+            count_running=lambda: 0,
+            count_running_lane=lambda lane: 0,
+            is_busy=lambda unit: False,
+        )
+        ld = LaneDispatcher(slot_manager=mgr)  # slot_log_dir=None (default)
+
+        item = SlotItem("gptme/gptme", 1, ["notification"], "Test item")
+        script = self._make_script(tmp_path)
+        unit_name = "bob-pm-fast-slot-test"
+        ld._launch_unit(
+            unit_name,
+            unit_name,
+            "gptme-gptme-1",
+            "fast",
+            item,
+            "claude-code",
+            "sonnet",
+            script,
+        )
+
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        assert not any("StandardOutput" in arg for arg in cmd)
+        assert not any("StandardError" in arg for arg in cmd)


### PR DESCRIPTION
## Problem

PM slot units stream full gptme output into journald line-by-line (~18 GB/day logical writes). journald's mmap-based random writes into 128 MiB rotating files are worst-case for the DRAM-less NVMe SSDs (128K-recordsize ZFS), contributing to accelerated wear.

Measured: 27.9 MB/132s = **18.3 GB/day** from the in-container journald. The top emitter was `bob-pm-fast-slot-gptme-gptme-contrib-1599` alone: 15,850 lines in 10 min.

Root cause investigation: `knowledge/incidents/2026-09-03-node1-nvme-wear-bob-write-amplification.md`

## Fix

Add `slot_log_dir: Path | None` to `LaneDispatcher`. When set, `_launch_unit()` adds `StandardOutput=append:<path>` and `StandardError=append:<path>` to the `systemd-run` command before launch.

Sequential file appends are far cheaper than journald's random-write pattern on the same hardware. The full slot output remains recoverable per-slot for debugging (pm-post-run-summary.sh reads from PM_RECORDS_DIR structured data, not journalctl).

- `append:` is used over `file:` to avoid clobbering across Exec* lines (per systemd semantics).
- The bash `run_slot_unit` path in `project-monitoring-lib.sh` is updated separately in the brain repo (both the runloops and bash executor blocks).
- A 7-day log rotation step is added to `prune-caches.sh`.

## Tests

2 new tests in `TestLaneDispatcherSlotLogDir`:
- `test_slot_log_dir_adds_output_properties`: verifies StandardOutput+StandardError properties appear in the systemd-run cmd when slot_log_dir is set
- `test_no_slot_log_dir_omits_output_properties`: verifies no redirect when slot_log_dir=None (default — no change to existing behavior)

226 total tests pass.

## Acceptance

- journald write_bytes < 3 GB/day (re-measure post-deploy via `pct exec 200 -- cat /proc/$(pidof systemd-journald)/io`)
- PM slot output still recoverable per slot from `logs/pm-slots/<unit>.log`