### PR TITLE
feat(gptme-sessions): resolve dispatch_id from harness-neutral BOB_DISPATCH_ID

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -342,9 +342,11 @@ def post_session(
         ``BOB_DISPATCH_KIND`` environment variable.
     dispatch_id:
         Run-id of the dispatcher when the dispatcher is not itself a recorded
-        session (e.g. project-monitoring slot unit name from ``PM_DISPATCH_ID``).
-        Complements ``parent_session_id``; use for dispatcher-run→child joins.
-        Defaults to the ``PM_DISPATCH_ID`` environment variable.
+        session (e.g. an autonomous-fanout run, a spawn-workers run, or a
+        project-monitoring slot unit name).  Complements ``parent_session_id``;
+        use for dispatcher-run→child joins.  Defaults to the harness-neutral
+        ``BOB_DISPATCH_ID`` environment variable, falling back to
+        ``PM_DISPATCH_ID`` for the project-monitoring path.
     run_type:
         Pipeline / trigger name (e.g. ``"autonomous"``, ``"monitoring"``).
         Kept for backward compatibility; prefer ``trigger`` going forward.
@@ -909,10 +911,18 @@ def post_session(
     resolved_dispatch_kind = dispatch_kind or os.environ.get("BOB_DISPATCH_KIND") or None
     if resolved_dispatch_kind is not None:
         record_kwargs["dispatch_kind"] = resolved_dispatch_kind
-    # dispatch_id: the run-id of a dispatcher that is not itself a session
-    # (e.g. PM slot unit name from PM_DISPATCH_ID).  Distinct from
-    # parent_session_id which links session→session.
-    resolved_dispatch_id = dispatch_id or os.environ.get("PM_DISPATCH_ID") or None
+    # dispatch_id: the run-id of a dispatcher that is not itself a session.
+    # Distinct from parent_session_id, which links session→session.
+    #
+    # BOB_DISPATCH_ID is the harness-neutral name every dispatcher can export
+    # (autonomous-fanout.sh, spawn-workers.sh, ...).  PM_DISPATCH_ID stays as a
+    # fallback because project-monitoring slot units already set it and its
+    # value is joined against the PM ledger; keeping both lets the PM path work
+    # unchanged while non-PM dispatchers stop being forced to borrow a
+    # PM-flavoured variable name to get their run-id recorded.
+    resolved_dispatch_id = (
+        dispatch_id or os.environ.get("BOB_DISPATCH_ID") or os.environ.get("PM_DISPATCH_ID") or None
+    )
     if resolved_dispatch_id is not None:
         record_kwargs["dispatch_id"] = resolved_dispatch_id
     if actual_category is not None:

--- a/packages/gptme-sessions/tests/test_dispatch_lineage.py
+++ b/packages/gptme-sessions/tests/test_dispatch_lineage.py
@@ -163,6 +163,7 @@ def test_post_session_records_dispatch_id_from_argument(tmp_path: Path):
 
 def test_post_session_reads_dispatch_id_from_env(tmp_path: Path, monkeypatch):
     """PM_DISPATCH_ID env var is the fallback when no explicit dispatch_id given."""
+    monkeypatch.delenv("BOB_DISPATCH_ID", raising=False)
     monkeypatch.setenv("PM_DISPATCH_ID", "bob-pm-activitywatch-aw-webui-slot-1")
     store = SessionStore(sessions_dir=tmp_path)
     result = post_session(
@@ -178,6 +179,7 @@ def test_post_session_reads_dispatch_id_from_env(tmp_path: Path, monkeypatch):
 
 def test_explicit_dispatch_id_beats_env(tmp_path: Path, monkeypatch):
     """Explicit argument takes priority over the PM_DISPATCH_ID env var."""
+    monkeypatch.delenv("BOB_DISPATCH_ID", raising=False)
     monkeypatch.setenv("PM_DISPATCH_ID", "env-value")
     store = SessionStore(sessions_dir=tmp_path)
     result = post_session(
@@ -193,6 +195,7 @@ def test_explicit_dispatch_id_beats_env(tmp_path: Path, monkeypatch):
 
 def test_no_dispatch_id_without_env_or_argument(tmp_path: Path, monkeypatch):
     monkeypatch.delenv("PM_DISPATCH_ID", raising=False)
+    monkeypatch.delenv("BOB_DISPATCH_ID", raising=False)
     store = SessionStore(sessions_dir=tmp_path)
     result = post_session(
         store=store,
@@ -202,6 +205,74 @@ def test_no_dispatch_id_without_env_or_argument(tmp_path: Path, monkeypatch):
         duration_seconds=10,
     )
     assert result.record.dispatch_id is None
+
+
+def test_post_session_reads_dispatch_id_from_bob_env(tmp_path: Path, monkeypatch):
+    """BOB_DISPATCH_ID is the harness-neutral fallback for non-PM dispatchers."""
+    monkeypatch.delenv("PM_DISPATCH_ID", raising=False)
+    monkeypatch.setenv("BOB_DISPATCH_ID", "bob-autonomous-fanout-code-1234")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="fanout-child1",
+        dispatch_kind="fanout",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "bob-autonomous-fanout-code-1234"
+    assert result.record.dispatch_kind == "fanout"
+
+
+def test_bob_dispatch_id_beats_pm_dispatch_id(tmp_path: Path, monkeypatch):
+    """A dispatcher's own BOB_DISPATCH_ID wins over an inherited PM_DISPATCH_ID.
+
+    Slot units export PM_DISPATCH_ID and children inherit the whole
+    environment, so a nested non-PM dispatcher would otherwise be attributed to
+    the outer PM slot run.
+    """
+    monkeypatch.setenv("PM_DISPATCH_ID", "bob-pm-gptme-gptme-slot-2")
+    monkeypatch.setenv("BOB_DISPATCH_ID", "bob-workers-run-99")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="worker-child1",
+        dispatch_kind="worker",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "bob-workers-run-99"
+
+
+def test_explicit_dispatch_id_beats_bob_env(tmp_path: Path, monkeypatch):
+    """Explicit argument still outranks the harness-neutral env var."""
+    monkeypatch.setenv("BOB_DISPATCH_ID", "env-value")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="fanout-child2",
+        dispatch_id="explicit-value",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "explicit-value"
+
+
+def test_blank_bob_dispatch_id_falls_back_to_pm(tmp_path: Path, monkeypatch):
+    """An exported-but-empty BOB_DISPATCH_ID must not blank out the PM value."""
+    monkeypatch.setenv("BOB_DISPATCH_ID", "")
+    monkeypatch.setenv("PM_DISPATCH_ID", "bob-pm-gptme-gptme-slot-5")
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="sonnet",
+        session_id="pm-child5",
+        duration_seconds=10,
+    )
+    assert result.record.dispatch_id == "bob-pm-gptme-gptme-slot-5"
 
 
 def test_dispatch_id_roundtrips_through_store(tmp_path: Path):


### PR DESCRIPTION
## Problem

`dispatch_id` is documented as *"the run-id of the dispatcher when the dispatcher
is not itself a recorded session"*, but `post_session()` only resolves it from
`PM_DISPATCH_ID`. In practice that makes the field reachable **only** from
project-monitoring slots.

`autonomous-fanout.sh` and `spawn-workers.sh` are exactly the same shape —
dispatcher scripts with no `session_id` of their own (confirmed: neither script
has any session identity in scope, so `parent_session_id` is the wrong field for
them). Their only route to recording a run-id today is to export a PM-flavoured
variable, which would also pollute the `PM_DISPATCH_ID` → PM-ledger join in
`pm-run-item-slot.sh`.

Measured on Bob's workspace over 24h (334 records):

| field | coverage |
|---|---|
| `dispatch_kind` | 12.9% (43 — 29 fanout, 14 worker) |
| `dispatch_id` | **0%** |
| `parent_session_id` | **0%** |

So the lineage is half-wired: the *kind* of dispatch is recorded with no
dispatcher run to join it to.

## Change

Put `BOB_DISPATCH_ID` ahead of `PM_DISPATCH_ID` in the fallback chain:

```python
resolved_dispatch_id = (
    dispatch_id or os.environ.get("BOB_DISPATCH_ID") or os.environ.get("PM_DISPATCH_ID") or None
)
```

`PM_DISPATCH_ID` is kept as a fallback so the PM path works unchanged. Ordering
matters beyond naming: slot units export `PM_DISPATCH_ID` and children inherit
the whole environment, so a nested non-PM dispatcher under a PM slot would
otherwise be attributed to the outer slot run.

Docstring updated to name the general case rather than the PM special case.

## Tests

4 added (`tests/test_dispatch_lineage.py`, 22 total in file):

- `test_post_session_reads_dispatch_id_from_bob_env` — the new fallback
- `test_bob_dispatch_id_beats_pm_dispatch_id` — inherited-PM-env precedence
- `test_explicit_dispatch_id_beats_bob_env` — explicit arg still outranks env
- `test_blank_bob_dispatch_id_falls_back_to_pm` — exported-but-empty must not
  blank out the PM value

The two behavioural tests were confirmed **red** before the change (`2 failed,
20 passed`) and green after. The three existing PM-env tests now
`delenv("BOB_DISPATCH_ID")` so an ambient value cannot silently satisfy them.

```
tests/test_dispatch_lineage.py    22 passed
```

## Scope

Recorder only. Exporting `BOB_DISPATCH_ID` from the individual spawners is
Bob-side and lands separately, same split as gptme/gptme-contrib#1606.

Refs `ErikBjare/bob` `tasks/session-record-field-coverage-fix-2026-09-04.md`.