### PR TITLE
feat(gptme-sessions): add extra_fields param to write_alignment_grade

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -1010,6 +1010,7 @@ def write_alignment_grade(
     session_id: str,
     verdict: JudgeVerdict,
     sessions_dir: Path,
+    extra_fields: dict[str, Any] | None = None,
 ) -> bool:
     """Persist an alignment verdict onto an existing session record.
 
@@ -1018,6 +1019,11 @@ def write_alignment_grade(
     the record is already being loaded and rewritten, so the extra work is
     amortized and keeps per-tool-call span data flowing into the LOO /
     analytics pipelines that key off ``SessionRecord``.
+
+    ``extra_fields`` are persisted into the record's ``_legacy_fields`` dict
+    during the same locked rewrite, avoiding a second full-store pass.
+    Values are JSON-serialised so non-serialisable objects (e.g. datetimes)
+    are coerced to strings.
     """
     store = SessionStore(sessions_dir=sessions_dir)
     records = store.load_all()
@@ -1080,6 +1086,13 @@ def write_alignment_grade(
                 legacy_fields["pivot_verdict"] = normalized["pivot_verdict"]
             if normalized.get("raw_response") is not None:
                 legacy_fields["llm_judge_raw_response"] = normalized["raw_response"]
+            # Caller-supplied extra fields: merged in the same rewrite to avoid
+            # a second full-store pass.  JSON-roundtrip coerces non-serialisable
+            # objects (datetimes, etc.) to strings — same policy as callers that
+            # previously used a separate _persist_judge_cascade_context pass.
+            if extra_fields:
+                for k, v in extra_fields.items():
+                    legacy_fields[k] = json.loads(json.dumps(v, default=str))
         _store_judge_meta(record, normalized.get("meta"))
         # Safe to run unconditionally: returns False when trajectory_path is
         # missing / unreadable or harness is unknown, and is idempotent when

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -1025,6 +1025,48 @@ class TestSessionRecordJudgeFields:
         assert updated.to_dict()["judge_status"] == JUDGE_STATUS_COMPLIANCE_FAILURE
         assert updated.to_dict()["llm_judge_raw_response"] == '{"score": 0.42}'
 
+    def test_write_alignment_grade_extra_fields(self, tmp_path: Path) -> None:
+        """write_alignment_grade persists extra_fields into legacy_fields in the same rewrite."""
+        from gptme_sessions.judge import write_alignment_grade
+
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        result = write_alignment_grade(
+            session_id="abc123",
+            verdict={"score": 0.8, "reason": "good", "model": "test-model"},
+            sessions_dir=tmp_path,
+            extra_fields={"llm_judge_cascade_context": {"category": "code", "score": 42}},
+        )
+
+        assert result is True
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        # Grade written
+        assert updated.grades["alignment"] == 0.8
+        # extra_fields merged into the same record
+        legacy = getattr(updated, "_legacy_fields", {}) or {}
+        ctx = legacy.get("llm_judge_cascade_context")
+        assert ctx == {"category": "code", "score": 42}
+
+    def test_write_alignment_grade_extra_fields_none_is_noop(self, tmp_path: Path) -> None:
+        """extra_fields=None leaves legacy_fields unchanged."""
+        from gptme_sessions.judge import write_alignment_grade
+
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        result = write_alignment_grade(
+            session_id="abc123",
+            verdict={"score": 0.7, "reason": "ok", "model": "test-model"},
+            sessions_dir=tmp_path,
+            extra_fields=None,
+        )
+
+        assert result is True
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        legacy = getattr(updated, "_legacy_fields", {}) or {}
+        assert "llm_judge_cascade_context" not in legacy
+
     def test_writeback_merges_trajectory_ref_for_codex(self, tmp_path: Path) -> None:
         """write_alignment_grade merges harness+trajectory_path from trajectory_ref.json
         when the stored record is missing them (codex path)."""


### PR DESCRIPTION
## Summary

Add an `extra_fields: dict | None = None` parameter to `write_alignment_grade` so callers can persist additional `_legacy_fields` in the **same locked store rewrite**, avoiding a second full-JSONL pass.

## Motivation

Bob's alignment close-out path (`metaproductivity.session_alignment.judge_and_writeback`) previously called `write_alignment_grade` to write the judge verdict, then issued a **second** full session-records rewrite through `_persist_judge_cascade_context` to store `llm_judge_cascade_context`. With a 71 MB session-records.jsonl (16,895 records), that second rewrite was pure write-amplification.

After this PR, callers pass the extra data via `extra_fields` and the single existing rewrite handles both.

## Changes

- `gptme_sessions/judge.py`: `write_alignment_grade` gains `extra_fields` param; values are JSON-round-tripped to coerce non-serialisable objects to strings
- `tests/test_judge.py`: two focused tests — round-trip and None-is-noop

## Downstream (Bob brain repo)

`metaproductivity.session_alignment.judge_and_writeback` will use `extra_fields` and drop the `_persist_judge_cascade_context` second-rewrite pass.