### PR TITLE
fix(activity-gate): carry CI state hash into dispatch detail

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -816,7 +816,7 @@ check_ci_failures() {
         # failure now re-emits `ci_failure`. That is the desired behaviour — new
         # commit, still red, is a fresh actionable signal, not a duplicate.
         ci_hash=$(echo "$pr_data" | jq -r '(.headRefOid // "") + ":" + ([.statusCheckRollup[] | .conclusion // .state // "pending"] | sort | join(","))' | portable_hash)
-        detail="CI failing"
+        detail="CI failing: state_hash=$ci_hash"
 
         if [ "$ci_state" = "inflight" ]; then
             # Checks still running is normal. Only actionable once the state has
@@ -826,7 +826,7 @@ check_ci_failures() {
                 mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null) || continue
                 age=$(( now - mtime ))
                 [ "$age" -ge "$stuck_secs" ] || continue
-                detail="CI stuck: checks in flight ${age}s with no state change"
+                detail="CI stuck: checks in flight ${age}s with no state change; state_hash=$ci_hash"
                 # Re-stamp so a still-stuck PR re-emits at most once per
                 # stuck_secs rather than on every gate run.
                 touch "$state_file"

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -364,6 +364,71 @@ check_ci_failures "o/r" '{json.dumps([pr])}'
     assert not state_file.exists(), "green PR must clean up the state file"
 
 
+def test_ci_failure_detail_includes_state_hash_token() -> None:
+    """A terminal CI flip must change the grouped dispatch payload.
+
+    ``activity-gate.sh`` state-tracks CI by ``ci_hash`` and emits only when the
+    stored hash changes. But the downstream PM dispatcher dedupes grouped items
+    by ``types`` + ``detail`` atoms. When the detail was the constant string
+    ``CI failing``, a PR whose previous red check was already dispatched could
+    flip to a different red check-set on the same head, pass activity-gate's
+    ``ci_hash`` test, and still be swallowed as ``event_unchanged`` /
+    ``event_subsumed`` by PM. Carrying the same state hash in the detail gives
+    dispatch dedupe the same state boundary the gate already uses.
+    """
+    old_rollup = [{"status": "COMPLETED", "conclusion": "FAILURE", "name": "old"}]
+    new_rollup = [
+        {"status": "COMPLETED", "conclusion": "FAILURE", "name": "old"},
+        {"status": "COMPLETED", "conclusion": "FAILURE", "name": "new"},
+    ]
+    old_key = _ci_hash_key(old_rollup)
+    new_key = _ci_hash_key(new_rollup)
+    assert old_key != new_key
+
+    pr = {
+        "number": 1,
+        "title": "red pr",
+        "headRefOid": "d" * 40,
+        "statusCheckRollup": new_rollup,
+    }
+
+    expected_hash = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"jq -r '{_extract_hash_program()}' | {_sha256_cmd()} | cut -d' ' -f1",
+        ],
+        input=json.dumps(pr),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    old_hash = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"printf %s {json.dumps(old_key)!r} | {_sha256_cmd()} | cut -d' ' -f1",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    script = f"""
+set -uo pipefail
+STATE_DIR=$(mktemp -d)
+CI_STUCK_SECS=3600
+portable_hash() {{ {_sha256_cmd()} | cut -d' ' -f1; }}
+emit_item() {{ echo "EMIT type=$1 repo=$2 pr=$3 detail=$5"; }}
+source_only=1
+{_extract_function()}
+check_ci_failures "o/r" '{json.dumps([pr])}'
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert f"state_hash={expected_hash}" in proc.stdout, proc.stdout
+    assert f"state_hash={old_hash}" not in proc.stdout, proc.stdout
+
+
 def test_ci_hash_changes_on_new_head_commit() -> None:
     """A push must start a new stuck episode even for an identical rollup.
 

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -403,12 +403,14 @@ def test_ci_failure_detail_includes_state_hash_token() -> None:
         text=True,
         check=True,
     ).stdout.strip()
+    old_pr = {**pr, "statusCheckRollup": old_rollup}
     old_hash = subprocess.run(
         [
             "bash",
             "-c",
-            f"printf %s {json.dumps(old_key)!r} | {_sha256_cmd()} | cut -d' ' -f1",
+            f"jq -r '{_extract_hash_program()}' | {_sha256_cmd()} | cut -d' ' -f1",
         ],
+        input=json.dumps(old_pr),
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
## Problem

`activity-gate.sh` correctly detects CI state changes with `ci_hash`, but PM dispatch dedup only sees grouped `types` + `detail` atoms. When `detail` was the constant `CI failing`, a PR could move to a different red check-set on the same head, pass the gate's hash test, then get swallowed downstream as `event_unchanged` / `event_subsumed`.

## Changes

- Include `state_hash=<ci_hash>` in `ci_failure` details.
- Include the same token in stuck-inflight CI details.
- Add a regression test proving the emitted detail carries the current CI state hash, not a stale one.

## Verification

- `pytest -q tests/test_activity_gate_stuck_ci.py`

Bob-local task: `pm-hold-fingerprint-misses-post-launch-check-flip`
