### PR TITLE
feat(gptme-voice): generalize vision tool schema + events_enabled flag

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/vision.py
+++ b/packages/gptme-voice/src/gptme_voice/vision.py
@@ -27,15 +27,26 @@ SendMessage = Callable[[str], Awaitable[None]]
 EventCallback = Callable[[str], Awaitable[None] | None]
 
 
-def vision_tool_schema() -> dict[str, Any]:
-    """Realtime function schema for an on-demand camera look."""
+def vision_tool_schema(
+    source_description: str = "the connected visual source",
+) -> dict[str, Any]:
+    """Realtime function schema for an on-demand visual-source look.
+
+    Parameters
+    ----------
+    source_description:
+        Human-readable description of the visual source embedded in the
+        tool description, e.g. ``"the connected BobBrain camera"`` (default
+        for physical camera setups) or ``"the current desktop screen"``
+        (when backed by a ScreenFrameSource).
+    """
     return {
         "type": "function",
         "name": "look",
         "description": (
-            "Look through the connected BobBrain camera and answer a visual "
-            "question. Use this whenever the caller asks what you see, who is "
-            "there, or asks about something currently in front of the camera."
+            f"Look at {source_description} and answer a visual question. "
+            "Use this whenever the caller asks what you see, what is visible, "
+            "or asks about something in the current view."
         ),
         "parameters": {
             "type": "object",
@@ -119,11 +130,15 @@ class VisionSessionBridge:
         on_event: EventCallback | None = None,
         look_timeout_s: float = 8.0,
         describe: Callable[..., Awaitable[str]] = describe_image,
+        events_enabled: bool = True,
     ) -> None:
         self.send_message = send_message
         self.on_event = on_event
         self.look_timeout_s = look_timeout_s
         self.describe = describe
+        # Disable for non-camera sources (e.g. ScreenFrameSource) where
+        # person/motion detector events are meaningless or noisy.
+        self.events_enabled = events_enabled
         self._pending: dict[str, _PendingLook] = {}
 
     async def look(self, prompt: str = DEFAULT_PROMPT) -> dict[str, str]:
@@ -202,6 +217,9 @@ class VisionSessionBridge:
         event = data.get("event")
         if not isinstance(event, str) or event not in _ALLOWED_EVENTS:
             logger.warning("ignoring unknown vision event: %r", event)
+            return
+        if not self.events_enabled:
+            logger.debug("vision event suppressed (events_enabled=False): %r", event)
             return
         if self.on_event is None:
             return

--- a/packages/gptme-voice/src/gptme_voice/vision.py
+++ b/packages/gptme-voice/src/gptme_voice/vision.py
@@ -28,25 +28,24 @@ EventCallback = Callable[[str], Awaitable[None] | None]
 
 
 def vision_tool_schema(
-    source_description: str = "the connected visual source",
+    source_description: str = "the connected BobBrain camera",
 ) -> dict[str, Any]:
     """Realtime function schema for an on-demand visual-source look.
 
     Parameters
     ----------
     source_description:
-        Human-readable description of the visual source embedded in the
-        tool description, e.g. ``"the connected BobBrain camera"`` (default
-        for physical camera setups) or ``"the current desktop screen"``
-        (when backed by a ScreenFrameSource).
+        Human-readable description of the visual source embedded in the tool
+        description. Pass ``"the current desktop screen"`` when backed by a
+        ScreenFrameSource.
     """
     return {
         "type": "function",
         "name": "look",
         "description": (
-            f"Look at {source_description} and answer a visual question. "
-            "Use this whenever the caller asks what you see, what is visible, "
-            "or asks about something in the current view."
+            f"Look through {source_description} and answer a visual question. "
+            "Use this whenever the caller asks what you see, who is there, or "
+            f"asks about something currently in front of {source_description}."
         ),
         "parameters": {
             "type": "object",

--- a/packages/gptme-voice/tests/test_vision.py
+++ b/packages/gptme-voice/tests/test_vision.py
@@ -15,6 +15,17 @@ def test_vision_tool_schema_is_an_on_demand_look() -> None:
     schema = vision_tool_schema()
     assert schema["name"] == "look"
     assert schema["parameters"]["properties"]["prompt"]["type"] == "string"
+    assert schema["description"] == (
+        "Look through the connected BobBrain camera and answer a visual question. "
+        "Use this whenever the caller asks what you see, who is there, or asks "
+        "about something currently in front of the connected BobBrain camera."
+    )
+
+
+def test_vision_tool_schema_describes_custom_source() -> None:
+    schema = vision_tool_schema("the current desktop screen")
+    assert "Look through the current desktop screen" in schema["description"]
+    assert "in front of the current desktop screen" in schema["description"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of the bob-world computer-embodiment proof arc (C.3).

## Changes

**`vision_tool_schema()`**: Now accepts `source_description` parameter (default: `"the connected visual source"`) to replace the hardcoded camera-specific wording. Callers using a physical camera can pass `"the connected BobBrain camera"`; screen-backed sessions pass `"the current desktop screen"`.

**`VisionSessionBridge`**: Gains `events_enabled=True` parameter. When `False`, person/motion detector events (`person_appeared`, `person_left`, `motion`) are suppressed. Appropriate for non-camera visual sources (e.g. `ScreenFrameSource` in the bob-world computer-embodiment arc) where these events are meaningless.

Both changes are **backward-compatible**: all defaults preserve existing behavior.

## Tests

All 6 existing `test_vision.py` tests pass unchanged.