### PR TITLE
feat(gptme-sessions): add cost attribution API

### DIFF
--- a/packages/gptme-sessions/pyproject.toml
+++ b/packages/gptme-sessions/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.0",
+    "PyYAML>=6.0",
     "tomli>=1.0; python_version < '3.11'",
 ]
 
@@ -37,6 +38,7 @@ cost = [
 dev = [
     "mypy>=1.0.0",
     "pytest>=7.0",
+    "types-PyYAML>=6.0",
 ]
 test = [
     "pytest>=7.0",

--- a/packages/gptme-sessions/src/gptme_sessions/__init__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__init__.py
@@ -47,6 +47,19 @@ from .signals import (
     grade_signals,
     is_productive,
 )
+from .attribution import (
+    CostAttributionReport,
+    LoadedRecords,
+    SourceSessionRecord,
+    TenantConfig,
+    TenantRule,
+    build_attribution_record,
+    build_report,
+    load_session_records,
+    load_tenant_config,
+    render_jsonl as render_cost_attribution_jsonl,
+    render_markdown as render_cost_attribution_markdown,
+)
 from .classification import (
     Category,
     ClassificationResult,
@@ -84,6 +97,17 @@ from .transcript import (
 )
 
 __all__ = [
+    "CostAttributionReport",
+    "LoadedRecords",
+    "SourceSessionRecord",
+    "TenantConfig",
+    "TenantRule",
+    "build_attribution_record",
+    "build_report",
+    "load_session_records",
+    "load_tenant_config",
+    "render_cost_attribution_jsonl",
+    "render_cost_attribution_markdown",
     "Category",
     "ClassificationResult",
     "DEFAULT_CATEGORIES",

--- a/packages/gptme-sessions/src/gptme_sessions/attribution.py
+++ b/packages/gptme-sessions/src/gptme_sessions/attribution.py
@@ -1,0 +1,679 @@
+"""Coverage-aware cost attribution over canonical gptme session records."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Literal, Mapping, Sequence, cast
+
+import yaml
+from .cost import estimate_record_cost
+from .record import SessionRecord
+
+
+DEFAULT_RECORDS = Path("state/sessions/session-records.jsonl")
+DEFAULT_TENANT_MAP = Path("config/cost-attribution-tenants.yaml")
+
+SCHEMA_VERSION = 1
+EXTRACTOR_VERSION = "agent-cost-attribution-v1"
+PRICING_SOURCE = "gptme_sessions.cost.estimate_record_cost"
+
+CostBasis = Literal[
+    "metered_cash",
+    "metered_equivalent",
+    "subscription_equivalent",
+    "unknown",
+]
+PricingStatus = Literal["reported", "estimated", "unknown"]
+
+TENANT_FIELDS = ("org_id", "user_id", "project_id", "environment")
+BILLING_STATUSES = {"billable", "non_billable", "promotional", "unknown"}
+
+
+@dataclass(frozen=True)
+class SourceSessionRecord:
+    record: SessionRecord
+
+
+@dataclass(frozen=True)
+class LoadedRecords:
+    records: list[SourceSessionRecord]
+    malformed_rows: int
+
+
+@dataclass(frozen=True)
+class TenantRule:
+    name: str
+    match: dict[str, Any]
+    tenant: dict[str, Any]
+    billing: dict[str, Any]
+    work: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TenantConfig:
+    defaults: dict[str, dict[str, Any]]
+    rules: list[TenantRule]
+
+
+@dataclass(frozen=True)
+class CostAttributionReport:
+    records: list[dict[str, Any]]
+    malformed_rows: int
+    source_path: Path
+    tenant_map_path: Path | None
+    since: date | None
+    until: date | None
+
+    @property
+    def coverage(self) -> dict[str, int]:
+        total = len(self.records)
+        priced = sum(1 for row in self.records if row["cost"]["pricing_status"] != "unknown")
+        tenant_known = sum(1 for row in self.records if tenant_is_known(row))
+        billable_known = sum(
+            1 for row in self.records if row["billing"]["billable_status"] != "unknown"
+        )
+        return {
+            "records": total,
+            "malformed_rows": self.malformed_rows,
+            "priced": priced,
+            "unpriced": total - priced,
+            "tenant_known": tenant_known,
+            "tenant_unknown": total - tenant_known,
+            "billable_known": billable_known,
+            "billable_unknown": total - billable_known,
+        }
+
+
+def _parse_record_datetime(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _record_date(record: SessionRecord) -> date | None:
+    parsed = _parse_record_datetime(record.timestamp or record.start_time)
+    return parsed.date() if parsed is not None else None
+
+
+def _in_date_window(
+    record: SessionRecord,
+    *,
+    since: date | None,
+    until: date | None,
+) -> bool:
+    if since is None and until is None:
+        return True
+    observed = _record_date(record)
+    if observed is None:
+        return False
+    if since is not None and observed < since:
+        return False
+    if until is not None and observed > until:
+        return False
+    return True
+
+
+def _load_jsonl_payloads(path: Path) -> tuple[list[dict[str, Any]], int]:
+    payloads: list[dict[str, Any]] = []
+    malformed_rows = 0
+    with path.open(encoding="utf-8") as handle:
+        for raw in handle:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                malformed_rows += 1
+                continue
+            if isinstance(payload, dict):
+                payloads.append(payload)
+            else:
+                malformed_rows += 1
+    return payloads, malformed_rows
+
+
+def load_session_records(
+    path: Path,
+    *,
+    since: date | None = None,
+    until: date | None = None,
+) -> LoadedRecords:
+    """Load SessionRecord objects from JSONL and count skipped malformed rows."""
+    records: list[SourceSessionRecord] = []
+    if not path.exists():
+        return LoadedRecords(records=[], malformed_rows=0)
+
+    payloads, malformed_rows = _load_jsonl_payloads(path)
+    for payload in payloads:
+        try:
+            record = SessionRecord.from_dict(payload)
+        except (TypeError, AttributeError, ValueError):
+            malformed_rows += 1
+            continue
+        if _in_date_window(record, since=since, until=until):
+            records.append(SourceSessionRecord(record=record))
+    return LoadedRecords(records=records, malformed_rows=malformed_rows)
+
+
+def load_tenant_config(path: Path | None) -> TenantConfig:
+    """Load deterministic tenant/project attribution rules from YAML."""
+    if path is None or not path.exists():
+        return TenantConfig(defaults={}, rules=[])
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("tenant map root must be a mapping")
+
+    defaults = _section_groups(cast("Mapping[str, Any]", raw.get("defaults") or {}))
+    rules: list[TenantRule] = []
+    raw_mappings = raw.get("mappings") or []
+    if not isinstance(raw_mappings, list):
+        raise ValueError("tenant map 'mappings' must be a list")
+    for index, item in enumerate(raw_mappings, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"tenant map rule {index} must be a mapping")
+        match = item.get("match") or {}
+        if not isinstance(match, dict):
+            raise ValueError(f"tenant map rule {index} match must be a mapping")
+        rules.append(
+            TenantRule(
+                name=str(item.get("name") or f"rule-{index}"),
+                match=dict(match),
+                tenant=_section_dict(item.get("tenant")),
+                billing=_section_dict(item.get("billing")),
+                work=_section_dict(item.get("work")),
+            )
+        )
+    return TenantConfig(defaults=defaults, rules=rules)
+
+
+def _section_groups(raw: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    groups: dict[str, dict[str, Any]] = {}
+    for name in ("tenant", "billing", "work"):
+        groups[name] = _section_dict(raw.get(name))
+    return groups
+
+
+def _section_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _text_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _nested_get(payload: Mapping[str, Any], dotted_key: str) -> Any:
+    current: Any = payload
+    for part in dotted_key.split("."):
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _task_id(record: SessionRecord, payload: Mapping[str, Any]) -> str | None:
+    intent = record.cascade_intent
+    if isinstance(intent, Mapping):
+        task_id = _text_or_none(intent.get("task_id"))
+        if task_id:
+            return task_id
+    return _text_or_none(payload.get("task_id"))
+
+
+def _match_lookup(
+    record: SessionRecord,
+    payload: Mapping[str, Any],
+    key: str,
+) -> Any:
+    if key == "model_normalized":
+        return record.model_normalized
+    if key == "task_id":
+        return _task_id(record, payload)
+    if key == "environment":
+        return _nested_get(payload, "tenant.environment") or payload.get("environment")
+    return _nested_get(payload, key)
+
+
+def _match_value(observed: Any, expected: Any) -> bool:
+    if isinstance(expected, list):
+        return any(_match_value(observed, item) for item in expected)
+    if expected == "*":
+        return observed not in (None, "")
+    if isinstance(expected, str):
+        expected = os.path.expandvars(expected)
+    return str(observed) == str(expected)
+
+
+def _rule_matches(
+    rule: TenantRule,
+    record: SessionRecord,
+    payload: Mapping[str, Any],
+) -> bool:
+    return all(
+        _match_value(_match_lookup(record, payload, key), expected)
+        for key, expected in rule.match.items()
+    )
+
+
+def _merge_section(
+    current: dict[str, Any],
+    incoming: Mapping[str, Any],
+    allowed_fields: Sequence[str],
+) -> None:
+    for field in allowed_fields:
+        value = incoming.get(field)
+        if _text_or_none(value) is not None:
+            current[field] = value
+
+
+def _explicit_tenant(payload: Mapping[str, Any]) -> dict[str, Any]:
+    tenant = _section_dict(payload.get("tenant"))
+    for field in TENANT_FIELDS:
+        for key in (f"tenant_{field}", field):
+            value = payload.get(key)
+            if _text_or_none(value) is not None:
+                tenant[field] = value
+                break
+    return tenant
+
+
+def _explicit_billing(payload: Mapping[str, Any]) -> dict[str, Any]:
+    billing = _section_dict(payload.get("billing"))
+    for field in ("billable_status", "policy_id", "line_item_type", "invoice_group"):
+        for key in (f"billing_{field}", field):
+            value = payload.get(key)
+            if _text_or_none(value) is not None:
+                billing[field] = value
+                break
+    return billing
+
+
+def _explicit_work(payload: Mapping[str, Any]) -> dict[str, Any]:
+    work = _section_dict(payload.get("work"))
+    for field in ("feature",):
+        for key in (f"work_{field}", field):
+            value = payload.get(key)
+            if _text_or_none(value) is not None:
+                work[field] = value
+                break
+    return work
+
+
+def _invoice_group(record: SessionRecord) -> str:
+    observed = _record_date(record)
+    if observed is None:
+        return "unknown"
+    return f"{observed.year:04d}-{observed.month:02d}"
+
+
+def resolve_attribution(
+    record: SessionRecord,
+    config: TenantConfig,
+) -> tuple[dict[str, str], dict[str, str | None], dict[str, str]]:
+    """Resolve tenant, billing, and work metadata.
+
+    Precedence is defaults -> first matching rule -> explicit session metadata.
+    The explicit-session layer is last because product telemetry should beat
+    Bob-local fallback configuration.
+    """
+    payload = cast("dict[str, Any]", record.to_dict())
+    tenant: dict[str, Any] = {}
+    billing: dict[str, Any] = {}
+    work: dict[str, Any] = {}
+
+    _merge_section(tenant, config.defaults.get("tenant", {}), TENANT_FIELDS)
+    _merge_section(
+        billing,
+        config.defaults.get("billing", {}),
+        ("billable_status", "policy_id", "line_item_type", "invoice_group"),
+    )
+    _merge_section(work, config.defaults.get("work", {}), ("feature",))
+
+    for rule in config.rules:
+        if _rule_matches(rule, record, payload):
+            _merge_section(tenant, rule.tenant, TENANT_FIELDS)
+            _merge_section(
+                billing,
+                rule.billing,
+                ("billable_status", "policy_id", "line_item_type", "invoice_group"),
+            )
+            _merge_section(work, rule.work, ("feature",))
+            break
+
+    _merge_section(tenant, _explicit_tenant(payload), TENANT_FIELDS)
+    _merge_section(
+        billing,
+        _explicit_billing(payload),
+        ("billable_status", "policy_id", "line_item_type", "invoice_group"),
+    )
+    _merge_section(work, _explicit_work(payload), ("feature",))
+
+    billable_status = _text_or_none(billing.get("billable_status")) or "unknown"
+    if billable_status not in BILLING_STATUSES:
+        billable_status = "unknown"
+
+    return (
+        {field: _text_or_none(tenant.get(field)) or "unknown" for field in TENANT_FIELDS},
+        {
+            "billable_status": billable_status,
+            "policy_id": _text_or_none(billing.get("policy_id")),
+            "line_item_type": _text_or_none(billing.get("line_item_type")) or "llm_usage",
+            "invoice_group": _text_or_none(billing.get("invoice_group")) or _invoice_group(record),
+        },
+        {"feature": _text_or_none(work.get("feature")) or "unknown"},
+    )
+
+
+def _has_usage(record: SessionRecord) -> bool:
+    return any(
+        value is not None
+        for value in (
+            record.input_tokens,
+            record.output_tokens,
+            record.cache_creation_tokens,
+            record.cache_read_tokens,
+            record.token_count,
+        )
+    )
+
+
+def _is_subscription_equivalent(record: SessionRecord) -> bool:
+    try:
+        from gptme_usage.harness_models import (
+            SUBSCRIPTION_BACKED_MODELS,
+            load_quota_config,
+            pricing_key_for_model,
+        )
+    except ImportError:
+        model = record.model or ""
+        provider = record.provider or ""
+        harness = record.harness or ""
+        return harness in {"claude-code", "codex", "copilot-cli", "grok-build"} or (
+            "subscription" in model or "subscription" in provider
+        )
+
+    harness = record.harness or ""
+    model = record.model or ""
+    provider = record.provider or ""
+    config = load_quota_config()
+    candidates = {
+        pricing_key_for_model(harness, model, config),
+        (harness, model.rsplit("/", 1)[-1]),
+        (harness, model),
+    }
+    return bool(
+        candidates & SUBSCRIPTION_BACKED_MODELS
+        or "subscription" in model
+        or "subscription" in provider
+    )
+
+
+def _cost_basis(record: SessionRecord, pricing_status: PricingStatus) -> CostBasis:
+    if pricing_status == "unknown":
+        return "unknown"
+    if _is_subscription_equivalent(record):
+        return "subscription_equivalent"
+    if record.cost_usd is not None:
+        return "metered_cash"
+    return "metered_equivalent"
+
+
+def _decimal_text(value: float | Decimal) -> str:
+    return format(Decimal(str(value)), "f")
+
+
+def _display_path(path: Path) -> str:
+    return str(path)
+
+
+def build_attribution_record(
+    source: SourceSessionRecord | SessionRecord,
+    *,
+    source_path: Path | None = None,
+    config: TenantConfig | None = None,
+) -> dict[str, Any]:
+    record = source.record if isinstance(source, SourceSessionRecord) else source
+    source_path = source_path or DEFAULT_RECORDS
+    config = config or TenantConfig(defaults={}, rules=[])
+    payload = cast("dict[str, Any]", record.to_dict())
+    tenant, billing, work_overrides = resolve_attribution(record, config)
+
+    amount = estimate_record_cost(record)
+    pricing_status: PricingStatus
+    if amount is None:
+        pricing_status = "unknown"
+    elif record.cost_usd is not None:
+        pricing_status = "reported"
+    else:
+        pricing_status = "estimated"
+    basis = _cost_basis(record, pricing_status)
+
+    missing_fields: list[str] = []
+    if amount is None:
+        missing_fields.append("cost.amount_usd")
+        if not _has_usage(record):
+            missing_fields.append("usage.token_data")
+    if tenant["org_id"] == "unknown":
+        missing_fields.append("tenant.org_id")
+    if tenant["project_id"] == "unknown":
+        missing_fields.append("tenant.project_id")
+    if billing["billable_status"] == "unknown":
+        missing_fields.append("billing.billable_status")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "session_id": record.session_id,
+        "source": {
+            "record_path": _display_path(source_path),
+            "record_timestamp": record.timestamp,
+            "extractor_version": EXTRACTOR_VERSION,
+        },
+        "tenant": tenant,
+        "work": {
+            "session_id": record.session_id,
+            "parent_session_id": record.parent_session_id,
+            "task_id": _task_id(record, payload),
+            "category": record.category
+            or record.recommended_category
+            or record.run_type
+            or "unknown",
+            "feature": work_overrides["feature"],
+            "intent_source": _text_or_none(payload.get("intent_source"))
+            or record.trigger
+            or record.run_type
+            or "unknown",
+        },
+        "usage": {
+            "harness": record.harness or "unknown",
+            "provider": record.provider or "unknown",
+            "model": record.model_normalized or record.model or "unknown",
+            "model_raw": record.model or "unknown",
+            "input_tokens": record.input_tokens,
+            "output_tokens": record.output_tokens,
+            "cache_creation_tokens": record.cache_creation_tokens,
+            "cache_read_tokens": record.cache_read_tokens,
+            "token_count": record.token_count,
+            "duration_seconds": record.duration_seconds,
+        },
+        "cost": {
+            "amount_usd": _decimal_text(amount) if amount is not None else None,
+            "basis": basis,
+            "pricing_status": pricing_status,
+            "pricing_source": PRICING_SOURCE,
+        },
+        "billing": billing,
+        "coverage": {
+            "status": "complete" if not missing_fields else "partial",
+            "missing_fields": missing_fields,
+        },
+    }
+
+
+def build_report(
+    *,
+    records_path: Path = DEFAULT_RECORDS,
+    tenant_map_path: Path | None = None,
+    since: date | None = None,
+    until: date | None = None,
+) -> CostAttributionReport:
+    tenant_map_path = DEFAULT_TENANT_MAP if tenant_map_path is None else tenant_map_path
+    config = load_tenant_config(tenant_map_path)
+    loaded = load_session_records(records_path, since=since, until=until)
+    records = [
+        build_attribution_record(source, source_path=records_path, config=config)
+        for source in loaded.records
+    ]
+    return CostAttributionReport(
+        records=records,
+        malformed_rows=loaded.malformed_rows,
+        source_path=records_path,
+        tenant_map_path=tenant_map_path if tenant_map_path and tenant_map_path.exists() else None,
+        since=since,
+        until=until,
+    )
+
+
+def tenant_is_known(row: Mapping[str, Any]) -> bool:
+    tenant = cast("Mapping[str, Any]", row["tenant"])
+    return tenant.get("org_id") != "unknown" and tenant.get("project_id") != "unknown"
+
+
+def _amount(row: Mapping[str, Any]) -> Decimal:
+    cost = cast("Mapping[str, Any]", row["cost"])
+    raw = cost.get("amount_usd")
+    return Decimal(str(raw)) if raw is not None else Decimal("0")
+
+
+def _sum_amount(rows: Sequence[Mapping[str, Any]]) -> Decimal:
+    total = Decimal("0")
+    for row in rows:
+        total += _amount(row)
+    return total
+
+
+def _money(value: Decimal) -> str:
+    return f"${value:.4f}"
+
+
+def _group_value(row: Mapping[str, Any], dotted_key: str) -> str:
+    value = _nested_get(row, dotted_key)
+    return _text_or_none(value) or "unknown"
+
+
+def _group_rows(
+    records: Sequence[Mapping[str, Any]],
+    dotted_key: str,
+) -> list[tuple[str, int, int, Decimal]]:
+    groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in records:
+        groups[_group_value(row, dotted_key)].append(row)
+    result: list[tuple[str, int, int, Decimal]] = []
+    for label, rows in groups.items():
+        priced = sum(1 for row in rows if row["cost"]["pricing_status"] != "unknown")
+        result.append((label, len(rows), priced, _sum_amount(rows)))
+    return sorted(result, key=lambda item: (-item[3], item[0]))
+
+
+def _render_group_table(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    title: str,
+    dotted_key: str,
+) -> list[str]:
+    lines = [
+        f"## {title}",
+        "",
+        "| Key | Sessions | Priced | Amount |",
+        "|---|---:|---:|---:|",
+    ]
+    rows = _group_rows(records, dotted_key)
+    if not rows:
+        lines.append("| none | 0 | 0 | $0.0000 |")
+        return lines
+    for label, count, priced, total in rows:
+        lines.append(f"| {label} | {count} | {priced} | {_money(total)} |")
+    return lines
+
+
+def render_markdown(report: CostAttributionReport) -> str:
+    coverage = report.coverage
+    total = _sum_amount(report.records)
+    by_basis = {
+        basis: total for basis, _count, _priced, total in _group_rows(report.records, "cost.basis")
+    }
+    lines = [
+        "# Cost Attribution Report",
+        "",
+        f"Source: `{_display_path(report.source_path)}`",
+        f"Tenant map: `{_display_path(report.tenant_map_path)}`"
+        if report.tenant_map_path
+        else "Tenant map: none",
+    ]
+    if report.since or report.until:
+        lines.append(
+            "Window: "
+            f"{report.since.isoformat() if report.since else 'beginning'} to "
+            f"{report.until.isoformat() if report.until else 'end'}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Coverage",
+            "",
+            f"- Records: {coverage['records']} accepted, {coverage['malformed_rows']} malformed skipped",
+            f"- Pricing: {coverage['priced']} priced, {coverage['unpriced']} unknown",
+            f"- Tenant: {coverage['tenant_known']} known, {coverage['tenant_unknown']} unknown",
+            f"- Billable policy: {coverage['billable_known']} known, {coverage['billable_unknown']} unknown",
+            "",
+            "## Totals",
+            "",
+            f"- Total USD-equivalent: {_money(total)}",
+            f"- Metered cash: {_money(by_basis.get('metered_cash', Decimal('0')))}",
+            f"- Metered equivalent: {_money(by_basis.get('metered_equivalent', Decimal('0')))}",
+            f"- Subscription equivalent: {_money(by_basis.get('subscription_equivalent', Decimal('0')))}",
+            "- Subscription equivalent is opportunity cost, not cash spend.",
+            "",
+        ]
+    )
+
+    for title, key in (
+        ("By Tenant", "tenant.org_id"),
+        ("By Project", "tenant.project_id"),
+        ("By Category", "work.category"),
+        ("By Model", "usage.model"),
+        ("By Cost Basis", "cost.basis"),
+    ):
+        lines.extend(_render_group_table(report.records, title=title, dotted_key=key))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_jsonl(records: Sequence[Mapping[str, Any]]) -> str:
+    return "\n".join(json.dumps(record, sort_keys=True) for record in records) + (
+        "\n" if records else ""
+    )
+
+
+def write_jsonl(path: Path, records: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_jsonl(records), encoding="utf-8")
+
+
+def write_markdown(path: Path, report: CostAttributionReport) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_markdown(report), encoding="utf-8")

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -28,6 +28,7 @@ from .discovery import (
     session_date_from_path,
     session_datetime_from_path,
 )
+from . import attribution
 from .post_session import VALID_AB_GROUPS, VALID_CONTEXT_TIERS, post_session
 from .replay import (
     ToolResultsMode,
@@ -3671,6 +3672,95 @@ def blame(
         raise click.ClickException(str(exc)) from exc
 
     click.echo(render_json(result) if as_json else render_text(result))
+
+
+def _parse_iso_date(_ctx: click.Context, _param: click.Parameter, value: str | None) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise click.BadParameter("expected YYYY-MM-DD") from exc
+
+
+@cli.command("cost-attribution")
+@click.option(
+    "--records",
+    "records_path",
+    type=click.Path(path_type=Path),  # type: ignore[type-var]
+    default=attribution.DEFAULT_RECORDS,
+    show_default=True,
+    help="session-records JSONL path.",
+)
+@click.option(
+    "--tenant-map",
+    "tenant_map_path",
+    type=click.Path(path_type=Path),  # type: ignore[type-var]
+    default=attribution.DEFAULT_TENANT_MAP,
+    show_default=True,
+    help="tenant/project attribution rules YAML path.",
+)
+@click.option("--since", callback=_parse_iso_date, help="Inclusive YYYY-MM-DD date window start.")
+@click.option("--until", callback=_parse_iso_date, help="Inclusive YYYY-MM-DD date window end.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["markdown", "jsonl"]),
+    default="markdown",
+    show_default=True,
+    help="Stdout format.",
+)
+@click.option(
+    "--output-jsonl",
+    type=click.Path(path_type=Path),  # type: ignore[type-var]
+    help="Write derived attribution records as JSONL.",
+)
+@click.option(
+    "--output-markdown",
+    type=click.Path(path_type=Path),  # type: ignore[type-var]
+    help="Write Markdown summary report.",
+)
+def cost_attribution(
+    records_path: Path,
+    tenant_map_path: Path,
+    since: date | None,
+    until: date | None,
+    output_format: str,
+    output_jsonl: Path | None,
+    output_markdown: Path | None,
+) -> None:
+    """Derive tenant/billing-aware cost attribution records.
+
+    This is the importable package CLI for the same coverage-aware attribution
+    primitive Bob uses in local cost-governance reports. Unknown tenant,
+    pricing, and billable-policy coverage remains explicit in the output.
+    """
+    if since and until and since > until:
+        raise click.UsageError("--since must be on or before --until")
+    try:
+        report = attribution.build_report(
+            records_path=records_path,
+            tenant_map_path=tenant_map_path,
+            since=since,
+            until=until,
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    if report.malformed_rows:
+        click.echo(
+            f"warning: skipped {report.malformed_rows} malformed JSONL row(s)",
+            err=True,
+        )
+    if output_jsonl:
+        attribution.write_jsonl(output_jsonl, report.records)
+    if output_markdown:
+        attribution.write_markdown(output_markdown, report)
+
+    if output_format == "jsonl":
+        click.echo(attribution.render_jsonl(report.records), nl=False)
+    else:
+        click.echo(attribution.render_markdown(report), nl=False)
 
 
 @cli.command("stamp-attempt-kind")

--- a/packages/gptme-sessions/tests/test_attribution.py
+++ b/packages/gptme-sessions/tests/test_attribution.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gptme_sessions import SessionRecord
+from gptme_sessions import attribution
+
+
+def write_jsonl(path: Path, *rows: object) -> None:
+    path.write_text(
+        "\n".join(json.dumps(row) if isinstance(row, dict) else str(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_load_session_records_counts_malformed_jsonl(tmp_path: Path) -> None:
+    records = tmp_path / "session-records.jsonl"
+    write_jsonl(
+        records,
+        {
+            "session_id": "good",
+            "timestamp": "2026-09-05T10:00:00+00:00",
+            "harness": "gptme",
+            "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+            "input_tokens": 100,
+            "output_tokens": 20,
+        },
+        "{not-json",
+    )
+
+    loaded = attribution.load_session_records(records)
+
+    assert loaded.malformed_rows == 1
+    assert [source.record.session_id for source in loaded.records] == ["good"]
+
+
+def test_missing_token_and_cost_data_is_unknown_not_billable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = tmp_path / "session-records.jsonl"
+    write_jsonl(
+        records,
+        {
+            "session_id": "missing-cost",
+            "timestamp": "2026-09-05T11:00:00+00:00",
+            "harness": "gptme",
+            "model": "unknown-model",
+        },
+    )
+    monkeypatch.setattr(attribution, "estimate_record_cost", lambda _record: None)
+
+    report = attribution.build_report(records_path=records, tenant_map_path=None)
+
+    row = report.records[0]
+    assert row["cost"] == {
+        "amount_usd": None,
+        "basis": "unknown",
+        "pricing_status": "unknown",
+        "pricing_source": "gptme_sessions.cost.estimate_record_cost",
+    }
+    assert row["billing"]["billable_status"] == "unknown"
+    assert row["coverage"] == {
+        "status": "partial",
+        "missing_fields": [
+            "cost.amount_usd",
+            "usage.token_data",
+            "tenant.org_id",
+            "tenant.project_id",
+            "billing.billable_status",
+        ],
+    }
+    assert report.coverage["unpriced"] == 1
+    assert report.coverage["billable_unknown"] == 1
+
+
+def test_subscription_backed_cost_is_labeled_subscription_equivalent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = tmp_path / "session-records.jsonl"
+    write_jsonl(
+        records,
+        {
+            "session_id": "codex-sub",
+            "timestamp": "2026-09-05T12:00:00+00:00",
+            "harness": "codex",
+            "model": "gpt-5.5",
+            "input_tokens": 1_000,
+            "output_tokens": 100,
+        },
+    )
+    monkeypatch.setattr(attribution, "estimate_record_cost", lambda _record: 1.25)
+
+    report = attribution.build_report(records_path=records, tenant_map_path=None)
+
+    assert report.records[0]["cost"]["amount_usd"] == "1.25"
+    assert report.records[0]["cost"]["pricing_status"] == "estimated"
+    assert report.records[0]["cost"]["basis"] == "subscription_equivalent"
+
+
+def test_tenant_map_resolution_and_explicit_metadata_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_path = str(tmp_path / "customer-project")
+    records = tmp_path / "session-records.jsonl"
+    write_jsonl(
+        records,
+        {
+            "session_id": "mapped",
+            "timestamp": "2026-09-05T13:00:00+00:00",
+            "project": project_path,
+            "harness": "gptme",
+            "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+            "provider": "openrouter",
+            "category": "code",
+            "input_tokens": 1_000,
+            "output_tokens": 100,
+            "tenant": {"org_id": "explicit-org"},
+        },
+    )
+    tenant_map = tmp_path / "tenants.yaml"
+    tenant_map.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "defaults": {
+                    "billing": {
+                        "billable_status": "non_billable",
+                        "policy_id": "default-policy",
+                    }
+                },
+                "mappings": [
+                    {
+                        "name": "customer",
+                        "match": {"project": project_path, "harness": "gptme"},
+                        "tenant": {
+                            "org_id": "mapped-org",
+                            "user_id": "erik",
+                            "project_id": "gptme-ai",
+                            "environment": "prod",
+                        },
+                        "billing": {
+                            "billable_status": "promotional",
+                            "policy_id": "promo-v1",
+                        },
+                        "work": {"feature": "managed-agent-session"},
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(attribution, "estimate_record_cost", lambda _record: 2.5)
+
+    report = attribution.build_report(records_path=records, tenant_map_path=tenant_map)
+
+    row = report.records[0]
+    assert row["tenant"] == {
+        "org_id": "explicit-org",
+        "user_id": "erik",
+        "project_id": "gptme-ai",
+        "environment": "prod",
+    }
+    assert row["billing"]["billable_status"] == "promotional"
+    assert row["billing"]["policy_id"] == "promo-v1"
+    assert row["billing"]["invoice_group"] == "2026-09"
+    assert row["work"]["feature"] == "managed-agent-session"
+    assert row["coverage"]["status"] == "complete"
+    assert report.coverage["tenant_known"] == 1
+    assert report.coverage["billable_known"] == 1
+
+
+def test_build_attribution_record_accepts_session_record_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    record = SessionRecord.from_dict(
+        {
+            "session_id": "direct",
+            "timestamp": "2026-09-05T14:00:00+00:00",
+            "harness": "gptme",
+            "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "tenant": {"org_id": "org", "project_id": "project"},
+            "billing": {"billable_status": "billable"},
+        }
+    )
+    monkeypatch.setattr(attribution, "estimate_record_cost", lambda _record: 0.5)
+
+    row = attribution.build_attribution_record(record)
+
+    assert row["session_id"] == "direct"
+    assert row["tenant"]["org_id"] == "org"
+    assert row["cost"]["amount_usd"] == "0.5"
+    assert row["coverage"]["status"] == "complete"
+
+
+def test_render_jsonl_and_markdown_exports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = tmp_path / "session-records.jsonl"
+    write_jsonl(
+        records,
+        {
+            "session_id": "exported",
+            "timestamp": "2026-09-05T14:00:00+00:00",
+            "harness": "gptme",
+            "model": "openrouter/deepseek/deepseek-v4-flash@deepseek",
+            "input_tokens": 1_000,
+            "output_tokens": 100,
+        },
+        "{bad",
+    )
+    monkeypatch.setattr(attribution, "estimate_record_cost", lambda _record: 0.75)
+
+    report = attribution.build_report(
+        records_path=records,
+        tenant_map_path=tmp_path / "missing.yaml",
+    )
+    jsonl_out = tmp_path / "derived.jsonl"
+    markdown_out = tmp_path / "summary.md"
+    attribution.write_jsonl(jsonl_out, report.records)
+    attribution.write_markdown(markdown_out, report)
+
+    exported = [json.loads(line) for line in jsonl_out.read_text().splitlines()]
+    assert exported[0]["session_id"] == "exported"
+    assert "# Cost Attribution Report" in attribution.render_markdown(report)
+    assert "Subscription equivalent is opportunity cost" in markdown_out.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -2451,6 +2451,7 @@ version = "0.1.0"
 source = { editable = "packages/gptme-sessions" }
 dependencies = [
     { name = "click" },
+    { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
@@ -2461,6 +2462,7 @@ cost = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "types-pyyaml" },
 ]
 test = [
     { name = "pytest" },
@@ -2473,7 +2475,9 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["cost", "dev", "test"]
 


### PR DESCRIPTION
## Summary
- add importable `gptme_sessions.attribution` API for tenant/billing-aware session cost attribution
- add `gptme-sessions cost-attribution` CLI with Markdown/JSONL output
- add fixture coverage for malformed rows, unknown coverage, tenant map precedence, subscription-equivalent labeling, direct `SessionRecord` attribution, and exports

## Verification
- `uv run --directory /tmp/worktrees/gptme-contrib-cost-c577 --package gptme-sessions pytest packages/gptme-sessions/tests/test_attribution.py -q`
- `uv run --directory /tmp/worktrees/gptme-contrib-cost-c577 --package gptme-sessions ruff check packages/gptme-sessions/src/gptme_sessions/attribution.py packages/gptme-sessions/src/gptme_sessions/cli.py packages/gptme-sessions/src/gptme_sessions/__init__.py packages/gptme-sessions/tests/test_attribution.py`
- `uv run --directory /tmp/worktrees/gptme-contrib-cost-c577 --package gptme-sessions --extra dev mypy packages/gptme-sessions/src/gptme_sessions/attribution.py`
- manual CLI smoke: `gptme-sessions cost-attribution --records <fixture> --tenant-map <missing> --format jsonl --output-markdown <report>`

Part of Bob task `gptme-sessions-cost-attribution-api`.
