### PR TITLE
fix(gptme-sessions): reject forbidden judge rationales

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -52,15 +52,17 @@ class JudgeMetadata(TypedDict):
 
 
 class JudgeVerdict(TypedDict, total=False):
-    # ``None`` when the judge returned a payload without a usable score.
-    # Never silently substituted with a neutral default — see
-    # ``_coerce_score`` and ``JUDGE_STATUS_NO_SCORE``.
+    # ``None`` when the judge returned a payload without a usable score, or
+    # when an otherwise parseable payload violated the judge contract. Never
+    # silently substituted with a neutral default — see ``_coerce_score``,
+    # ``JUDGE_STATUS_NO_SCORE``, and ``JUDGE_STATUS_COMPLIANCE_FAILURE``.
     score: float | None
     judge_status: str
     reason: str
     model: str
     alignment_score: float | None
     pivot_verdict: str | None
+    raw_response: str
     meta: JudgeMetadata
 
 
@@ -187,6 +189,7 @@ that ship a durable, high-impact deliverable.
 
 ## Forbidden Constructions
 Do NOT invoke any of the following as a penalty rationale:
+- "priority #6", "goal #6", "lowest priority"
 - "low priority", "Tier 3", "Tier 5", "not a top goal"
 - "misaligned with top goals" or "misaligned with top-priority"
 - "not revenue-generating" or "not revenue work"
@@ -495,6 +498,72 @@ VALID_ALIGNMENT_VALUES = frozenset({"on_track", "partial", "pivot", "off_target"
 
 JUDGE_STATUS_OK = "ok"
 JUDGE_STATUS_NO_SCORE = "no_score"
+JUDGE_STATUS_COMPLIANCE_FAILURE = "compliance_failure"
+
+FORBIDDEN_RATIONALE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bpriority\s*#?\s*6\b", re.IGNORECASE),
+    re.compile(r"\bgoal\s*#?\s*6\b", re.IGNORECASE),
+    re.compile(r"\blowest\s+priority\b", re.IGNORECASE),
+    re.compile(r"\blow\s+priority\b", re.IGNORECASE),
+    re.compile(r"\btier\s+[35]\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+(?:a\s+)?top(?:-priority)?\s+goal\b", re.IGNORECASE),
+    re.compile(r"\bmisaligned\s+with\s+top(?:-priority)?\s+goals?\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+revenue(?:-generating|\s+work)\b", re.IGNORECASE),
+    re.compile(r"\bbelow\s+the\s+top\s+revenue-generating\s+goal\b", re.IGNORECASE),
+    re.compile(r"\bfallback\s+tier\b", re.IGNORECASE),
+    re.compile(r"\blower-tier\s+work\b", re.IGNORECASE),
+)
+
+
+def _strip_quoted_spans(text: str) -> str:
+    """Remove quoted phrases so reporting a forbidden phrase is not rejected."""
+    # Handles the common quote forms the judge and journal use. This is not a
+    # full natural-language parser; it deliberately protects benign mentions
+    # like ``fixed the "priority #6" defect`` from the rationale detector.
+    return re.sub(r"(['\"`“‘]).*?(['\"`”’])", " ", text)
+
+
+def _has_negation_near(text: str, start: int, end: int) -> bool:
+    """Return True when a forbidden phrase is explicitly negated nearby."""
+    window = text[max(0, start - 80) : min(len(text), end + 80)].lower()
+    return any(
+        marker in window
+        for marker in (
+            "do not penalize",
+            "does not penalize",
+            "did not penalize",
+            "don't penalize",
+            "not penalized",
+            "not a penalty",
+            "not because",
+            "not for being",
+            "without penalizing",
+            "rather than penalizing",
+            "instead of penalizing",
+            "fixed the",
+            "fixes the",
+            "reports that",
+            "documented that",
+        )
+    )
+
+
+def _reason_violates_forbidden_rationale(reason: str) -> bool:
+    """Detect forbidden goal-order/category rationale in a judge reason.
+
+    The judge prompt may mention these phrases as a *contract*, but a returned
+    reason must not use them to justify a penalty or cap. We strip quoted spans
+    and accept explicit negations/reporting so sessions that fix this defect are
+    not rejected merely for naming it.
+    """
+    if not reason:
+        return False
+    candidate = _strip_quoted_spans(reason)
+    for pattern in FORBIDDEN_RATIONALE_PATTERNS:
+        match = pattern.search(candidate)
+        if match and not _has_negation_near(candidate, match.start(), match.end()):
+            return True
+    return False
 
 
 def _coerce_score(raw: Any) -> float | None:
@@ -548,7 +617,9 @@ def normalize_judge_verdict(payload: dict[str, Any]) -> JudgeVerdict:
     base_meta = _build_judge_meta(model=model)
     score = _coerce_score(payload.get("score"))
     status = str(payload.get("judge_status") or JUDGE_STATUS_OK)
-    if score is None:
+    if status == JUDGE_STATUS_COMPLIANCE_FAILURE:
+        score = None
+    elif score is None:
         status = JUDGE_STATUS_NO_SCORE
         logger.warning(
             "Judge verdict has no usable score (raw=%r, model=%s); "
@@ -569,6 +640,8 @@ def normalize_judge_verdict(payload: dict[str, Any]) -> JudgeVerdict:
             "judge_version": str(meta.get("judge_version", base_meta["judge_version"])),
         },
     }
+    if payload.get("raw_response") is not None:
+        verdict["raw_response"] = str(payload["raw_response"])
     return verdict
 
 
@@ -603,7 +676,16 @@ def _parse_judge_payload(text: str, model: str) -> dict | None:
         verdict = json.loads(match.group(0))
     score = _coerce_score(verdict.get("score"))
     reason = str(verdict.get("reason", ""))
-    if score is None:
+    compliance_failure = _reason_violates_forbidden_rationale(reason)
+    if compliance_failure:
+        logger.warning(
+            "LLM judge returned forbidden goal-order/category penalty rationale "
+            "(model=%s, reason=%r)",
+            model,
+            reason,
+        )
+        score = None
+    if score is None and not compliance_failure:
         logger.warning(
             "LLM judge returned a payload without a usable score (raw=%r, model=%s)",
             verdict.get("score"),
@@ -611,9 +693,12 @@ def _parse_judge_payload(text: str, model: str) -> dict | None:
         )
     result: dict[str, Any] = {
         "score": score,
-        "judge_status": JUDGE_STATUS_OK if score is not None else JUDGE_STATUS_NO_SCORE,
+        "judge_status": JUDGE_STATUS_COMPLIANCE_FAILURE
+        if compliance_failure
+        else (JUDGE_STATUS_OK if score is not None else JUDGE_STATUS_NO_SCORE),
         "reason": reason,
         "model": model,
+        "raw_response": text,
     }
     # Phase 3: pass through intent-contract fields when the judge returns them
     alignment_score = _coerce_alignment_score(verdict.get("alignment_score"))
@@ -993,6 +1078,8 @@ def write_alignment_grade(
                 legacy_fields["alignment_score"] = normalized["alignment_score"]
             if normalized.get("pivot_verdict") is not None:
                 legacy_fields["pivot_verdict"] = normalized["pivot_verdict"]
+            if normalized.get("raw_response") is not None:
+                legacy_fields["llm_judge_raw_response"] = normalized["raw_response"]
         _store_judge_meta(record, normalized.get("meta"))
         # Safe to run unconditionally: returns False when trajectory_path is
         # missing / unreadable or harness is unknown, and is idempotent when
@@ -1064,6 +1151,6 @@ def judge_and_writeback(
     if not updated:
         return {"status": "no_record", **normalized}
     if normalized.get("score") is None:
-        return {"status": JUDGE_STATUS_NO_SCORE, **normalized}
+        return {"status": normalized.get("judge_status", JUDGE_STATUS_NO_SCORE), **normalized}
 
     return {"status": "ok", **normalized}

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -16,12 +16,14 @@ from gptme_sessions.judge import (
     DEFAULT_JUDGE_MODEL,
     JUDGE_VERSION,
     JUDGE_PROMPT_TEMPLATE,
+    JUDGE_STATUS_COMPLIANCE_FAILURE,
     JUDGE_SYSTEM,
     NO_THINK_PREFILL,
     _get_api_key,
     _judge_openrouter_env,
     _parse_judge_payload,
     _prepare_messages_for_model,
+    _reason_violates_forbidden_rationale,
     _resolve_openrouter_api_key,
     _is_anthropic_direct_model,
     _strip_anthropic_prefix,
@@ -32,6 +34,7 @@ from gptme_sessions.judge import (
     judge_session,
     judge_session_with_fallback,
     normalize_judge_verdict,
+    write_alignment_grade,
 )
 from gptme_sessions.record import SessionRecord
 from gptme_sessions.store import SessionStore
@@ -430,7 +433,54 @@ class TestJudgeSession:
             "judge_status": "ok",
             "reason": "Shipped a real fix",
             "model": "openai-subscription/gpt-5.4",
+            "raw_response": """
+<think>internal</think>
+```json
+{\"score\": 1.4, \"reason\": \"Shipped a real fix\"}
+```
+""",
         }
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "Capped at 0.45 because this was priority #6 content work rather than a top goal.",
+            "Score is 0.4 because it targeted goal #6 instead of revenue work.",
+            "This is the lowest priority lane, so the session cannot score above 0.5.",
+            "Useful but not revenue-generating, so it is capped below the top goal.",
+        ],
+    )
+    def test_forbidden_rationale_detector_flags_penalty_reasons(self, reason: str) -> None:
+        assert _reason_violates_forbidden_rationale(reason) is True
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            'Added tests for the "priority #6" judge-bias defect and preserved raw responses.',
+            "The session fixed the `goal #6` failure mode and did not penalize content work.",
+            "This content session shipped a durable post without penalizing it for being low priority.",
+            "The note reports that prior judges said 'not revenue-generating' and removes that bias.",
+        ],
+    )
+    def test_forbidden_rationale_detector_allows_benign_mentions(self, reason: str) -> None:
+        assert _reason_violates_forbidden_rationale(reason) is False
+
+    def test_parse_judge_payload_marks_forbidden_rationale_non_ok(self) -> None:
+        parsed = _parse_judge_payload(
+            json.dumps(
+                {
+                    "score": 0.42,
+                    "reason": "Capped because it was priority #6 and not revenue-generating.",
+                }
+            ),
+            "openai-subscription/gpt-5.4",
+        )
+
+        assert parsed is not None
+        assert parsed["score"] is None
+        assert parsed["judge_status"] == JUDGE_STATUS_COMPLIANCE_FAILURE
+        assert parsed["reason"] == "Capped because it was priority #6 and not revenue-generating."
+        assert "raw_response" in parsed
 
     def test_prepare_messages_for_qwen_adds_no_think_prefill(self) -> None:
         prepared = _prepare_messages_for_model(
@@ -799,6 +849,22 @@ class TestModelRouting:
         assert normalized["alignment_score"] == 0.75
         assert normalized["pivot_verdict"] is None
 
+    def test_normalize_judge_verdict_preserves_compliance_failure_status(self) -> None:
+        """Compliance failures must not silently retain a usable score."""
+        normalized = normalize_judge_verdict(
+            {
+                "score": 0.42,
+                "judge_status": JUDGE_STATUS_COMPLIANCE_FAILURE,
+                "reason": "Capped because it was goal #6.",
+                "model": "test",
+                "raw_response": '{"score": 0.42}',
+            }
+        )
+
+        assert normalized["score"] is None
+        assert normalized["judge_status"] == JUDGE_STATUS_COMPLIANCE_FAILURE
+        assert normalized["raw_response"] == '{"score": 0.42}'
+
 
 class TestSessionRecordJudgeFields:
     """Tests for LLM judge fields on SessionRecord."""
@@ -936,6 +1002,29 @@ class TestSessionRecordJudgeFields:
         updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
         assert updated.grades["alignment"] == 0.5
 
+    def test_writeback_persists_compliance_failure_without_alignment_grade(
+        self, tmp_path: Path
+    ) -> None:
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        verdict = normalize_judge_verdict(
+            {
+                "score": 0.42,
+                "judge_status": JUDGE_STATUS_COMPLIANCE_FAILURE,
+                "reason": "Capped because this was priority #6 content work.",
+                "model": "openai-subscription/gpt-5.4",
+                "raw_response": '{"score": 0.42}',
+            }
+        )
+        assert write_alignment_grade(session_id="abc123", verdict=verdict, sessions_dir=tmp_path)
+
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        assert "alignment" not in updated.grades
+        assert updated.llm_judge_reason == "Capped because this was priority #6 content work."
+        assert updated.to_dict()["judge_status"] == JUDGE_STATUS_COMPLIANCE_FAILURE
+        assert updated.to_dict()["llm_judge_raw_response"] == '{"score": 0.42}'
+
     def test_writeback_merges_trajectory_ref_for_codex(self, tmp_path: Path) -> None:
         """write_alignment_grade merges harness+trajectory_path from trajectory_ref.json
         when the stored record is missing them (codex path)."""
@@ -1025,6 +1114,7 @@ class TestSessionRecordJudgeFields:
             "judge_status": "no_score",
             "reason": "judge forgot the score",
             "model": "openai-subscription/gpt-5.4",
+            "raw_response": '{"reason": "judge forgot the score"}',
         }
 
     def test_parse_judge_payload_with_unparseable_score_is_no_score(self) -> None:


### PR DESCRIPTION
## Summary
- detect forbidden goal-order/category penalty rationales in parseable session-judge responses
- mark those verdicts as `compliance_failure` with no alignment score instead of silently accepting the score
- preserve raw judge responses for audit/debugging and cover observed violation phrases plus benign quoted/negated mentions

## Tests
- `uv run ruff check packages/gptme-sessions/src/gptme_sessions/judge.py packages/gptme-sessions/tests/test_judge.py`
- `uv run --with gptme --package gptme-sessions pytest packages/gptme-sessions/tests/test_judge.py -q`

Related: ErikBjare/bob#1212
