### PR TITLE
fix(pm): scale gptme-canary default timeout 900→1800

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item_config.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item_config.py
@@ -84,9 +84,44 @@ _ENV_OVERRIDES = {
     "wait_merge_auto_enabled_repos": "PROJECT_MONITORING_AUTO_WAIT_AND_MERGE_REPOS",
 }
 
+# gptme PM canary slots already set PM_GPTME_CANARY=1. Their fast-lane default
+# of 900s kills 29% of gptme:grok-4.6 sessions (duration >= budget) vs 0.7%
+# of grok-build:grok-4.6 on the same budget. Timeouts zero PM_ITEM_SUCCESSES
+# and the model bandit records a failure — the 24-point grok-gptme vs
+# grok-cli gap. Scale only the default tier; extended 1500/2700 tiers stay.
+GPTME_CANARY_DEFAULT_TIMEOUT = 1800
+GPTME_CANARY_DEFAULT_TIME_DESC = "~25 minutes"
+
 
 def default_config_path(workspace: Path) -> Path:
     return workspace / "config" / "pm-run-item.toml"
+
+
+def apply_gptme_canary_default_timeout(
+    kwargs: dict[str, Any], environ: dict[str, str] | None = None
+) -> None:
+    """Raise the fast-lane default timeout for gptme canary slots.
+
+    ``PM_GPTME_CANARY=1`` is already forwarded onto those slots. An explicit
+    ``PM_GPTME_CANARY_DEFAULT_TIMEOUT`` overrides the 1800s default; ``0`` or a
+    non-integer leaves the config/TOML value unchanged.
+    """
+    env = os.environ if environ is None else environ
+    if env.get("PM_GPTME_CANARY") != "1":
+        return
+    raw = env.get("PM_GPTME_CANARY_DEFAULT_TIMEOUT", str(GPTME_CANARY_DEFAULT_TIMEOUT))
+    try:
+        timeout = int(raw)
+    except (TypeError, ValueError):
+        return
+    if timeout <= 0:
+        return
+    kwargs["default_timeout"] = timeout
+    kwargs["default_time_desc"] = (
+        GPTME_CANARY_DEFAULT_TIME_DESC
+        if timeout == GPTME_CANARY_DEFAULT_TIMEOUT
+        else f"~{max(1, timeout // 60)} minutes"
+    )
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
@@ -129,6 +164,8 @@ def load_run_item_config(
         env_value = os.environ.get(env_name)
         if env_value:
             kwargs[field_name] = env_value
+
+    apply_gptme_canary_default_timeout(kwargs)
 
     for key, value in overrides.items():
         if value is not None and key in valid_fields:

--- a/packages/gptme-runloops/src/gptme_runloops/run_item_config.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item_config.py
@@ -171,6 +171,12 @@ def load_run_item_config(
         if value is not None and key in valid_fields:
             kwargs[key] = value
 
+    # If default_timeout was overridden after the canary function set default_time_desc,
+    # recompute the description so they stay consistent.
+    if overrides.get("default_timeout") is not None and "default_time_desc" in kwargs:
+        t = int(kwargs["default_timeout"])
+        kwargs["default_time_desc"] = f"~{max(1, t // 60)} minutes"
+
     return RunItemConfig(workspace=workspace, **kwargs), raw
 
 

--- a/packages/gptme-runloops/tests/test_run_item_config.py
+++ b/packages/gptme-runloops/tests/test_run_item_config.py
@@ -105,6 +105,7 @@ def test_cli_override_wins_over_gptme_canary_timeout(tmp_path, monkeypatch) -> N
     monkeypatch.setenv("PM_GPTME_CANARY", "1")
     config, _ = load_run_item_config(tmp_path, default_timeout=900)
     assert config.default_timeout == 900
+    assert config.default_time_desc == "~15 minutes"  # recomputed from final timeout
 
 
 def test_cli_overrides_win_over_everything(tmp_path) -> None:

--- a/packages/gptme-runloops/tests/test_run_item_config.py
+++ b/packages/gptme-runloops/tests/test_run_item_config.py
@@ -77,6 +77,36 @@ def test_env_overrides_win_over_toml(tmp_path, monkeypatch) -> None:
     assert config.self_merge_repos == "from/env"
 
 
+def test_gptme_canary_scales_default_timeout_only(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PM_GPTME_CANARY", "1")
+    config, _ = load_run_item_config(tmp_path)
+    assert config.default_timeout == 1800
+    assert config.default_time_desc == "~25 minutes"
+    assert config.assigned_issue_timeout == 1500
+    assert config.greptile_fix_timeout == 2700
+
+
+def test_gptme_canary_timeout_env_override(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PM_GPTME_CANARY", "1")
+    monkeypatch.setenv("PM_GPTME_CANARY_DEFAULT_TIMEOUT", "2100")
+    config, _ = load_run_item_config(tmp_path)
+    assert config.default_timeout == 2100
+    assert config.default_time_desc == "~35 minutes"
+
+
+def test_gptme_canary_timeout_disabled_keeps_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PM_GPTME_CANARY", "1")
+    monkeypatch.setenv("PM_GPTME_CANARY_DEFAULT_TIMEOUT", "0")
+    config, _ = load_run_item_config(tmp_path)
+    assert config.default_timeout == 900
+
+
+def test_cli_override_wins_over_gptme_canary_timeout(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PM_GPTME_CANARY", "1")
+    config, _ = load_run_item_config(tmp_path, default_timeout=900)
+    assert config.default_timeout == 900
+
+
 def test_cli_overrides_win_over_everything(tmp_path) -> None:
     config, _ = load_run_item_config(tmp_path, author="CliAuthor", agent_name=None)
     assert config.author == "CliAuthor"


### PR DESCRIPTION
## Why

The 2026-09-06 PM canary readout scored `grok-build:grok-4.6` at 90.1% (539/598) vs `gptme:grok-4.6` at 66.2% (86/130) — same model, two backends. Session records show the converter is the 900s fast-lane budget:

- gptme monitoring: 21/72 (29.2%) overran 900s
- grok-build monitoring: 3/424 (0.7%) overran 900s
- duration p50 839s vs 330s

Bandit success is `PM_ITEM_SUCCESSES > 0` after `successes = total - failures - timeouts`, so a 900s kill is recorded as a model failure. 86 productive session-record rows match the 86 bandit successes exactly. Dropping the 21 overruns from the denominator is 86/109 = 78.9%.

Diagnosis: https://github.com/ErikBjare/bob/blob/master/knowledge/technical/2026-09-06-pm-gptme-harness-gap.md (lands in the brain repo with this session).

## Change

When `PM_GPTME_CANARY=1` (already setenv'd on gptme canary slots), raise only the **default** timeout 900→1800. Extended tiers (1500/2700) are unchanged. `PM_GPTME_CANARY_DEFAULT_TIMEOUT` overrides; `0` disables.

## Success criterion

After ≥50 new `gptme:grok-4.6` PM pulls: live default-budget kill rate ≤5%, and notification-triage bandit rate within 8 points of grok-build.

## Tests

`uv run pytest packages/gptme-runloops/tests/test_run_item_config.py -q` — 10 passed.