### PR TITLE
fix(gptme-runloops): record effect=observed when generic route completes a voice post-call

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2629,7 +2629,14 @@ def run_post_session(
     # instead of leaving the actuation verifier to re-derive it from journal
     # markers.
     if effect != EFFECT_OBSERVED and "voice_postcall" in item.types:
-        if voice_postcall_effect_observed(item.detail, config.workspace):
+        session_start: datetime | None = None
+        try:
+            session_start = datetime.fromisoformat(outcome.started_iso)
+        except ValueError:
+            pass
+        if voice_postcall_effect_observed(
+            item.detail, config.workspace, now=session_start
+        ):
             effect = EFFECT_OBSERVED
     if effect == EFFECT_NONE:
         _log(

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -128,6 +128,7 @@ from gptme_runloops.worker_records import (
     read_record_effect_signal,
     read_record_pr_state_after,
     update_record_pr_state,
+    voice_postcall_effect_observed,
     write_fallback_session_record,
     write_post_session_record,
     write_worker_result_manifest,
@@ -2620,6 +2621,16 @@ def run_post_session(
         record_file,
         delivery_outcome=effect_delivery,
     )
+    # A pure voice_postcall item has no PR and no thread, so the signal above
+    # grades it ``unknown`` even when the generic notification-triage route
+    # completed the call (post-call.sh wrote a terminal trace row + journal).
+    # The native pm-run-item-slot path grades that ``observed`` explicitly;
+    # do the same here so the dispatch row carries one authoritative signal
+    # instead of leaving the actuation verifier to re-derive it from journal
+    # markers.
+    if effect != EFFECT_OBSERVED and "voice_postcall" in item.types:
+        if voice_postcall_effect_observed(item.detail, config.workspace):
+            effect = EFFECT_OBSERVED
     if effect == EFFECT_NONE:
         _log(
             f"WARN: PM dispatch produced NO observable effect on {plan.repo}#{plan.number} "

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -72,11 +72,14 @@ Design rules (same as steps 1-2):
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import re
 import subprocess
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -1214,6 +1217,123 @@ def _parse_thread_count(value: object) -> int | None:
     except (TypeError, ValueError):
         return None
     return count if count >= 0 else None
+
+
+# --- Voice post-call effect detection ---
+#
+# The generic notification-triage route (``gptme_runloops.run_item``) completes
+# a voice post-call by running ``scripts/runs/voice/post-call.sh`` inside the
+# gptme session. That script writes a terminal row to the trace ledger
+# (``state/voice-calls/post-call-events.tsv``) plus a journal linking the call
+# record — durable external effects the native ``pm-run-item-slot`` path grades
+# ``effect=observed`` via its ``voice_postcall_effect_verified`` shim. But a
+# ``voice_postcall`` item has no PR and no thread, so :func:`derive_effect_signal`
+# has no signal to read and grades ``unknown``. This helper is the parity check
+# for that gap: when the generic route completed the call, the dispatch row
+# should carry ``effect=observed`` so the actuation verifier has one
+# authoritative signal instead of re-deriving completion from journal markers.
+
+#: ``record=`` token separator, mirrored from the bash
+#: ``voice_postcall_records_for_work_file`` (pm-run-item-slot.sh).
+VOICE_POSTCALL_RECORD_RE = re.compile(
+    r"(?:^|;\s*)record=(.*?)(?=;\s*[A-Za-z_][A-Za-z0-9_]*(?:=|:)|$)"
+)
+
+#: Terminal trace phases post-call.sh writes on a completed call. ``run_failed``
+#: is deliberately absent — a failed call is not an observed effect.
+VOICE_POSTCALL_TERMINAL_PHASES = frozenset({"run_completed", "stub_call_skip"})
+
+#: Env override for the trace ledger, mirroring the bash + prompt-templates param.
+VOICE_POSTCALL_TRACE_ENV = "GPTME_VOICE_POST_CALL_TRACE_FILE"
+
+#: Journal markers that link a completed call to its archive record.
+_VOICE_POSTCALL_JOURNAL_MARKERS = (
+    "**Archive**: `{record}`",
+    "**Call record**: `{record}`",
+    "**Source record**: `{record}`",
+)
+
+
+def voice_postcall_record_paths(detail: str) -> list[str]:
+    """Extract ``record=`` archive paths from a voice_postcall item's detail."""
+    return [
+        match.group(1).strip()
+        for match in VOICE_POSTCALL_RECORD_RE.finditer(detail or "")
+    ]
+
+
+def voice_postcall_journal_path(
+    workspace: str | Path, record_paths: Iterable[str], now: datetime
+) -> Path:
+    """Deterministic journal path post-call.sh writes for the given records."""
+    digest = hashlib.sha256()
+    for record in record_paths:
+        digest.update(record.encode())
+        digest.update(b"\0")
+    return (
+        Path(workspace)
+        / "journal"
+        / now.astimezone(timezone.utc).strftime("%Y-%m-%d")
+        / f"autonomous-session-voice-postcall-{digest.hexdigest()[:8]}.md"
+    )
+
+
+def voice_postcall_effect_observed(
+    detail: str,
+    workspace: str | Path,
+    *,
+    now: datetime | None = None,
+    trace_file: str | Path | None = None,
+) -> bool:
+    """True when the generic route completed a voice post-call for ``detail``.
+
+    Mirrors ``voice_postcall_effect_verified`` in
+    ``scripts/runs/github/pm-run-item-slot.sh``: a terminal trace row naming
+    every record, plus a journal linking every record to its archive.
+    """
+    records = voice_postcall_record_paths(detail)
+    if not records:
+        return False
+
+    when = now or datetime.now(timezone.utc)
+    journal = voice_postcall_journal_path(workspace, records, when)
+
+    if trace_file is None:
+        trace_file = os.environ.get(
+            VOICE_POSTCALL_TRACE_ENV,
+            str(Path(workspace) / "state" / "voice-calls" / "post-call-events.tsv"),
+        )
+    trace_file = Path(trace_file)
+
+    trace_ok = False
+    try:
+        for raw in trace_file.read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines():
+            parts = raw.split("\t")
+            if len(parts) < 3 or parts[1] not in VOICE_POSTCALL_TERMINAL_PHASES:
+                continue
+            row_records = {part.strip() for part in parts[2].split(",") if part.strip()}
+            if all(record in row_records for record in records):
+                trace_ok = True
+                break
+    except OSError:
+        trace_ok = False
+
+    journal_ok = False
+    try:
+        text = journal.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        text = ""
+    journal_ok = all(
+        any(
+            marker.format(record=record) in text
+            for marker in _VOICE_POSTCALL_JOURNAL_MARKERS
+        )
+        for record in records
+    )
+
+    return trace_ok and journal_ok
 
 
 def derive_effect_signal(

--- a/packages/gptme-runloops/tests/test_worker_records_voice_postcall.py
+++ b/packages/gptme-runloops/tests/test_worker_records_voice_postcall.py
@@ -122,3 +122,34 @@ def test_grouped_records_require_all_present_in_one_trace_row(tmp_path):
     assert not voice_postcall_effect_observed(
         f"record={a}; record={b}", tmp_path, now=when, trace_file=trace
     )
+
+
+def test_midnight_crossing_uses_session_start_date(tmp_path):
+    """Journal written at 23:58 on day X must be found when run_post_session runs at 00:02 on day X+1.
+
+    Without passing ``now=session_start``, voice_postcall_effect_observed falls
+    back to the current time (day X+1) and looks in the wrong journal directory.
+    """
+    record = "/data/calls/one.wav"
+    call_time = datetime(2026, 9, 6, 23, 58, 0, tzinfo=timezone.utc)
+    next_day = datetime(2026, 9, 7, 0, 2, 0, tzinfo=timezone.utc)
+
+    # Journal written by post-call.sh during the session (at call_time's date).
+    journal = voice_postcall_journal_path(tmp_path, [record], call_time)
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    journal.write_text(f"**Archive**: `{record}`\n", encoding="utf-8")
+
+    trace = tmp_path / "post-call-events.tsv"
+    trace.write_text(
+        f"2026-09-06T23:59:00Z\trun_completed\t{record}\n",
+        encoding="utf-8",
+    )
+
+    # Passing the session start date finds the journal correctly.
+    assert voice_postcall_effect_observed(
+        f"record={record}", tmp_path, now=call_time, trace_file=trace
+    )
+    # Passing the next day's date misses the journal → False.
+    assert not voice_postcall_effect_observed(
+        f"record={record}", tmp_path, now=next_day, trace_file=trace
+    )

--- a/packages/gptme-runloops/tests/test_worker_records_voice_postcall.py
+++ b/packages/gptme-runloops/tests/test_worker_records_voice_postcall.py
@@ -1,0 +1,124 @@
+"""Voice post-call completion is an observable effect on the generic route.
+
+The generic notification-triage route (``run_item``) completes a voice
+post-call by running ``post-call.sh`` inside the session; that script writes a
+terminal trace row plus a journal linking the record. The native
+``pm-run-item-slot`` path grades that ``effect=observed`` explicitly, but the
+generic effect derivation (``derive_effect_signal``) had no signal to read for
+a threadless, PR-less ``voice_postcall`` item and graded ``unknown``. This is
+the parity check that closes that gap.
+"""
+
+from datetime import datetime, timezone
+
+from gptme_runloops.worker_records import (
+    voice_postcall_effect_observed,
+    voice_postcall_journal_path,
+    voice_postcall_record_paths,
+)
+
+
+def test_record_paths_extraction():
+    detail = (
+        "record=/data/calls/a.wav; remote_party=+46765784797; record=/data/calls/b.wav"
+    )
+    assert voice_postcall_record_paths(detail) == [
+        "/data/calls/a.wav",
+        "/data/calls/b.wav",
+    ]
+
+
+def test_record_paths_empty_when_no_token():
+    assert voice_postcall_record_paths("just some prose") == []
+
+
+def test_journal_path_is_deterministic_and_sha_based():
+    when = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+    path = voice_postcall_journal_path("/ws", ["/data/a.wav"], when)
+    assert path == voice_postcall_journal_path("/ws", ["/data/a.wav"], when)
+    assert str(path).startswith(
+        "/ws/journal/2026-09-06/autonomous-session-voice-postcall-"
+    )
+    assert len(path.name.rsplit("-", 1)[-1].removesuffix(".md")) == 8
+
+
+def test_effect_observed_when_trace_and_journal_agree(tmp_path):
+    record = "/data/calls/one.wav"
+    when = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+    journal = voice_postcall_journal_path(tmp_path, [record], when)
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    journal.write_text(f"## Notes\n**Archive**: `{record}`\n", encoding="utf-8")
+
+    trace = tmp_path / "post-call-events.tsv"
+    trace.write_text(
+        f"2026-09-06T12:01:00Z\trun_completed\t{record}\n",
+        encoding="utf-8",
+    )
+
+    assert voice_postcall_effect_observed(
+        f"record={record}", tmp_path, now=when, trace_file=trace
+    )
+
+
+def test_not_observed_when_trace_has_only_failed_phase(tmp_path):
+    record = "/data/calls/one.wav"
+    when = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+    journal = voice_postcall_journal_path(tmp_path, [record], when)
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    journal.write_text(f"**Archive**: `{record}`\n", encoding="utf-8")
+
+    trace = tmp_path / "post-call-events.tsv"
+    trace.write_text(
+        f"2026-09-06T12:01:00Z\trun_failed\t{record}\n",
+        encoding="utf-8",
+    )
+
+    assert not voice_postcall_effect_observed(
+        f"record={record}", tmp_path, now=when, trace_file=trace
+    )
+
+
+def test_not_observed_when_journal_missing(tmp_path):
+    record = "/data/calls/one.wav"
+    when = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+
+    trace = tmp_path / "post-call-events.tsv"
+    trace.write_text(
+        f"2026-09-06T12:01:00Z\trun_completed\t{record}\n",
+        encoding="utf-8",
+    )
+
+    assert not voice_postcall_effect_observed(
+        f"record={record}", tmp_path, now=when, trace_file=trace
+    )
+
+
+def test_not_observed_when_no_records_in_detail(tmp_path):
+    assert not voice_postcall_effect_observed("", tmp_path)
+
+
+def test_grouped_records_require_all_present_in_one_trace_row(tmp_path):
+    a, b = "/data/a.wav", "/data/b.wav"
+    when = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+    journal = voice_postcall_journal_path(tmp_path, [a, b], when)
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    journal.write_text(f"**Archive**: `{a}`\n**Archive**: `{b}`\n", encoding="utf-8")
+
+    trace = tmp_path / "post-call-events.tsv"
+    # One row names both records -> observed.
+    trace.write_text(
+        f"t\trun_completed\t{a},{b}\n",
+        encoding="utf-8",
+    )
+    assert voice_postcall_effect_observed(
+        f"record={a}; record={b}", tmp_path, now=when, trace_file=trace
+    )
+
+    # Split rows each name one record -> the group is not complete in any row.
+    trace.write_text(
+        f"t\trun_completed\t{a}\nt\trun_completed\t{b}\n",
+        encoding="utf-8",
+    )
+    assert not voice_postcall_effect_observed(
+        f"record={a}; record={b}", tmp_path, now=when, trace_file=trace
+    )


### PR DESCRIPTION
## Problem

The generic notification-triage route (`gptme_runloops.run_item`) completes a voice post-call by running `scripts/runs/voice/post-call.sh` inside the session. That script writes a terminal trace row (`state/voice-calls/post-call-events.tsv`) plus a journal linking the call record — durable external effects.

The native `pm-run-item-slot` path grades that `effect=observed` explicitly via its `voice_postcall_effect_verified` shim. But a `voice_postcall` item has no PR and no thread, so `derive_effect_signal` has no signal to read and grades `unknown`. That leaves two drifting signals: the dispatch row says `unknown` while the journal says the call completed, forcing the actuation verifier (Bob's `actuation_status.py`) to re-derive completion from journal markers instead of reading one authoritative dispatch row.

Tracked as ErikBjare/bob task `generic-pm-completion-records-effect-observed` (gap 2 of the voice post-call rearm loop).

## Change

Add `voice_postcall_effect_observed()` to `worker_records.py` — a parity check mirroring `pm-run-item-slot.sh`'s `voice_postcall_effect_verified`: a terminal trace row naming every record (`run_completed`/`stub_call_skip`; `run_failed` is deliberately excluded), plus a journal linking every record to its archive.

In `run_post_session` step 9, when a `voice_postcall` item graded non-observed, upgrade to `observed` if that check passes.

## Tests

8 new cases in `test_worker_records_voice_postcall.py` covering record extraction, deterministic journal-path derivation, and the trace+journal agreement (including the `run_failed`-is-not-effect and grouped-records-must-share-one-trace-row edges). Existing worker_records/thread_effect/run_item suites stay green (294 passed).