### PR TITLE
fix(gptme-sessions): extract codex session id from rollout filename

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from datetime import date, datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -804,6 +805,27 @@ def session_datetime_from_path(harness: str, path: Path) -> datetime | None:
         return _quick_datetime_from_jsonl(path)
 
 
+_CODEX_ROLLOUT_ID_RE = re.compile(
+    r"rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-"
+    r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+)
+
+
+def _codex_session_name(stem: str) -> str | None:
+    """Return a stable name for a Codex rollout filename stem.
+
+    Codex names its sessions ``rollout-YYYY-MM-DDTHH-MM-SS-<session-id>.jsonl``.
+    The first-8-chars-of-stem rule yields the literal ``rollout-`` prefix for
+    every such file, which is not a useful name. Extract the trailing Codex
+    session id and return its first 8 chars (matching the claude-code
+    convention) instead. Unknown stem shapes fall back to the old rule.
+    """
+    m = _CODEX_ROLLOUT_ID_RE.match(stem)
+    if m:
+        return m.group(1)[:8]
+    return stem[:8] if stem else None
+
+
 def extract_session_name(harness: str, path: Path) -> str | None:
     """Extract a human-readable session name from a discovered session path.
 
@@ -831,7 +853,7 @@ def extract_session_name(harness: str, path: Path) -> str | None:
         # JSONL filename is a UUID like "abc12345-...-def67890.jsonl"
         return path.stem[:8]
     elif harness == "codex":
-        return path.stem[:8] if path.stem else None
+        return _codex_session_name(path.stem)
     elif harness == "copilot":
         return path.parent.name[:8]
     elif harness == "pi":

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -1380,6 +1380,12 @@ class TestExtractSessionName:
         jsonl.touch()
         assert extract_session_name("codex", jsonl) == "session-"
 
+    def test_codex_rollout_uses_session_id(self, tmp_path: Path) -> None:
+        """codex: rollout-* files extract the trailing session id, not 'rollout-'."""
+        jsonl = tmp_path / "rollout-2026-09-06T22-04-16-01a078c0-2ff3-7080-a370-221c9c968dae.jsonl"
+        jsonl.touch()
+        assert extract_session_name("codex", jsonl) == "01a078c0"
+
     def test_copilot_uses_parent_dir(self, tmp_path: Path) -> None:
         """copilot: uses first 8 chars of parent dir name."""
         session_dir = tmp_path / "abcdefgh-1234-5678"


### PR DESCRIPTION
## Problem

`extract_session_name('codex', path)` returned `path.stem[:8]`, which for a Codex rollout filename `rollout-YYYY-MM-DDTHH-MM-SS-<uuid>.jsonl` yields the literal `rollout-` prefix. Every Codex session discovered this way got the same unhelpful name.

This surfaced in Bob's `trajectory-source-uniqueness` check as a cosmetic sibling to a real mis-attribution bug (two session records both showing `session_name: rollout-`).

## Fix

Add `_codex_session_name()` which extracts the trailing Codex session id (a UUID) from the rollout stem and returns its first 8 chars (matching the claude-code convention). Unknown stem shapes fall back to the old rule.

## Test

`test_codex_rollout_uses_session_id` pins the rollout-filename case; the existing `test_codex_uses_stem` (non-rollout shape) still passes via the fallback.