### PR TITLE
fix(gptme-sessions): close two bypasses in judge compliance detector

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -515,12 +515,26 @@ FORBIDDEN_RATIONALE_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+_STRAIGHT_QUOTE_SPAN_RE = re.compile(r"(?<!\w)([\"'`])(.*?)\1(?!\w)")
+_CURLY_DOUBLE_SPAN_RE = re.compile(r"“[^”]*”")
+_CURLY_SINGLE_SPAN_RE = re.compile(r"(?<!\w)‘[^’]*’(?!\w)")
+
+
 def _strip_quoted_spans(text: str) -> str:
     """Remove quoted phrases so reporting a forbidden phrase is not rejected."""
     # Handles the common quote forms the judge and journal use. This is not a
     # full natural-language parser; it deliberately protects benign mentions
     # like ``fixed the "priority #6" defect`` from the rationale detector.
-    return re.sub(r"(['\"`“‘]).*?(['\"`”’])", " ", text)
+    #
+    # The word-boundary guards matter: without them, the apostrophes in
+    # ordinary contractions ("don't", "it's", "Author's") pair up as fake
+    # quote delimiters and can strip a genuine forbidden phrase sitting
+    # between two unrelated contractions (e.g. "Author's take: this is low
+    # priority, don't ship it." would silently erase "low priority").
+    text = _STRAIGHT_QUOTE_SPAN_RE.sub(" ", text)
+    text = _CURLY_DOUBLE_SPAN_RE.sub(" ", text)
+    text = _CURLY_SINGLE_SPAN_RE.sub(" ", text)
+    return text
 
 
 def _has_negation_near(text: str, start: int, end: int) -> bool:
@@ -540,10 +554,6 @@ def _has_negation_near(text: str, start: int, end: int) -> bool:
             "without penalizing",
             "rather than penalizing",
             "instead of penalizing",
-            "fixed the",
-            "fixes the",
-            "reports that",
-            "documented that",
         )
     )
 

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -465,6 +465,22 @@ class TestJudgeSession:
     def test_forbidden_rationale_detector_allows_benign_mentions(self, reason: str) -> None:
         assert _reason_violates_forbidden_rationale(reason) is False
 
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            # Two unrelated contractions must not pair up as fake quote
+            # delimiters and erase the forbidden phrase sitting between them.
+            "Author's take: this is low priority, don't ship it. Capping score at 0.3.",
+            # A generic phrase like "fixed the" elsewhere in the reason must
+            # not be treated as negating a genuine penalty rationale later
+            # in the same sentence.
+            "Score 0.3. The session fixed the auth bug, but this remains low "
+            "priority content work, capping below the top goal.",
+        ],
+    )
+    def test_forbidden_rationale_detector_catches_bypass_attempts(self, reason: str) -> None:
+        assert _reason_violates_forbidden_rationale(reason) is True
+
     def test_parse_judge_payload_marks_forbidden_rationale_non_ok(self) -> None:
         parsed = _parse_judge_payload(
             json.dumps(


### PR DESCRIPTION
## Summary

Follow-up to #1619, from the post-merge review Erik requested there. The compliance detector added in #1619 (`_reason_violates_forbidden_rationale`) has two confirmed bypasses that let a judge use a forbidden goal-order/category rationale to penalize a session without tripping `compliance_failure`:

1. **Quote-span stripping pairs unrelated contractions.** `_strip_quoted_spans` matched any two quote-like characters (including a bare ASCII apostrophe) as a span. Two ordinary contractions bracket a forbidden phrase and it gets silently erased before the pattern check ever runs:
   ```python
   _strip_quoted_spans("Author's take: this is low priority, don't ship it.")
   # -> "Author t ship it."   (the "'s" ... "don'" span consumed "low priority")
   ```
   `_reason_violates_forbidden_rationale("Author's take: this is low priority, don't ship it. Capping score at 0.3.")` returned `False` pre-fix — a real penalty rationale went undetected.

2. **Overly generic negation markers.** `_has_negation_near` treated `"fixed the"`, `"fixes the"`, `"reports that"`, `"documented that"` as negation markers within an 80-char window. These are common in ordinary judge commentary unrelated to negating a penalty:
   ```python
   _reason_violates_forbidden_rationale(
       "Score 0.3. The session fixed the auth bug, but this remains low "
       "priority content work, capping below the top goal."
   )
   # -> False pre-fix (the earlier "fixed the" masked the real penalty rationale)
   ```

## Fix

- `_strip_quoted_spans`: require the quote characters to sit at a word boundary (`(?<!\w)...(?!\w)`), so contractions no longer pair up as fake quote delimiters, and match quote types symmetrically instead of any-to-any.
- `_has_negation_near`: drop the four generic markers. They were only needed for the two existing benign-mention test cases, both of which are already protected by quote-stripping (the forbidden phrase is quoted in both). The remaining markers stay tied to explicit penalize/penalty language.

## Tests

Both bypasses are now regression-tested in `test_forbidden_rationale_detector_catches_bypass_attempts` (fails pre-fix, passes post-fix). Full suite:
```
uv run ruff check packages/gptme-sessions/src/gptme_sessions/judge.py packages/gptme-sessions/tests/test_judge.py
PYTHONPATH=.../packages/gptme-sessions/src uv run --with gptme --with pytest --with pytest-mock python3 -m pytest packages/gptme-sessions/tests/test_judge.py -q
# 84 passed
```