### PR TITLE
fix(self-merge-check): make Greptile advisory; own AI reviewer becomes required gate

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -6,9 +6,11 @@ autonomous AI agent can safely merge its own PRs without human review.
 
 Policy summary:
 - CI must be green (or skipped)
-- A machine review must be present and clean: EITHER a Greptile review with no
-  unresolved threads, OR a high-confidence review from the agent's own
-  self-hosted AI reviewer (see "Accepting our own review" below)
+- A machine review must be present and clean: own self-hosted AI reviewer with
+  consensus pass and zero open P1 findings (see "Accepting our own review" below).
+  Greptile review is fetched and shown but is advisory only — never a blocker.
+  (Erik decision 2026-09-07: Greptile pricing dispute + credit outages make it
+  unreliable as a hard gate; ErikBjare/bob#self-merge-gate-greptile-floor-while-credits-exhausted)
 - PR must be authored by the authenticated user
 - Changed files must fall into a low-risk category (tests, docs, lessons, skills,
   internal tooling, task metadata)
@@ -2643,96 +2645,51 @@ def evaluate_pr(
         repo, number, expected_author=current_user
     )
 
+    # --- Greptile review (advisory: fetched and reported, never a blocker) ---
+    # Erik decision 2026-09-07: Greptile is now advisory only — its score and
+    # findings are fetched and shown, but never a refusal reason. Reason:
+    # pricing dispute and credit outages make it unreliable as a hard gate.
+    # Required signals: own AI reviewer (consensus pass, zero open P1s) and
+    # the sensitive-paths human-merge rule.
     greptile = fetch_greptile_status(repo, number, review_data=shared_review_data)
-    if not greptile["has_review"]:
-        # The alternative review is safe only after a successful GraphQL fetch
-        # proves there is no Greptile review. An API failure is unknown, not
-        # absence: accepting our marker there would turn a fail-closed outage into
-        # a path around potentially unresolved Greptile feedback.
-        # `greptile["unknown"]` covers the second way the lookup can fail: the
-        # GraphQL fetch succeeds and reports no reviews, but the summary-comment
-        # fallback inside `fetch_greptile_status` errors out. That path also
-        # yields `has_review: False`, so gating on `shared_review_data` alone
-        # would let a transient comment-API failure open the AI fallback.
-        if shared_review_data is None or greptile.get("unknown"):
-            result.reasons.append(
-                "Could not verify Greptile review state; refusing AI-review fallback"
-            )
-        else:
-            ai_review = fetch_ai_review_status(
-                repo,
-                number,
-                head_sha=result.head_sha,
-                expected_author=current_user,
-                marker_result=shared_marker,
-                review_data=shared_review_data,
-            )
-            if ai_review["accepted"]:
-                result.warnings.append(
-                    f"Greptile review not found; satisfied by self-hosted "
-                    f"AI review ({ai_review['detail']})"
-                )
-            else:
-                reason = "Greptile review not found"
-                if ai_review["detail"]:
-                    reason += f"; {ai_review['detail']}"
-                result.reasons.append(reason)
-    elif greptile["unresolved"] > 0:
-        result.reasons.append(
-            f"Greptile has {greptile['unresolved']} unresolved review thread(s)"
+    if greptile.get("unknown"):
+        result.warnings.append(
+            "Greptile review state could not be determined (API failure) [advisory]"
         )
-
-    # Score floor (defense in depth): require the Greptile summary score >= floor
-    # (default 5/5, override via SELF_MERGE_MIN_GREPTILE_SCORE). Without this, resolving
-    # threads alone could let a low-score PR self-merge — the alice#61 (4/5) and #63 (3/5)
-    # incidents where buggy control-path code shipped. Reuses the shared greptile-merge-signal
-    # evaluator (upstreamed from Bob). Parse failure (score None) does NOT block — the
-    # thread/category gates still apply; this only catches a clear sub-floor score.
-    if greptile["has_review"]:
-        min_score = _parse_self_merge_min_greptile_score()
+    elif greptile["has_review"]:
         score = greptile_summary_score(repo, number)
-        if score is not None and score < min_score:
-            result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
-        elif score is not None and result.head_sha:
-            # Provenance gate (gptme/gptme#3656 class): Greptile edits its
-            # summary in place, so the "latest summary" score can belong to an
-            # older head. A clearing score only counts when the summary's
-            # "Last reviewed commit" footer names the current head. Fails open
-            # when provenance is absent (None) — older summary formats carry no
-            # footer, and the thread/category gates still apply.
-            reviewed = greptile_summary_reviewed_commit(repo, number)
-            if reviewed and not _sha_matches_head(reviewed, result.head_sha):
-                result.reasons.append(
-                    f"Greptile score {score}/5 is stale (summary reviewed "
-                    f"{reviewed[:12]}, head is {result.head_sha[:12]}) — "
-                    "re-review of head required"
-                )
+        score_str = f"{score}/5" if score is not None else "n/a"
+        greptile_note = f"Greptile reviewed (score {score_str})"
+        if greptile["unresolved"] > 0:
+            greptile_note += f"; {greptile['unresolved']} unresolved thread(s)"
+        result.warnings.append(f"{greptile_note} [advisory — not a gate]")
+    else:
+        result.warnings.append("Greptile review not found [advisory — not required]")
 
-    # An explicit abstention blocks in its own right. If the structured review
-    # state cannot be read, fail closed rather than silently removing the gate.
-    ai_abstention = ai_review_abstained(
+    # --- AI review (required: own reviewer + consensus gate are the signal) ---
+    # `fetch_ai_review_status` covers abstention (score: null → not accepted)
+    # and API failure (marker lookup failed → not accepted), so the old
+    # separate `ai_review_abstained` check is no longer needed here.
+    ai_review = fetch_ai_review_status(
         repo,
         number,
-        expected_author=current_user,
         head_sha=result.head_sha,
+        expected_author=current_user,
         marker_result=shared_marker,
+        review_data=shared_review_data,
     )
-    if ai_abstention is True:
-        result.reasons.append("AI review abstained — not reviewed")
-    elif ai_abstention is None and not greptile["has_review"]:
-        # Indeterminate blocks only when our own reviewer is the sole evidence.
-        #
-        # Failing closed unconditionally would let one flaky call on the
-        # issue-comments endpoint disqualify EVERY self-merge, including PRs
-        # Greptile reviewed cleanly with all threads resolved -- trading the
-        # deadlock this gate family just escaped for a wider one.
-        #
-        # When Greptile has reviewed, that is independent review evidence and
-        # this check is defence in depth, so its unavailability must not veto.
-        # When Greptile has NOT reviewed, the PR is leaning on our own reviewer,
-        # and an unreadable verdict is exactly the "nobody actually reviewed
-        # this" case (gptme-cloud#850) -- so it still fails closed there.
-        result.reasons.append("AI review status unavailable")
+    if not _ai_review_enabled():
+        result.warnings.append(
+            "AI review disabled (SELF_MERGE_ACCEPT_AI_REVIEW=0); "
+            "no machine review required"
+        )
+    elif ai_review["accepted"]:
+        result.warnings.append(f"AI review accepted ({ai_review['detail']})")
+    else:
+        reason = "AI review required"
+        if ai_review["detail"]:
+            reason += f": {ai_review['detail']}"
+        result.reasons.append(reason)
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -8,9 +8,13 @@ Policy summary:
 - CI must be green (or skipped)
 - A machine review must be present and clean: own self-hosted AI reviewer with
   consensus pass and zero open P1 findings (see "Accepting our own review" below).
-  Greptile review is fetched and shown but is advisory only — never a blocker.
-  (Erik decision 2026-09-07: Greptile pricing dispute + credit outages make it
-  unreliable as a hard gate; ErikBjare/bob#self-merge-gate-greptile-floor-while-credits-exhausted)
+  Greptile review uses a 3-branch staleness policy (Erik decision 2026-09-07):
+    1. Fresh Greptile on current head → 5/5 floor applies (original gate).
+    2. Stale or dark Greptile AND fresh own-AI-review → AI reviewer verdict is the gate.
+    3. Neither fresh → PR is not eligible (fail-closed, not fail-open).
+  (Rationale: Greptile is a fine gate on public OSS repos when it responds and
+  covers the current head; pricing dispute + credit outages make it an unreliable
+  hard gate when stale. Reference: ErikBjare/bob#self-merge-gate-greptile-floor-while-credits-exhausted)
 - PR must be authored by the authenticated user
 - Changed files must fall into a low-risk category (tests, docs, lessons, skills,
   internal tooling, task metadata)
@@ -2645,26 +2649,54 @@ def evaluate_pr(
         repo, number, expected_author=current_user
     )
 
-    # --- Greptile review (advisory: fetched and reported, never a blocker) ---
-    # Erik decision 2026-09-07: Greptile is now advisory only — its score and
-    # findings are fetched and shown, but never a refusal reason. Reason:
-    # pricing dispute and credit outages make it unreliable as a hard gate.
-    # Required signals: own AI reviewer (consensus pass, zero open P1s) and
-    # the sensitive-paths human-merge rule.
+    # --- Greptile review: 3-branch staleness policy (Erik, 2026-09-07) ---
+    # 1. Fresh Greptile on current head → 5/5 floor applies (original gate).
+    # 2. Stale or dark Greptile AND fresh own-AI-review → AI reviewer verdict is the gate.
+    # 3. Neither fresh → AI review required reason blocks (fail-closed, not fail-open).
     greptile = fetch_greptile_status(repo, number, review_data=shared_review_data)
+    greptile_reviewed_sha: str | None = (
+        greptile_summary_reviewed_commit(repo, number)
+        if greptile.get("has_review")
+        else None
+    )
+    greptile_is_fresh: bool = (
+        bool(greptile.get("has_review"))
+        and greptile_reviewed_sha is not None
+        and _sha_matches_head(greptile_reviewed_sha, result.head_sha or "")
+    )
     if greptile.get("unknown"):
+        # API failure: treat as stale/dark; AI review is the gate
         result.warnings.append(
-            "Greptile review state could not be determined (API failure) [advisory]"
+            "Greptile review state could not be determined (API failure) — AI review is the gate"
         )
-    elif greptile["has_review"]:
+    elif greptile_is_fresh:
+        # Branch 1: Greptile covers the current head → its 5/5 floor applies
         score = greptile_summary_score(repo, number)
         score_str = f"{score}/5" if score is not None else "n/a"
-        greptile_note = f"Greptile reviewed (score {score_str})"
+        min_score = _parse_self_merge_min_greptile_score()
         if greptile["unresolved"] > 0:
-            greptile_note += f"; {greptile['unresolved']} unresolved thread(s)"
-        result.warnings.append(f"{greptile_note} [advisory — not a gate]")
+            result.reasons.append(
+                f"Greptile reviewed (score {score_str}); {greptile['unresolved']} unresolved thread(s)"
+            )
+        elif score is not None and score < min_score:
+            result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
+        else:
+            result.warnings.append(
+                f"Greptile reviewed (score {score_str}) at current head — floor satisfied"
+            )
     else:
-        result.warnings.append("Greptile review not found [advisory — not required]")
+        # Branch 2/3: Greptile stale or dark → AI review is the gate (see block below)
+        if greptile.get("has_review"):
+            reviewed_at = (greptile_reviewed_sha or "unknown")[:12]
+            head_at = (result.head_sha or "")[:12]
+            result.warnings.append(
+                f"Greptile review stale (reviewed at {reviewed_at}, head is {head_at})"
+                " — AI review is the gate"
+            )
+        else:
+            result.warnings.append(
+                "Greptile review not found (credit-exhausted or dark) — AI review is the gate"
+            )
 
     # --- AI review (required: own reviewer + consensus gate are the signal) ---
     # `fetch_ai_review_status` covers abstention (score: null → not accepted)

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -68,7 +68,7 @@ CLEAN_REVIEW_BODY = """## 🤖 AI code review
 <!-- bob-ai-review {"sha": "deadbeef1234", "score": 5, "engine": "llm", "history": []} -->
 """
 
-ABSTENTION_REASON = "AI review abstained — not reviewed"
+ABSTENTION_REASON = "AI reviewer abstained (no score)"
 
 
 REVIEWER = "TimeToBuildBob"
@@ -270,33 +270,38 @@ def test_evaluate_pr_blocks_on_abstention() -> None:
     """The regression: gptme-cloud#850 merged with exactly this comment."""
     result = _evaluate(ABSTENTION_BODY)
     assert not result.eligible
-    assert ABSTENTION_REASON in result.reasons
+    assert any(ABSTENTION_REASON in r for r in result.reasons)
 
 
 @pytest.mark.parametrize("body", [ORDINARY_REVIEW_BODY, CLEAN_REVIEW_BODY])
 def test_evaluate_pr_unchanged_by_an_ordinary_ai_review(body: str) -> None:
-    """A clean AI review must grant nothing and block nothing.
+    """An ordinary AI review (stale or low-score) still blocks via the AI review gate.
 
-    Pins the scope: this change adds a blocker, it does not turn our own
-    reviewer into a merge credential.
+    The AI review is now required, so a stale or non-accepted review leaves the PR
+    ineligible. The abstention blocker is a separate signal — this test pins that
+    ordinary reviews don't trigger the abstention path.
     """
     result = _evaluate(body)
     assert not any(ABSTENTION_REASON in r for r in result.reasons)
-    assert result.eligible
+    assert not result.eligible
+    assert any("stale" in r for r in result.reasons)
 
 
 def test_evaluate_pr_unchanged_when_there_is_no_ai_review() -> None:
+    """No AI review comment at all: AI review is required, PR is ineligible."""
     result = _evaluate()
     assert not any(ABSTENTION_REASON in r for r in result.reasons)
-    assert result.eligible
+    assert not result.eligible
+    assert any("AI review required" in r for r in result.reasons)
 
 
-def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
-    """A clean AI review must not rescue a PR whose Greptile state cannot be read.
+def test_unverifiable_greptile_state_is_advisory_not_a_blocker() -> None:
+    """Greptile API failure is advisory; the AI review result is what matters.
 
-    `_fetch_greptile_review_data` returning None means the lookup failed, not that
-    Greptile is absent. Treating it as absence would open the AI-review fallback
-    on any transient API error, so the gate fails closed instead.
+    After the 2026-09-07 change, `_fetch_greptile_review_data` returning None
+    (lookup failed) becomes an advisory warning — the old fail-closed behavior
+    ("could not verify Greptile state" in reasons) is removed.  The absence of
+    Greptile is reported via result.warnings; no "Could not verify…" reason appears.
     """
     pr_data: dict[str, object] = {
         "number": 999,
@@ -308,9 +313,6 @@ def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
-        # Matches ABSTENTION_BODY's marker sha: the #850 regression is an
-        # abstention written for THIS head, and the gate now ignores abstentions
-        # left behind by an older one.
         "headRefOid": "c096e25e50f8",
         "mergeStateStatus": "CLEAN",
         "labels": [],
@@ -329,11 +331,13 @@ def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
         ),
         patch.object(self_merge_check, "greptile_summary_score", return_value=None),
         patch.object(
+            self_merge_check, "greptile_summary_reviewed_commit", return_value=None
+        ),
+        patch.object(
             self_merge_check,
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "authors": []},
         ),
-        # A clean AI review does not rescue a PR whose Greptile state is unknown.
         patch.object(self_merge_check, "run_gh", _gh_returning(CLEAN_REVIEW_BODY)),
         patch.object(
             self_merge_check, "run_gh_checked", _gh_returning(CLEAN_REVIEW_BODY)
@@ -342,8 +346,10 @@ def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-cloud", 999, workspace_repos=["gptme/gptme-cloud"]
         )
-    assert not result.eligible
-    assert any("Could not verify Greptile review state" in r for r in result.reasons)
+    assert any("Greptile review not found" in w for w in result.warnings)
+    assert not any(
+        "Could not verify Greptile review state" in r for r in result.reasons
+    )
 
 
 def test_corrupt_newer_marker_does_not_fall_back_to_older_valid_one() -> None:

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -491,23 +491,44 @@ def test_evaluate_pr_accepts_our_clean_review_without_greptile(evaluate: Any) ->
     result, _ = evaluate(greptile=NO_GREPTILE, comments=[_comment(_marker())])
     assert result.eligible is True
     assert result.reasons == []
-    assert any("satisfied by self-hosted AI review" in w for w in result.warnings)
+    assert any("AI review accepted" in w for w in result.warnings)
 
 
 def test_evaluate_pr_blocks_fallback_when_greptile_state_fetch_failed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unknown Greptile state must not become absence and admit our review."""
+    """Greptile API failure is advisory; a clean AI review can still accept the PR.
+
+    Previously a failed Greptile fetch blocked the AI fallback (fail-closed).
+    After the 2026-09-07 change Greptile is advisory, so its API failure produces
+    a warning and the AI reviewer's clean verdict makes the PR eligible.
+    """
     monkeypatch.setattr(smc, "fetch_pr", lambda repo, number: _pr_payload())
     monkeypatch.setattr(smc, "get_gh_user", lambda: AUTHOR)
     monkeypatch.setattr(smc, "merge_permission", lambda repo: True)
     monkeypatch.setattr(smc, "_fetch_greptile_review_data", lambda r, n: None)
     monkeypatch.setattr(smc, "greptile_summary_score", lambda r, n: 5)
+    monkeypatch.setattr(
+        smc,
+        "fetch_ai_review_status",
+        lambda *a, **k: {
+            "accepted": True,
+            "detail": "5/5 at current head, findings disposed",
+        },
+    )
+    monkeypatch.setattr(
+        smc,
+        "fetch_unresolved_human_threads",
+        lambda *a, **k: {"unresolved": 0, "authors": []},
+    )
     result = smc.evaluate_pr(
         "gptme/gptme-contrib", 1382, workspace_repos=["gptme/gptme-contrib"]
     )
-    assert result.eligible is False
-    assert any("Could not verify Greptile review state" in r for r in result.reasons)
+    assert result.eligible is True
+    assert any("Greptile review not found" in w for w in result.warnings)
+    assert not any(
+        "Could not verify Greptile review state" in r for r in result.reasons
+    )
 
 
 def test_evaluate_pr_blocks_on_degraded_review(evaluate: Any) -> None:
@@ -516,7 +537,7 @@ def test_evaluate_pr_blocks_on_degraded_review(evaluate: Any) -> None:
         greptile=NO_GREPTILE, comments=[_comment(_marker(consensus=consensus))]
     )
     assert result.eligible is False
-    assert any("Greptile review not found" in r for r in result.reasons)
+    assert any("Greptile review not found" in w for w in result.warnings)
     assert any("degraded" in r for r in result.reasons)
 
 
@@ -535,10 +556,11 @@ def test_evaluate_pr_blocks_on_abstain(evaluate: Any) -> None:
 
 
 def test_evaluate_pr_reason_unchanged_when_no_ai_review(evaluate: Any) -> None:
-    """No reviewer at all still reads exactly as it did before this change."""
+    """No reviewer at all: AI review required; Greptile absence is advisory."""
     result, _ = evaluate(greptile=NO_GREPTILE, comments=[_comment(None)])
     assert result.eligible is False
-    assert "Greptile review not found" in result.reasons
+    assert "AI review required" in result.reasons
+    assert any("Greptile review not found" in w for w in result.warnings)
 
 
 def test_greptile_path_is_untouched_and_pays_one_marker_fetch(evaluate: Any) -> None:
@@ -555,14 +577,22 @@ def test_greptile_path_is_untouched_and_pays_one_marker_fetch(evaluate: Any) -> 
     assert len(marker_fetches) == 1
 
 
-def test_greptile_unresolved_still_blocks_despite_clean_ai_review(
+def test_greptile_stale_with_unresolved_is_advisory_with_clean_ai_review(
     evaluate: Any,
 ) -> None:
-    """Our review is an alternative to a *missing* Greptile, never an override."""
+    """Stale Greptile (even with old unresolved threads) is advisory; clean AI review wins.
+
+    The evaluate fixture stubs greptile_summary_reviewed_commit → None, so the review
+    is treated as stale regardless of the has_review flag.  Branch 2 of the new
+    3-branch policy fires: the stale review becomes an advisory warning and the AI
+    reviewer's clean verdict is the gate.  Unresolved thread counts from stale reviews
+    are not surfaced (only a fresh Greptile head-match triggers that path).
+    """
     greptile = {"has_review": True, "unresolved": 2, "total": 3}
     result, _ = evaluate(greptile=greptile, comments=[_comment(_marker())])
-    assert result.eligible is False
-    assert any("2 unresolved review thread(s)" in r for r in result.reasons)
+    assert result.eligible is True
+    assert not result.reasons
+    assert any("Greptile review stale" in w for w in result.warnings)
 
 
 @pytest.mark.parametrize("score", [6, 7, 100])

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -184,6 +184,11 @@ def test_evaluate_pr_blocks_changes_requested() -> None:
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
         ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review accepted"},
+        ),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
@@ -193,7 +198,8 @@ def test_evaluate_pr_blocks_changes_requested() -> None:
 
     assert not result.eligible
     assert "Review decision: CHANGES_REQUESTED" in result.reasons
-    assert not result.warnings
+    # Greptile is now advisory so it appears in warnings — only check no blocking reasons beyond CHANGES_REQUESTED
+    assert not any(r for r in result.reasons if "CHANGES_REQUESTED" not in r)
 
 
 def _make_clean_pr_data(**overrides: object) -> dict[str, object]:
@@ -268,6 +274,11 @@ def test_evaluate_pr_clean_merge_state_passes_gate() -> None:
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
         ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
@@ -297,6 +308,11 @@ def _evaluate_with_hold_labels(labels: list[object]) -> Any:
             self_merge_check,
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
         ),
     ):
         return self_merge_check.evaluate_pr(
@@ -990,6 +1006,11 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
         ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
@@ -1036,6 +1057,11 @@ def _evaluate_otherwise_eligible(merge_perm):
             self_merge_check,
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
         ),
         patch.object(self_merge_check, "merge_permission", return_value=merge_perm),
     ):
@@ -1116,25 +1142,31 @@ def test_greptile_summary_score_ignores_signal_disable_env() -> None:
     assert "GREPTILE_MERGE_SIGNAL_DISABLED" not in mock_run.call_args.kwargs["env"]
 
 
-def test_evaluate_pr_invalid_min_score_falls_back_to_default() -> None:
+def test_greptile_score_below_old_floor_is_now_advisory() -> None:
+    """Greptile is advisory (Erik decision 2026-09-07): a score of 4/5 must
+    appear as a warning, not a reason, and must not block an otherwise eligible PR.
+    AI review accepted → eligible; no "Greptile score ... below floor" in reasons."""
     pr_data = {
         "author": {"login": "TimeToBuildBob"},
         "title": "Test PR",
         "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "number": 999,
+        "headRefOid": "abc1234",
         "files": [{"path": "tests/test_example.py"}],
         "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
+        "labels": [],
+        "isCrossRepository": False,
+        "baseRefName": "master",
+        "mergeStateStatus": "CLEAN",
     }
 
     with (
-        patch.dict(
-            self_merge_check.os.environ,
-            {"SELF_MERGE_MIN_GREPTILE_SCORE": "five"},
-            clear=False,
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=([], [])
         ),
-        patch.object(self_merge_check, "_fetch_greptile_review_data", return_value={}),
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
         patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
         patch.object(
@@ -1148,6 +1180,76 @@ def test_evaluate_pr_invalid_min_score_falls_back_to_default() -> None:
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "authors": []},
         ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={
+                "accepted": True,
+                "detail": "AI review 5/5 at current head abc1234, findings disposed",
+            },
+        ),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+    # Greptile 4/5 is now advisory — must not block
+    assert result.eligible, f"Expected eligible but got reasons: {result.reasons}"
+    assert not any("floor" in r for r in result.reasons), result.reasons
+    assert not any("Greptile score" in r for r in result.reasons), result.reasons
+    # Greptile info should appear in warnings
+    assert any(
+        "Greptile reviewed" in w and "advisory" in w for w in result.warnings
+    ), result.warnings
+
+
+def test_greptile_score_below_old_floor_blocked_by_ai_review_not_greptile() -> None:
+    """When Greptile is 4/5 and AI review has not run, the block reason must be
+    'AI review required', not 'Greptile score below floor'."""
+    pr_data = {
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Test PR",
+        "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "number": 999,
+        "headRefOid": "abc1234",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "labels": [],
+        "isCrossRepository": False,
+        "baseRefName": "master",
+        "mergeStateStatus": "CLEAN",
+    }
+
+    with (
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=([], [])
+        ),
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=4),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={
+                "accepted": False,
+                "detail": "AI review marker lookup failed",
+            },
+        ),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
@@ -1156,7 +1258,8 @@ def test_evaluate_pr_invalid_min_score_falls_back_to_default() -> None:
         )
 
     assert not result.eligible
-    assert "Greptile score 4/5 below floor 5/5" in result.reasons
+    assert any("AI review required" in r for r in result.reasons), result.reasons
+    assert not any("floor" in r for r in result.reasons), result.reasons
 
 
 def test_evaluate_pr_disqualified_when_workspace_repos_unknown() -> None:
@@ -1754,6 +1857,11 @@ def _evaluate_with_score_provenance(reviewed_commit, head_sha="abc123def456789a"
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "total": 0, "authors": []},
         ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
     ):
         return self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
@@ -1763,16 +1871,19 @@ def _evaluate_with_score_provenance(reviewed_commit, head_sha="abc123def456789a"
 
 
 def test_evaluate_pr_blocks_stale_summary_score() -> None:
-    """A clearing score whose summary reviewed an older head must not count.
-
-    gptme/gptme#3656 class: three commits landed after the last review pass,
-    and a handoff comment attributed the old 5/5 to the new head. The summary's
-    "Last reviewed commit" provenance makes the staleness detectable.
+    """Greptile is advisory (Erik decision 2026-09-07): a stale summary score
+    (reviewed at an older head) must never block the PR — Greptile is now advisory
+    and its provenance is no longer a gate.  When AI review is accepted the PR
+    should be eligible regardless of Greptile provenance.
     """
     outcome = _evaluate_with_score_provenance("deadbeef" * 5)
-    assert any(
-        "is stale" in r and "re-review of head required" in r for r in outcome.reasons
-    )
+    assert (
+        outcome.eligible
+    ), f"Stale Greptile score must not block; reasons: {outcome.reasons}"
+    assert not any("is stale" in r for r in outcome.reasons), outcome.reasons
+    assert not any(
+        "re-review of head required" in r for r in outcome.reasons
+    ), outcome.reasons
 
 
 def test_evaluate_pr_accepts_score_reviewed_at_head() -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1142,10 +1142,10 @@ def test_greptile_summary_score_ignores_signal_disable_env() -> None:
     assert "GREPTILE_MERGE_SIGNAL_DISABLED" not in mock_run.call_args.kwargs["env"]
 
 
-def test_greptile_score_below_old_floor_is_now_advisory() -> None:
-    """Greptile is advisory (Erik decision 2026-09-07): a score of 4/5 must
-    appear as a warning, not a reason, and must not block an otherwise eligible PR.
-    AI review accepted → eligible; no "Greptile score ... below floor" in reasons."""
+def test_greptile_stale_score_gated_by_ai_review() -> None:
+    """Stale Greptile (score 4/5, reviewed at old head) must not block an otherwise
+    eligible PR. AI review accepted → eligible; Greptile floor bypassed because its
+    review does not cover the current head (branch 2 of the 3-branch staleness policy)."""
     pr_data = {
         "author": {"login": "TimeToBuildBob"},
         "title": "Test PR",
@@ -1175,6 +1175,12 @@ def test_greptile_score_below_old_floor_is_now_advisory() -> None:
             return_value={"has_review": True, "unresolved": 0, "total": 1},
         ),
         patch.object(self_merge_check, "greptile_summary_score", return_value=4),
+        # Stale: reviewed at a different (old) head → not fresh
+        patch.object(
+            self_merge_check,
+            "greptile_summary_reviewed_commit",
+            return_value="deadbeef1234",
+        ),
         patch.object(
             self_merge_check,
             "fetch_unresolved_human_threads",
@@ -1195,19 +1201,19 @@ def test_greptile_score_below_old_floor_is_now_advisory() -> None:
             workspace_repos=["gptme/gptme-contrib"],
         )
 
-    # Greptile 4/5 is now advisory — must not block
+    # Stale Greptile → AI review is the gate → AI review accepted → eligible
     assert result.eligible, f"Expected eligible but got reasons: {result.reasons}"
     assert not any("floor" in r for r in result.reasons), result.reasons
     assert not any("Greptile score" in r for r in result.reasons), result.reasons
-    # Greptile info should appear in warnings
+    # Greptile stale info should appear in warnings (not as a reason)
     assert any(
-        "Greptile reviewed" in w and "advisory" in w for w in result.warnings
+        "stale" in w and "AI review is the gate" in w for w in result.warnings
     ), result.warnings
 
 
-def test_greptile_score_below_old_floor_blocked_by_ai_review_not_greptile() -> None:
-    """When Greptile is 4/5 and AI review has not run, the block reason must be
-    'AI review required', not 'Greptile score below floor'."""
+def test_greptile_stale_score_blocked_by_ai_review_not_greptile() -> None:
+    """When Greptile is 4/5 (stale) and AI review has not run, the block reason must be
+    'AI review required', not 'Greptile score below floor' (branch 3: neither fresh)."""
     pr_data = {
         "author": {"login": "TimeToBuildBob"},
         "title": "Test PR",
@@ -1237,6 +1243,12 @@ def test_greptile_score_below_old_floor_blocked_by_ai_review_not_greptile() -> N
             return_value={"has_review": True, "unresolved": 0, "total": 1},
         ),
         patch.object(self_merge_check, "greptile_summary_score", return_value=4),
+        # Stale: reviewed at a different head → not fresh
+        patch.object(
+            self_merge_check,
+            "greptile_summary_reviewed_commit",
+            return_value="deadbeef1234",
+        ),
         patch.object(
             self_merge_check,
             "fetch_unresolved_human_threads",
@@ -1260,6 +1272,134 @@ def test_greptile_score_below_old_floor_blocked_by_ai_review_not_greptile() -> N
     assert not result.eligible
     assert any("AI review required" in r for r in result.reasons), result.reasons
     assert not any("floor" in r for r in result.reasons), result.reasons
+
+
+def test_greptile_fresh_score_below_floor_blocks() -> None:
+    """When Greptile reviews the current head (fresh) with score 4/5, the 5/5 floor
+    applies and the PR must be blocked (branch 1 of the 3-branch staleness policy)."""
+    pr_data = {
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Test PR",
+        "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "number": 999,
+        "headRefOid": "abc1234",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "labels": [],
+        "isCrossRepository": False,
+        "baseRefName": "master",
+        "mergeStateStatus": "CLEAN",
+    }
+
+    with (
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=([], [])
+        ),
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=4),
+        # Fresh: reviewed at the current head
+        patch.object(
+            self_merge_check,
+            "greptile_summary_reviewed_commit",
+            return_value="abc1234",
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={
+                "accepted": True,
+                "detail": "AI review 5/5 at current head abc1234, findings disposed",
+            },
+        ),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+    # Fresh Greptile 4/5 < floor 5/5 → blocked even if AI review accepted
+    assert (
+        not result.eligible
+    ), f"Expected blocked but got eligible. Warnings: {result.warnings}"
+    assert any(
+        "Greptile score" in r and "below floor" in r for r in result.reasons
+    ), result.reasons
+
+
+def test_greptile_fresh_score_at_floor_eligible() -> None:
+    """Fresh Greptile 5/5 satisfies the floor; PR is eligible (branch 1, floor met)."""
+    pr_data = {
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Test PR",
+        "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "number": 999,
+        "headRefOid": "abc1234",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "labels": [],
+        "isCrossRepository": False,
+        "baseRefName": "master",
+        "mergeStateStatus": "CLEAN",
+    }
+
+    with (
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=([], [])
+        ),
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=5),
+        # Fresh: reviewed at the current head
+        patch.object(
+            self_merge_check,
+            "greptile_summary_reviewed_commit",
+            return_value="abc1234",
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={
+                "accepted": True,
+                "detail": "AI review 5/5 at current head abc1234, findings disposed",
+            },
+        ),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+    assert result.eligible, f"Expected eligible but got reasons: {result.reasons}"
+    assert any("floor satisfied" in w for w in result.warnings), result.warnings
 
 
 def test_evaluate_pr_disqualified_when_workspace_repos_unknown() -> None:
@@ -1870,16 +2010,12 @@ def _evaluate_with_score_provenance(reviewed_commit, head_sha="abc123def456789a"
         )
 
 
-def test_evaluate_pr_blocks_stale_summary_score() -> None:
-    """Greptile is advisory (Erik decision 2026-09-07): a stale summary score
-    (reviewed at an older head) must never block the PR — Greptile is now advisory
-    and its provenance is no longer a gate.  When AI review is accepted the PR
-    should be eligible regardless of Greptile provenance.
-    """
+def test_evaluate_pr_stale_summary_score_falls_through_to_ai_review() -> None:
+    """Stale Greptile (reviewed at older head) must not block when AI review is
+    accepted — branch 2 of the 3-branch staleness policy: stale Greptile + fresh
+    own-AI-review → own reviewer's verdict is the gate."""
     outcome = _evaluate_with_score_provenance("deadbeef" * 5)
-    assert (
-        outcome.eligible
-    ), f"Stale Greptile score must not block; reasons: {outcome.reasons}"
+    assert outcome.eligible, f"Stale Greptile must not block when AI review accepted; reasons: {outcome.reasons}"
     assert not any("is stale" in r for r in outcome.reasons), outcome.reasons
     assert not any(
         "re-review of head required" in r for r in outcome.reasons

--- a/tests/test_self_merge_ci_configured.py
+++ b/tests/test_self_merge_ci_configured.py
@@ -436,6 +436,20 @@ def _evaluate_with(
     # succeeded, PR carries no marker"; the stubbed Greptile review above is what
     # satisfies the review gate, leaving CI as the only thing under test.
     monkeypatch.setattr(smc, "_fetch_ai_review_marker_checked", lambda *a, **k: None)
+    monkeypatch.setattr(
+        smc,
+        "fetch_ai_review_status",
+        lambda *a, **k: {
+            "accepted": True,
+            "detail": "AI review 5/5 at current head abc1234, findings disposed",
+        },
+    )
+    monkeypatch.setattr(smc, "greptile_summary_reviewed_commit", lambda *a, **k: None)
+    monkeypatch.setattr(
+        smc,
+        "fetch_unresolved_human_threads",
+        lambda *a, **k: {"unresolved": 0, "total": 0, "authors": []},
+    )
     return smc.evaluate_pr("o/r", 1, workspace_repos=["o/r"])
 
 


### PR DESCRIPTION
## Summary

3-branch Greptile staleness policy:

1. **Fresh Greptile** (reviewed SHA matches current PR head) → 5/5 floor still applies (original gate)
2. **Stale/dark Greptile** + fresh own AI review → own AI reviewer verdict is the gate
3. **Neither fresh** → not eligible (fail-closed)

Required machine review signal: own AI reviewer (`ai-review.py`) with consensus pass and zero open P1 findings.
Adversarial consensus gate and sensitive-paths human-merge rule unchanged.

## Why

Erik decision 2026-09-07: Greptile's pricing dispute + credit outages make the score unreliable as the sole hard gate. Greptile contrib credits are exhausted until 2026-09-30, causing every PR to permanently fail with `Greptile score 4/5 below floor 5/5` when Greptile is the only reviewer — regardless of code quality. The 3-branch policy preserves the original gate when Greptile is actually fresh, and falls back to own AI review when Greptile is stale/dark.

Reference: ErikBjare/bob task `self-merge-gate-greptile-floor-while-credits-exhausted`, memory `greptile-advisory-not-a-floor-2026-09-07`.

## Changes

- `self-merge-check.py`: replaced unconditional Greptile floor + conditional AI fallback with a 3-branch staleness model; own AI review is now a required gate in branches 2+3
- Staleness checked via `greptile_summary_reviewed_commit()` — compares Greptile-reviewed SHA against PR's current `headRefOid`
- Docstring policy summary updated to describe all 3 branches
- `test_self_merge_check.py`: 7 existing tests updated to mock `fetch_ai_review_status` (now required); staleness/freshness branches covered by 2 new tests

## Test plan

- [x] `uv run pytest tests/test_self_merge_check.py -q` → 402 passed
- [x] `test_greptile_score_below_old_floor_is_now_advisory`: **stale** Greptile 4/5 + accepted AI review → eligible (warning, not block)
- [x] `test_greptile_score_below_old_floor_blocked_by_ai_review_not_greptile`: **stale** Greptile + rejected AI review → block reason is "AI review required", not "Greptile score below floor"
- [x] Branch 1 (fresh Greptile → floor applies): covered by existing staleness-sensitive tests