### PR TITLE
fix(gptme-usage): apply cache cost heuristics to GPT-5.6 routes

### DIFF
--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -418,9 +418,15 @@ _CACHE_PRICING_PROVIDER: dict[tuple[str, str], str] = {
     ("copilot-cli", "sonnet"): "anthropic",
     ("codex", "gpt-5.4"): "openai",
     ("codex", "gpt-5.5"): "openai",
+    ("codex", "gpt-5.6-sol"): "openai",
+    ("codex", "gpt-5.6-terra"): "openai",
+    ("codex", "gpt-5.6-luna"): "openai",
     ("copilot-cli", "gpt-5.4"): "openai",
     ("gptme", "gpt-5.4"): "openai",
     ("gptme", "gpt-5.5"): "openai",
+    ("gptme", "gpt-5.6-sol"): "openai",
+    ("gptme", "gpt-5.6-terra"): "openai",
+    ("gptme", "gpt-5.6-luna"): "openai",
     # kimi-k2.6: no cache pricing exposed on OpenRouter
 }
 
@@ -510,6 +516,9 @@ SUBSCRIPTION_BACKED_MODELS: set[tuple[str, str]] = {
     ("grok-build", "grok-build"),
     ("codex", "gpt-5.4"),
     ("codex", "gpt-5.5"),
+    ("codex", "gpt-5.6-sol"),
+    ("codex", "gpt-5.6-terra"),
+    ("codex", "gpt-5.6-luna"),
     # copilot-cli: both full model name (for pricing-table lookups from existing
     # session records, where model="claude-sonnet-4.6") and short alias (to match
     # HARNESS_TIERS canonical keys after the 2026-08-01 naming alignment). Once
@@ -522,6 +531,9 @@ SUBSCRIPTION_BACKED_MODELS: set[tuple[str, str]] = {
     ("copilot-cli", "gpt-5.4"),
     ("gptme", "gpt-5.4"),
     ("gptme", "gpt-5.5"),
+    ("gptme", "gpt-5.6-sol"),
+    ("gptme", "gpt-5.6-terra"),
+    ("gptme", "gpt-5.6-luna"),
 }
 
 # Tier ordering for scoring

--- a/packages/gptme-usage/tests/test_gpt56_cost.py
+++ b/packages/gptme-usage/tests/test_gpt56_cost.py
@@ -1,0 +1,68 @@
+"""GPT-5.6 routes retain the existing subscription/cache cost heuristics."""
+
+import pytest
+from gptme_usage.harness_models import (
+    HarnessQuotaConfig,
+    estimate_session_cost,
+    estimate_tokens_from_duration,
+)
+
+pytestmark = [
+    pytest.mark.parametrize("harness", ["codex", "gptme"]),
+    pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]),
+]
+
+
+@pytest.fixture()
+def config(harness: str, model: str) -> HarnessQuotaConfig:
+    # Deliberately synthetic prices and throughput: test the cost contract,
+    # independent of any agent's config or current vendor rates.
+    return HarnessQuotaConfig(
+        price_table={(harness, model): (4.0, 20.0)},
+        tps_table={(harness, model): 1000.0},
+        model_routes={model: f"openai-subscription/{model}"},
+    )
+
+
+def test_total_only_uses_subscription_heuristic(
+    harness: str, model: str, config: HarnessQuotaConfig
+) -> None:
+    assert estimate_session_cost(
+        harness, model, token_count=1_000_000, config=config
+    ) == pytest.approx(2.0)
+
+
+def test_duration_tokens_use_subscription_heuristic(
+    harness: str, model: str, config: HarnessQuotaConfig
+) -> None:
+    tokens = estimate_tokens_from_duration(harness, model, 60, config=config)
+    assert tokens == 60_000
+    assert estimate_session_cost(
+        harness, model, token_count=tokens, config=config
+    ) == pytest.approx(0.12)
+
+
+def test_observed_breakdown_discounts_only_cache_reads(
+    harness: str, model: str, config: HarnessQuotaConfig
+) -> None:
+    # $4 input + $20 output + $4 cache creation + $2 cache reads.
+    # An inconsistent total must not override the observed breakdown.
+    assert estimate_session_cost(
+        harness,
+        model,
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_creation_tokens=1_000_000,
+        cache_read_tokens=1_000_000,
+        token_count=99_000_000,
+        config=config,
+    ) == pytest.approx(30.0)
+
+
+def test_provider_route_uses_same_cost(
+    harness: str, model: str, config: HarnessQuotaConfig
+) -> None:
+    routed_model = f"openai-subscription/{model}" if harness == "gptme" else model
+    assert estimate_session_cost(
+        harness, routed_model, cache_read_tokens=1_000_000, config=config
+    ) == pytest.approx(2.0)


### PR DESCRIPTION
GPT-5.6 sol/terra/luna were missing from the upstream subscription set and cache-provider map for `codex` and `gptme`. Total-token-only estimates returned `None`, so duration-based consumers could fall back to full input pricing; observed cache-read tokens also used the full input rate. Register all six pairs so they use the existing OpenAI cache heuristic. A 60-second gptme/sol duration estimate becomes $1.20 instead of $2.40 with the consuming agent's configured prices/TPS.

This preserves existing prices, throughput estimates, and the 0.5 cache factor. The amounts are modeled equivalents, not subscription charges. Consumers recomputing from raw token/duration fields pick up the correction; stored reported costs are unchanged.

Validation: 24 new regression cases fail before the change and pass afterward; all 89 `gptme-usage` tests pass. Tests use synthetic prices and cover total-only input, duration-derived tokens, observed breakdown precedence, and configured provider routes across both harnesses and all three model names. All pre-commit hooks pass. A read-only replay of 1,585 frozen consumer rows matches the predicted corrected estimates; all 101 duration-only estimates halve, and 1,483 observed-breakdown rows also change.
