### PR TITLE
feat(self-merge): gptme core eligibility by diff shape, not path category

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -677,7 +677,7 @@ def fetch_pr(repo: str, number: int) -> dict[str, Any]:
             "--repo",
             repo,
             "--json",
-            "number,title,url,author,statusCheckRollup,isDraft,state,reviewDecision,headRefOid,mergeStateStatus,isCrossRepository,baseRefName,labels",
+            "number,title,body,url,author,statusCheckRollup,isDraft,state,reviewDecision,headRefOid,mergeStateStatus,isCrossRepository,baseRefName,labels",
         ]
     )
     if not raw:
@@ -2369,6 +2369,233 @@ def classify_category(
     ]
 
 
+# --- gptme/gptme core: diff-shape eligibility, not path category ---
+#
+# Erik (2026-09-07), on gptme#3620's gate message: "The PR is self-merge
+# ineligible due to gptme/util/reduce.py being outside the bot's allowed
+# category — manual merge needed. <-- path alone doesn't feel like a good
+# eligibility gate, at least not for this PR". Erik's own merge history routes
+# on the *shape* of a diff, not on which directory it lands in (workspace
+# brain repo, knowledge/strategic/2026-09-07-auto-merge-analysis.md §3/§5).
+#
+# For gptme/gptme only, classify_category's "must fall into an allowed
+# category" requirement stops applying (see evaluate_pr). The sensitive-path/
+# bot-config/spec-like-doc hard stops that classify_category also enforces
+# still apply — those are the one thing Erik has said belongs to a human
+# every time (auto-merge-analysis §3 cluster 3). In their place, these
+# detectors flag the diff *shapes* Erik has repeatedly asked to see himself:
+# new public CLI surface, new config schema, a wholly new module, a new docs
+# page, an unmotivated `feat` with no linked issue, and anything touching
+# LLM/server/provider routing or auth. A PR triggering none of these — and
+# otherwise clean on CI, AI review, Greptile, and human threads — is eligible
+# regardless of which directory it touches. Every other repo's
+# classify_category call is untouched by this block.
+_GPTME_CORE_REPO = "gptme/gptme"
+
+# A newly *added* .py file at most one subdirectory below gptme/ — deep
+# enough to catch a new subpackage module (gptme/hooks/guardrails.py,
+# gptme#3695) as well as a bare top-level one (gptme/error_hintkit.py,
+# gptme#3706), shallow enough that it doesn't also match a test file three
+# levels down (gptme/hooks/tests/test_x.py — is_test_file already excludes
+# those, but the depth bound keeps this detector's own intent legible).
+_GPTME_CORE_NEW_MODULE_RE = re.compile(r"^gptme/(?:[^/]+/)?[^/]+\.py$")
+# A dataclass-style attribute declaration added inside gptme/config/ — how
+# gptme declares its config schema (gptme/config/models.py: `field_name: Type
+# = field(...)` at class scope, indented). Matched against the added line's
+# *own* indentation, so a top-level statement (import, function def) does not
+# false-positive.
+_GPTME_CORE_CONFIG_FIELD_RE = re.compile(r"^\s{4,}[A-Za-z_][A-Za-z0-9_]*\s*:\s*\S")
+_GPTME_CORE_ISSUE_REF_RE = re.compile(r"#\d+")
+# gptme/llm/ (model calls), gptme/server/ (HTTP surface + auth), gptme/oauth/
+# and gptme/credentials.py (auth), gptme/providers/ and gptme/cli/auth.py
+# (provider routing / auth). Generic auth/oauth keyword matching already
+# exists in is_sensitive_path and still applies everywhere; this list adds
+# the LLM/server/provider-routing surface that keyword isn't aimed at.
+_GPTME_CORE_SENSITIVE_SURFACE_PREFIXES = (
+    "gptme/llm/",
+    "gptme/server/",
+    "gptme/providers/",
+    "gptme/oauth/",
+    "gptme/credentials.py",
+    "gptme/cli/auth.py",
+)
+
+
+def _iter_json_documents(text: str) -> Iterator[Any]:
+    """Yield successive JSON values from paginated compact API/jq output.
+
+    `gh api --paginate --jq` concatenates one JSON value per page/item without
+    a guaranteed separator (usually newlines, but not contractually so), so
+    this walks the text with a raw decoder instead of splitting on lines.
+    """
+    decoder = json.JSONDecoder()
+    idx = 0
+    n = len(text)
+    while idx < n:
+        while idx < n and text[idx].isspace():
+            idx += 1
+        if idx >= n:
+            break
+        try:
+            val, end = decoder.raw_decode(text, idx)
+        except json.JSONDecodeError:
+            break
+        yield val
+        idx = end
+
+
+def _fetch_pr_file_shapes(repo: str, number: int) -> list[dict[str, Any]]:
+    """Per-file status + patch text, for the gptme/gptme diff-shape detectors only.
+
+    Separate from `_fetch_pr_files` (which only needs `.filename`, used by
+    every other repo's category classification via classify_category): patch
+    text is the bulk of the file-list payload, so fetching it is gated to the
+    one repo that needs it, and only reached once classify_category's
+    replacement for gptme/gptme has ruled out the cheaper sensitive/bot-
+    config/spec-doc hard stops.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/pulls/{number}/files",
+                "--paginate",
+                "--jq",
+                ".[] | {path: .filename, status: .status, patch: .patch}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [doc for doc in _iter_json_documents(result.stdout) if isinstance(doc, dict)]
+
+
+def _gptme_core_added_lines(patch: str | None) -> list[str]:
+    """Added (`+`-prefixed, non-hunk-header) lines of a unified diff patch."""
+    if not patch:
+        return []
+    return [
+        line[1:]
+        for line in patch.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+
+
+def gptme_core_route_to_erik_reasons(
+    title: str, body: str, file_shapes: list[dict[str, Any]]
+) -> list[str]:
+    """Diff-shape checks that route a gptme/gptme PR to Erik.
+
+    Each reason quotes, in one clause, the cluster of Erik's block reasons it
+    encodes (workspace brain repo,
+    knowledge/strategic/2026-09-07-auto-merge-analysis.md §3). Returns an
+    empty list when none of the shapes are present — evaluate_pr then treats
+    the PR as eligible on diff shape, regardless of which directory it
+    touches (subject to CI/AI-review/Greptile/human-thread checks elsewhere).
+    """
+    reasons: list[str] = []
+
+    new_click_surface: set[str] = set()
+    new_cli_files: set[str] = set()
+    new_config_keys: set[str] = set()
+    new_modules: set[str] = set()
+    new_docs_pages: set[str] = set()
+
+    for entry in file_shapes:
+        path = str(entry.get("path", "")).replace("\\", "/").removeprefix("./")
+        status = entry.get("status", "")
+        added_lines = _gptme_core_added_lines(cast("str | None", entry.get("patch")))
+
+        if status == "added" and path.startswith("gptme/cli/"):
+            new_cli_files.add(path)
+        if any(
+            "@click.option(" in line or "@click.command(" in line
+            for line in added_lines
+        ):
+            new_click_surface.add(path)
+        if path.startswith("gptme/config/") and any(
+            _GPTME_CORE_CONFIG_FIELD_RE.match(line) for line in added_lines
+        ):
+            new_config_keys.add(path)
+        if (
+            status == "added"
+            and not is_test_file(path)
+            and _GPTME_CORE_NEW_MODULE_RE.match(path)
+        ):
+            new_modules.add(path)
+        if status == "added" and path.startswith("docs/"):
+            new_docs_pages.add(path)
+
+    if new_click_surface or new_cli_files:
+        reasons.append(
+            "New CLI surface ("
+            + ", ".join(sorted(new_click_surface | new_cli_files))
+            + "): Erik — \"I don't like adding a whole set of --arguments to "
+            "the default gptme CLI\" / \"can't justify a whole 'nother CLI "
+            'flag" (auto-merge-analysis §3 cluster 4, e.g. gptme#3209, #3296)'
+        )
+    if new_config_keys:
+        reasons.append(
+            "New config schema key ("
+            + ", ".join(sorted(new_config_keys))
+            + "): core config surface is Erik's call, same cluster as new CLI "
+            "flags (auto-merge-analysis §3 cluster 4)"
+        )
+    if new_modules:
+        reasons.append(
+            "New module under gptme/ ("
+            + ", ".join(sorted(new_modules))
+            + "): Erik — public-surface proliferation and naming/placement is "
+            "his taste to set (auto-merge-analysis §3 cluster 4, e.g. #3529 "
+            "\"'harness' is kinda vague\")"
+        )
+    if new_docs_pages:
+        reasons.append(
+            "New docs page under docs/ ("
+            + ", ".join(sorted(new_docs_pages))
+            + "): Erik has flagged duplicate/misplaced doc pages before "
+            "(auto-merge-analysis §3 cluster 4, e.g. #3178)"
+        )
+
+    normalized_title = title.strip()
+    if re.match(r"(?i)^feat[:(]", normalized_title):
+        if not _GPTME_CORE_ISSUE_REF_RE.search(title) and not (
+            body and _GPTME_CORE_ISSUE_REF_RE.search(body)
+        ):
+            reasons.append(
+                "feat: title with no #issue reference in title or body: Erik — "
+                '"Idk if this is an actually useful feature" / "kinda low '
+                'value" (auto-merge-analysis §3 cluster 5, e.g. gptme#2836, '
+                "#2979)"
+            )
+
+    sensitive_surface = sorted(
+        {
+            str(entry.get("path", "")).replace("\\", "/").removeprefix("./")
+            for entry in file_shapes
+            if str(entry.get("path", ""))
+            .replace("\\", "/")
+            .removeprefix("./")
+            .startswith(_GPTME_CORE_SENSITIVE_SURFACE_PREFIXES)
+        }
+    )
+    if sensitive_surface:
+        reasons.append(
+            "Touches gptme/llm/, gptme/server/, auth, or provider routing ("
+            + ", ".join(sensitive_surface)
+            + '): Erik — "avoid making too much auth cloud-specific"; silent '
+            "auth/provider misrouting is exactly this class (auto-merge-"
+            "analysis §3 cluster 3, e.g. gptme#2820, #2901)"
+        )
+
+    return reasons
+
+
 def _check_workspace_repo(
     repo: str, workspace_repos: list[str] | None
 ) -> tuple[list[str], list[str]]:
@@ -2733,9 +2960,39 @@ def evaluate_pr(
             f"from: {authors}"
         )
 
-    category, category_reasons = classify_category(files, repo=repo)
-    result.category = category
-    result.reasons.extend(category_reasons)
+    if repo == _GPTME_CORE_REPO:
+        # gptme/gptme: diff shape, not path category (see the block above
+        # classify_category's definition). The sensitive/bot-config/spec-
+        # like-doc hard stops classify_category also enforces still apply
+        # here; only the "must fall into an allowed category" requirement is
+        # replaced, and only for this repo.
+        if any(is_sensitive_path(path) for path in files):
+            result.category = None
+            result.reasons.append("Touches sensitive/security/infra paths")
+        elif any(is_bot_config(path) for path in files):
+            result.category = None
+            result.reasons.append(
+                "Bot/CI config changes require human review under current policy"
+            )
+        elif any(is_doc_file(path) and is_spec_like_doc(path) for path in files):
+            result.category = None
+            result.reasons.append(
+                "Touches spec-like documentation requiring human review"
+            )
+        else:
+            file_shapes = _fetch_pr_file_shapes(repo, number)
+            shape_reasons = gptme_core_route_to_erik_reasons(
+                title, cast("str", pr.get("body") or ""), file_shapes
+            )
+            if shape_reasons:
+                result.category = None
+                result.reasons.extend(shape_reasons)
+            else:
+                result.category = "gptme-core-diff-shape-eligible"
+    else:
+        category, category_reasons = classify_category(files, repo=repo)
+        result.category = category
+        result.reasons.extend(category_reasons)
 
     review_decision = pr.get("reviewDecision")
     if review_decision == "CHANGES_REQUESTED":

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -2502,3 +2502,508 @@ def test_classify_category_legacy_lookalikes_are_not_test_only(path: str) -> Non
 )
 def test_genuine_test_paths_still_match(path: str) -> None:
     assert self_merge_check.is_test_file(path) is True
+
+
+# --- gptme/gptme core: diff-shape eligibility, not path category ---
+#
+# Erik (2026-09-07), on gptme#3620's gate message: "path alone doesn't feel
+# like a good eligibility gate, at least not for this PR". Corpus fixtures
+# below capture real file lists (`gh pr view --json title,body,files`, 3
+# calls total) for the PRs named in
+# tasks/gptme-core-self-merge-diff-shape-not-path-category.md; patch text is
+# synthesized to match each PR's documented shape (not re-fetched — the
+# detectors only need to see *some* added line of the relevant shape).
+
+
+def test_gptme_core_cache_fix_no_route_reasons() -> None:
+    """gptme#3620: cache fix in gptme/util/reduce.py + tests, clean review.
+
+    Modifies an existing core-internal module and adds tests only — no new
+    CLI/config/module/docs surface, no unlinked feat, nothing sensitive.
+    Must produce zero route-to-Erik reasons (diff-shape eligible).
+    """
+    file_shapes = [
+        {
+            "path": "gptme/util/reduce.py",
+            "status": "modified",
+            "patch": (
+                "@@ -10,6 +10,10 @@\n"
+                "+_CACHE: dict[str, Message] = {}\n"
+                "+\n"
+                "+def _cache_key(model: str, msgs: list[Message]) -> str:\n"
+                "+    return hashlib.sha256(...).hexdigest()\n"
+            ),
+        },
+        {
+            "path": "tests/conftest.py",
+            "status": "modified",
+            "patch": (
+                "@@ -1,3 +1,22 @@\n"
+                "+@pytest.fixture(autouse=True)\n"
+                "+def _clear_reduce_cache():\n"
+                "+    yield\n"
+            ),
+        },
+        {
+            "path": "tests/test_reduce.py",
+            "status": "added",
+            "patch": (
+                "@@ -0,0 +1,296 @@\n"
+                "+def test_proactive_summarize_cache_hit_skips_llm():\n"
+                "+    pass\n"
+            ),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "fix(reduce): cache proactive_summarize_log result by middle-message content hash",
+        "Phase 4.1 of the append-only request construction audit. "
+        "Phases 2+3 landed in #3616.",
+        file_shapes,
+    )
+    assert reasons == []
+
+
+def test_gptme_core_new_hook_module_and_config_routes() -> None:
+    """gptme#3695: new gptme/hooks/guardrails.py hook module + config surface.
+
+    A wholly new module two levels under gptme/, plus a new env-gated config
+    knob declared in gptme/config/ — must route to Erik on the new-module (and,
+    when the config field is present, config) reason.
+    """
+    file_shapes = [
+        {
+            "path": "gptme/hooks/__init__.py",
+            "status": "modified",
+            "patch": (
+                "@@ -1,3 +1,8 @@\n" "+register_hook(guardrails_hook, priority=200)\n"
+            ),
+        },
+        {
+            "path": "gptme/hooks/guardrails.py",
+            "status": "added",
+            "patch": (
+                "@@ -0,0 +1,677 @@\n" "+def guardrails_hook(...):\n" "+    pass\n"
+            ),
+        },
+        {
+            "path": "gptme/config/models.py",
+            "status": "modified",
+            "patch": (
+                "@@ -260,6 +260,9 @@ class HooksConfig:\n"
+                '+    guardrails_mode: str = field(default="shadow")\n'
+            ),
+        },
+        {
+            "path": "tests/test_guardrails_policy.py",
+            "status": "added",
+            "patch": ("@@ -0,0 +1,43 @@\n+def test_shell_policy(): pass\n"),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "feat(hooks): add guardrails policy hook",
+        "Resolves the three design questions from RFC #3598 ... Closes #3598",
+        file_shapes,
+    )
+    assert any("New module under gptme/" in r and "guardrails.py" in r for r in reasons)
+    assert any("New config schema key" in r and "models.py" in r for r in reasons)
+    # This PR *does* link an issue (#3598), so the unlinked-feat reason must
+    # not also fire — only the new-module/config reasons should.
+    assert not any("no #issue reference" in r for r in reasons)
+
+
+def test_gptme_core_new_top_level_module_routes() -> None:
+    """gptme#3706: new top-level gptme/error_hintkit.py module.
+
+    A bare new top-level module (added file, one path segment under gptme/)
+    must route to Erik on the new-module reason.
+    """
+    file_shapes = [
+        {
+            "path": "gptme/cli/main.py",
+            "status": "modified",
+            "patch": ("@@ -10,6 +10,7 @@\n+sys.excepthook = hintkit_excepthook\n"),
+        },
+        {
+            "path": "gptme/error_hintkit.py",
+            "status": "added",
+            "patch": ("@@ -0,0 +1,261 @@\n+HINTKIT_ENABLED = True\n"),
+        },
+        {
+            "path": "tests/test_error_hintkit.py",
+            "status": "added",
+            "patch": ("@@ -0,0 +1,250 @@\n+def test_hint(): pass\n"),
+        },
+        {
+            "path": "tests/test_cli_fatal_error_envelope.py",
+            "status": "added",
+            "patch": ("@@ -0,0 +1,89 @@\n+def test_envelope(): pass\n"),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "feat(cli): add Error-HintKit hints",
+        "Part of Error-HintKit M1 from Bob's local task "
+        "error-hintkit-m1-registry-and-cli-adapter.",
+        file_shapes,
+    )
+    assert any(
+        "New module under gptme/" in r and "error_hintkit.py" in r for r in reasons
+    )
+    # feat: title with genuinely no #issue reference anywhere — must ALSO fire.
+    assert any("no #issue reference" in r for r in reasons)
+
+
+def test_gptme_core_feat_title_without_issue_routes() -> None:
+    """A `feat:` PR touching only ordinary internal files but with no linked
+    issue anywhere in title or body must still route (auto-merge-analysis §3
+    cluster 5: unmotivated/low-value features are exactly what Erik closes)."""
+    file_shapes = [
+        {
+            "path": "gptme/tools/browser.py",
+            "status": "modified",
+            "patch": ("@@ -1,3 +1,9 @@\n+def new_helper():\n+    pass\n"),
+        },
+        {
+            "path": "tests/test_browser.py",
+            "status": "modified",
+            "patch": ("@@ -1,3 +1,7 @@\n+def test_new_helper(): pass\n"),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "feat: add a configurable retry delay to the browser tool",
+        "No design doc, just seemed useful.",
+        file_shapes,
+    )
+    assert len(reasons) == 1
+    assert "no #issue reference" in reasons[0]
+
+
+def test_gptme_core_new_click_option_routes() -> None:
+    file_shapes = [
+        {
+            "path": "gptme/cli/main.py",
+            "status": "modified",
+            "patch": (
+                "@@ -540,6 +540,11 @@\n"
+                '+@click.option("--no-verify", is_flag=True, help="Skip verification")\n'
+            ),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "fix(cli): add --no-verify escape hatch", "", file_shapes
+    )
+    assert any("New CLI surface" in r for r in reasons)
+
+
+def test_gptme_core_new_cli_subcommand_file_routes() -> None:
+    file_shapes = [
+        {
+            "path": "gptme/cli/cmd_replay.py",
+            "status": "added",
+            "patch": (
+                "@@ -0,0 +1,40 @@\n+@click.command()\n+def cmd_replay():\n+    pass\n"
+            ),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "fix(cli): add replay subcommand", "", file_shapes
+    )
+    assert any("New CLI surface" in r and "cmd_replay.py" in r for r in reasons)
+
+
+def test_gptme_core_new_docs_page_routes() -> None:
+    file_shapes = [
+        {
+            "path": "docs/replay.rst",
+            "status": "added",
+            "patch": ("@@ -0,0 +1,20 @@\n+Replay\n+======\n"),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "fix(docs): document replay", "", file_shapes
+    )
+    assert any("New docs page" in r and "replay.rst" in r for r in reasons)
+
+
+def test_gptme_core_llm_server_provider_paths_route() -> None:
+    file_shapes = [
+        {
+            "path": "gptme/llm/llm_anthropic.py",
+            "status": "modified",
+            "patch": ("@@ -1,3 +1,6 @@\n+def _retry(): pass\n"),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "fix(llm): retry on 529", "", file_shapes
+    )
+    assert any(
+        "gptme/llm/, gptme/server/, auth, or provider routing" in r for r in reasons
+    )
+
+
+def test_gptme_core_modified_existing_module_is_not_new() -> None:
+    """A modified (not added) file under gptme/ must not trip the new-module
+    detector — only genuinely new files count."""
+    file_shapes = [
+        {
+            "path": "gptme/tools/browser.py",
+            "status": "modified",
+            "patch": ("@@ -1,3 +1,5 @@\n+x = 1\n"),
+        },
+    ]
+    reasons = self_merge_check.gptme_core_route_to_erik_reasons(
+        "fix(tools): tighten browser timeout", "", file_shapes
+    )
+    assert reasons == []
+
+
+def _evaluate_gptme_core(
+    files: list[dict[str, Any]],
+    file_shapes: list[dict[str, Any]],
+    *,
+    title: str = "fix(reduce): cache result",
+    body: str = "",
+) -> Any:
+    pr_data = _make_clean_pr_data(
+        title=title,
+        body=body,
+        files=files,
+        url="https://github.com/gptme/gptme/pull/999",
+    )
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": False, "unresolved": 0, "total": 0},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
+        patch.object(
+            self_merge_check, "_fetch_pr_file_shapes", return_value=file_shapes
+        ),
+    ):
+        return self_merge_check.evaluate_pr(
+            "gptme/gptme",
+            999,
+            workspace_repos=["gptme/gptme"],
+        )
+
+
+def test_evaluate_pr_gptme_core_cache_fix_is_eligible() -> None:
+    """gptme#3620 end-to-end: CI green, AI review clean, no route-to-Erik
+    shape → eligible regardless of gptme/util/reduce.py's directory."""
+    files = [
+        {"path": "gptme/util/reduce.py"},
+        {"path": "tests/conftest.py"},
+        {"path": "tests/test_reduce.py"},
+    ]
+    file_shapes = [
+        {
+            "path": "gptme/util/reduce.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+x = 1\n",
+        },
+        {
+            "path": "tests/conftest.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+y = 1\n",
+        },
+        {
+            "path": "tests/test_reduce.py",
+            "status": "added",
+            "patch": "@@ -0,0 +1,2 @@\n+def test_x(): pass\n",
+        },
+    ]
+    result = _evaluate_gptme_core(
+        files,
+        file_shapes,
+        title="fix(reduce): cache proactive_summarize_log result by middle-message content hash",
+        body="Phase 4.1 of the append-only request construction audit. Phases 2+3 landed in #3616.",
+    )
+    assert result.eligible, result.reasons
+    assert result.category == "gptme-core-diff-shape-eligible"
+
+
+def test_evaluate_pr_gptme_core_new_hook_module_routes_to_erik() -> None:
+    """gptme#3695 end-to-end: new hook module + config surface → NOT eligible,
+    even with CI green and AI review clean."""
+    files = [
+        {"path": "gptme/hooks/__init__.py"},
+        {"path": "gptme/hooks/guardrails.py"},
+        {"path": "gptme/config/models.py"},
+        {"path": "tests/test_guardrails_policy.py"},
+    ]
+    file_shapes = [
+        {
+            "path": "gptme/hooks/__init__.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+register_hook(guardrails_hook)\n",
+        },
+        {
+            "path": "gptme/hooks/guardrails.py",
+            "status": "added",
+            "patch": "@@ -0,0 +1,2 @@\n+def guardrails_hook(): pass\n",
+        },
+        {
+            "path": "gptme/config/models.py",
+            "status": "modified",
+            "patch": '@@ -260,1 +260,2 @@\n+    guardrails_mode: str = field(default="shadow")\n',
+        },
+        {
+            "path": "tests/test_guardrails_policy.py",
+            "status": "added",
+            "patch": "@@ -0,0 +1,2 @@\n+def test_x(): pass\n",
+        },
+    ]
+    result = _evaluate_gptme_core(
+        files,
+        file_shapes,
+        title="feat(hooks): add guardrails policy hook",
+        body="Resolves the three design questions from RFC #3598 ... Closes #3598",
+    )
+    assert not result.eligible
+    assert any("New module under gptme/" in r for r in result.reasons)
+
+
+def test_evaluate_pr_gptme_core_new_top_level_module_routes_to_erik() -> None:
+    """gptme#3706 end-to-end: new top-level gptme/error_hintkit.py module."""
+    files = [
+        {"path": "gptme/cli/main.py"},
+        {"path": "gptme/error_hintkit.py"},
+        {"path": "tests/test_error_hintkit.py"},
+        {"path": "tests/test_cli_fatal_error_envelope.py"},
+    ]
+    file_shapes = [
+        {
+            "path": "gptme/cli/main.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+x = 1\n",
+        },
+        {
+            "path": "gptme/error_hintkit.py",
+            "status": "added",
+            "patch": "@@ -0,0 +1,2 @@\n+HINTKIT_ENABLED = True\n",
+        },
+        {
+            "path": "tests/test_error_hintkit.py",
+            "status": "added",
+            "patch": "@@ -0,0 +1,2 @@\n+def test_x(): pass\n",
+        },
+        {
+            "path": "tests/test_cli_fatal_error_envelope.py",
+            "status": "added",
+            "patch": "@@ -0,0 +1,2 @@\n+def test_y(): pass\n",
+        },
+    ]
+    result = _evaluate_gptme_core(
+        files,
+        file_shapes,
+        title="feat(cli): add Error-HintKit hints",
+        body="Part of Error-HintKit M1 from Bob's local task "
+        "error-hintkit-m1-registry-and-cli-adapter.",
+    )
+    assert not result.eligible
+    assert any("New module under gptme/" in r for r in result.reasons)
+    assert any("no #issue reference" in r for r in result.reasons)
+
+
+def test_evaluate_pr_gptme_core_feat_without_issue_routes_to_erik() -> None:
+    """A synthetic `feat:` PR with no linked issue must route, even when every
+    file it touches is otherwise an ordinary internal module."""
+    files = [
+        {"path": "gptme/tools/browser.py"},
+        {"path": "tests/test_browser.py"},
+    ]
+    file_shapes = [
+        {
+            "path": "gptme/tools/browser.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+def new_helper(): pass\n",
+        },
+        {
+            "path": "tests/test_browser.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+def test_x(): pass\n",
+        },
+    ]
+    result = _evaluate_gptme_core(
+        files,
+        file_shapes,
+        title="feat: add a configurable retry delay to the browser tool",
+        body="No design doc, just seemed useful.",
+    )
+    assert not result.eligible
+    assert any("no #issue reference" in r for r in result.reasons)
+    assert result.category is None
+
+
+def test_evaluate_pr_gptme_core_sensitive_path_still_blocks() -> None:
+    """The generic sensitive-path hard stop still applies to gptme/gptme —
+    dropping the category-allowlist requirement does not touch it."""
+    files = [{"path": "gptme/oauth/tokens.py"}]
+    file_shapes = [
+        {
+            "path": "gptme/oauth/tokens.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+x = 1\n",
+        }
+    ]
+    result = _evaluate_gptme_core(files, file_shapes, title="fix(oauth): rotate token")
+    assert not result.eligible
+    assert any("sensitive" in r.lower() for r in result.reasons)
+
+
+def test_evaluate_pr_other_repo_category_allowlist_unchanged() -> None:
+    """gptme/gptme-contrib must still use classify_category's path-category
+    allowlist — the diff-shape override is gptme/gptme-only."""
+    files = [{"path": "gptme/util/reduce.py"}]
+    pr_data = _make_clean_pr_data(files=files)
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": False, "unresolved": 0, "total": 0},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
+        patch.object(self_merge_check, "_fetch_pr_file_shapes") as mock_shapes,
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+    # gptme/util/reduce.py is not in any allowed category for contrib (no
+    # SELF_MERGE_ALLOWED_PATHS entry for it) — the old behaviour must persist.
+    assert not result.eligible
+    assert any(
+        "Files not in any allowed self-merge category" in r for r in result.reasons
+    )
+    mock_shapes.assert_not_called()


### PR DESCRIPTION
## What

Erik (2026-09-07), on gptme#3620's gate message:

> "The PR is self-merge ineligible due to gptme/util/reduce.py being outside the bot's allowed category — manual merge needed." <-- path alone doesn't feel like a good eligibility gate, at least not for this PR

For `gptme/gptme` only, `classify_category`'s "must fall into an allowed category" requirement stops gating eligibility. In its place, six diff-shape detectors route to Erik with a reason that quotes his own rationale in one clause. Every other repo's `classify_category` call is unchanged.

## Rule (gptme/gptme only)

| Detector | Routes to Erik because |
|---|---|
| New `@click.option`/`@click.command`, or a new `gptme/cli/` subcommand file | "I don't like adding a whole set of --arguments to the default gptme CLI" (#3209) / "can't justify a whole 'nother CLI flag" (#3296) |
| New config schema key under `gptme/config/` (dataclass field pattern) | same cluster — core config surface is his call |
| New module under `gptme/` (added file, not modified — one path segment deep, so it also catches a new subpackage module like `gptme/hooks/guardrails.py`, not just a bare top-level file) | public-surface proliferation/naming/placement is his taste to set (#3529 "'harness' is kinda vague") |
| New docs page under `docs/` (added file) | he's flagged duplicate/misplaced doc pages before (#3178) |
| `feat:`/`feat(` title with no `#issue` reference in title or body | "Idk if this is an actually useful feature" (#2836) / "kinda low value" (#2979) |
| Touches `gptme/llm/`, `gptme/server/`, `gptme/providers/`, `gptme/oauth/`, or auth | "avoid making too much auth cloud-specific" (#2901); silent auth/provider misrouting is this class (#2820) |

The sensitive-path / bot-config / spec-like-doc hard stops `classify_category` already enforces still apply unconditionally — dropping the category-allowlist requirement doesn't touch them. A PR triggering none of the six shapes above, with CI green on head, own AI review clean on head (P0/P1 disposed, P2 non-blocking), Greptile per the 3-branch staleness policy, and no unresolved human threads, is eligible regardless of which directory it touches.

Full analysis: `knowledge/strategic/2026-09-07-auto-merge-analysis.md` §3 (block-reason corpus) and §5 (policy table), workspace brain repo.

## Corpus verdicts

- **gptme#3620** (cache fix in `gptme/util/reduce.py` + tests, clean review) → **ELIGIBLE**
- **gptme#3695** (new `gptme/hooks/guardrails.py` + config surface) → **routed** (new-module + config reasons)
- **gptme#3706** (new top-level `gptme/error_hintkit.py`) → **routed** (new-module + unlinked-feat reasons)
- synthetic `feat:` PR with no linked issue, touching only ordinary internal files → **routed** (unlinked-feat reason)

## Tests

Corpus fixtures use real file lists (`gh pr view --json title,body,files`) for the three real PRs above, with synthesized patch text matching each PR's documented shape; per-detector unit tests; a control case confirming `gptme/gptme-contrib`'s path-category allowlist is unchanged. `pytest tests/test_self_merge_check.py` — 297 passed (282 pre-existing + 15 new). `ruff check` and `mypy` clean.
