### PR TITLE
feat(self-merge): contrib placement rule, segment-matched sensitive paths, spec-doc waiver

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2229,6 +2229,20 @@ def is_sensitive_path(path: str) -> bool:
         or name.endswith(SENSITIVE_FILE_SUFFIXES)
     ):
         return True
+    # The keyword scan below matches a sensitive word as one TOKEN of a
+    # compound filename (split on "_"/"-"/"."), by design — e.g. "authToken.py"
+    # and "docker-deployment.yaml" must still match. But a *test* filename is
+    # itself a compound of "<subject>_test"/"test_<subject>": "secrets_test.py"
+    # (a test file about secrets handling, not a file that holds a secret) is
+    # exactly the same shape and the scan cannot tell the two apart from the
+    # filename alone. is_test_file() already resolves this ambiguity by path
+    # component (segment), not substring — a test file's OWN name accidentally
+    # containing a sensitive word does not make the file sensitive. This only
+    # skips the keyword scan: the hard prefix/suffix/dotfile/private-key checks
+    # above (a real secret can still live at a test-looking path, e.g.
+    # "tests/fixtures/id_rsa") still apply unconditionally.
+    if is_test_file(path):
+        return False
     # Use the original (pre-lowercase) path to preserve camelCase boundaries for
     # detection; e.g. "authToken.py" → "auth_token" catches the "auth" rule.
     original_components = path.replace("\\", "/").split("/")
@@ -2594,6 +2608,430 @@ def gptme_core_route_to_erik_reasons(
         )
 
     return reasons
+
+
+# --- gptme/gptme-contrib: placement rule + segment-matched sensitive paths +
+# spec-doc waiver ---
+#
+# knowledge/strategic/2026-09-07-auto-merge-analysis.md §3 cluster 2 / §5
+# policy table, T2. Composes with the gptme/gptme diff-shape detectors
+# (gptme_core_route_to_erik_reasons, contrib#1626) — same idea (route on diff
+# SHAPE, not just path category), different repo, disjoint helper names so
+# both additions can land and be reverted independently.
+#
+# Erik's actual block reasons in contrib, verbatim: contrib#1088 "Bob
+# shouldn't have his configuration in gptme-contrib"; #1250 "state belongs in
+# brain, not contrib"; #1325/#1428 "better placed in docs (core)" / "the
+# `knowledge` top-level directory shouldn't exist" — a brand-new top-level
+# directory; #1219 "please don't re-implement prior art (gptme-rag)" —
+# gptme-wisdom-mcp added indexer.py/mcp_server.py, basenames that already
+# exist under packages/gptme-rag/src/. classify_category cannot see any of
+# this from path category alone (packages/**, scripts/** are already-allowed
+# categories) — it needs the diff SHAPE: is this an EXISTING package/dir, or
+# a new one / one colliding with a package that already implements this?
+_GPTME_CONTRIB_REPO = "gptme/gptme-contrib"
+
+# Bare word literals, not substrings — "erik" must not fire on a variable
+# named "erikson_score" (custom, not \b: \w treats "_" as a word char, so a
+# plain \b boundary would MISS "BOB_SPECIFIC_WEIGHT" — snake_case identifiers
+# are exactly where an agent-name literal shows up in code). Case-insensitive:
+# agent names show up both as bare identifiers (bob_config = ...) and
+# capitalized prose/log strings.
+_CONTRIB_AGENT_LITERAL_RE = re.compile(
+    r"(?<![A-Za-z0-9])(bob|alice|gordon|sven|erik)(?![A-Za-z0-9])", re.IGNORECASE
+)
+
+
+def _contrib_repo_root() -> Path:
+    """Repo root for the gptme-contrib checkout this script itself lives in.
+
+    self-merge-check.py is at <repo>/scripts/github/self-merge-check.py, so
+    two parents up is the repo root — whether that's a standalone
+    gptme-contrib checkout or, as in Bob's workspace, the `gptme-contrib`
+    subdirectory the brain-local wrapper loads this module from.
+    """
+    return Path(__file__).resolve().parents[2]
+
+
+@cache
+def _contrib_known_top_level_entries() -> frozenset[str]:
+    """Non-hidden top-level directory/file names already in the repo tree.
+
+    Cached for the process lifetime — the checked-out tree does not change
+    between PR evaluations in one run. Reflects whatever commit is checked
+    out locally (normally close to origin/master); a directory added by a PR
+    that has ALREADY merged since the last checkout update would read as
+    "new" for one stale cycle, which only makes the placement gate
+    conservative (routes to Erik), never lets a genuinely new top-level dir
+    through unrouted.
+    """
+    root = _contrib_repo_root()
+    try:
+        return frozenset(p.name for p in root.iterdir() if not p.name.startswith("."))
+    except OSError:
+        return frozenset()
+
+
+@cache
+def _contrib_known_package_names() -> frozenset[str]:
+    packages_dir = _contrib_repo_root() / "packages"
+    try:
+        return frozenset(p.name for p in packages_dir.iterdir() if p.is_dir())
+    except OSError:
+        return frozenset()
+
+
+# Basenames too generic/boilerplate to signal real API overlap — nearly every
+# package legitimately has an __init__.py or a cli.py entrypoint, so treating
+# those as collisions would route almost every new package to Erik and defeat
+# the point of the rule. Anything else repeated across packages/*/src is a
+# much stronger signal (gptme-wisdom-mcp's indexer.py/mcp_server.py exactly
+# duplicating gptme-rag's).
+_CONTRIB_COLLISION_BASENAME_DENYLIST = frozenset(
+    {
+        "__init__.py",
+        "__main__.py",
+        "conftest.py",
+        "py.typed",
+        "cli.py",
+        "config.py",
+        "types.py",
+        "utils.py",
+        "constants.py",
+        "models.py",
+        "exceptions.py",
+        "settings.py",
+    }
+)
+
+
+@cache
+def _contrib_existing_src_basenames() -> dict[str, frozenset[str]]:
+    """basename -> package names already using it, under packages/*/src/**.
+
+    Cached for the process lifetime, same staleness tradeoff as
+    _contrib_known_top_level_entries.
+    """
+    index: dict[str, set[str]] = {}
+    packages_dir = _contrib_repo_root() / "packages"
+    try:
+        package_dirs = [p for p in packages_dir.iterdir() if p.is_dir()]
+    except OSError:
+        return {}
+    for pkg_dir in package_dirs:
+        src_dir = pkg_dir / "src"
+        if not src_dir.is_dir():
+            continue
+        for f in src_dir.rglob("*.py"):
+            if f.name in _CONTRIB_COLLISION_BASENAME_DENYLIST:
+                continue
+            index.setdefault(f.name, set()).add(pkg_dir.name)
+    return {name: frozenset(pkgs) for name, pkgs in index.items()}
+
+
+def _contrib_normalize(path: str) -> str:
+    return path.replace("\\", "/").removeprefix("./")
+
+
+def _contrib_new_top_level_dirs(paths: list[str]) -> list[str]:
+    known = _contrib_known_top_level_entries()
+    new_dirs: set[str] = set()
+    for raw in paths:
+        normalized = _contrib_normalize(raw)
+        if "/" not in normalized:
+            continue  # a new top-level FILE, not a new top-level DIRECTORY
+        top = normalized.split("/", 1)[0]
+        if top.startswith("."):
+            continue
+        if top not in known:
+            new_dirs.add(top)
+    return sorted(new_dirs)
+
+
+def _contrib_new_packages(paths: list[str]) -> list[str]:
+    known = _contrib_known_package_names()
+    new_pkgs: set[str] = set()
+    for raw in paths:
+        normalized = _contrib_normalize(raw)
+        parts = normalized.split("/")
+        # len >= 3: packages/<name>/<something> — a file directly at
+        # packages/<name> with nothing nested (len == 2, e.g. a loose
+        # "packages/README.md") is not a package directory at all.
+        if len(parts) >= 3 and parts[0] == "packages" and parts[1] not in known:
+            new_pkgs.add(parts[1])
+    return sorted(new_pkgs)
+
+
+def _contrib_state_writes(paths: list[str]) -> list[str]:
+    return sorted(
+        {
+            _contrib_normalize(p)
+            for p in paths
+            if _contrib_normalize(p).startswith("state/")
+        }
+    )
+
+
+def _contrib_basename_collisions(paths: list[str]) -> dict[str, frozenset[str]]:
+    """basename -> OTHER packages already using it, for new files this PR adds.
+
+    Scoped to packages/<name>/src/**/*.py so a same-named test fixture or
+    script (packages/<name>/tests/indexer.py) does not trip this — those live
+    outside src/ and aren't the package's public API.
+    """
+    existing = _contrib_existing_src_basenames()
+    collisions: dict[str, set[str]] = {}
+    for raw in paths:
+        normalized = _contrib_normalize(raw)
+        parts = normalized.split("/")
+        if (
+            len(parts) < 4
+            or parts[0] != "packages"
+            or parts[2] != "src"
+            or not normalized.endswith(".py")
+        ):
+            continue
+        basename = parts[-1]
+        if basename in _CONTRIB_COLLISION_BASENAME_DENYLIST:
+            continue
+        pkg_name = parts[1]
+        other_pkgs = existing.get(basename, frozenset()) - {pkg_name}
+        if other_pkgs:
+            collisions.setdefault(basename, set()).update(other_pkgs)
+    return {name: frozenset(pkgs) for name, pkgs in collisions.items()}
+
+
+def _contrib_spec_doc_waived(doc_path: str, all_paths: list[str]) -> bool:
+    """Whether a spec-like doc's own hard stop is waived for this PR.
+
+    Mirror table (auto-merge-analysis §5): "Spec-like doc requires human
+    review | 1 (#1576, 73 identical refusals) | Yes when the doc lives inside
+    a package the same PR implements." contrib#1576 touched root README.md
+    (SPEC_LIKE_DOCS) purely to register two packages it also implemented
+    end-to-end in the same diff (gptme-body-protocol, gptme-voice) — Erik
+    merged it untouched. The waiver requires at least one OTHER changed file
+    in this PR to live under packages/ (real implementation work, not a
+    doc-only edit) — a doc-only PR touching README.md/ARCHITECTURE.md/etc.
+    with nothing else still routes to Erik.
+    """
+    return any(
+        _contrib_normalize(p).startswith("packages/") and p != doc_path
+        for p in all_paths
+    )
+
+
+def _contrib_placement_route_reasons(paths: list[str]) -> list[str]:
+    """Path-shape checks that route a gptme-contrib PR to Erik.
+
+    Each fired reason quotes, in one clause, the corpus cluster it encodes
+    (auto-merge-analysis §3 cluster 2 — "wrong home / re-implementing prior
+    art", the one placement class Erik actually blocks on in contrib).
+    Returns an empty list when none of the shapes are present.
+    """
+    reasons: list[str] = []
+
+    new_dirs = _contrib_new_top_level_dirs(paths)
+    if new_dirs:
+        reasons.append(
+            "New top-level directory ("
+            + ", ".join(new_dirs)
+            + "): Erik — \"the `knowledge` top-level directory shouldn't "
+            'exist" / "better placed in docs (core)" (auto-merge-analysis §3 '
+            "cluster 2, e.g. contrib#1325 cookbook/, #1428 knowledge/)"
+        )
+
+    new_pkgs = _contrib_new_packages(paths)
+    if new_pkgs:
+        reasons.append(
+            "New packages/<name>/ ("
+            + ", ".join(new_pkgs)
+            + "): a brand-new package is exactly the placement decision Erik "
+            "reserves for himself, same cluster as the top-level-dir case "
+            "(auto-merge-analysis §3 cluster 2)"
+        )
+
+    state_writes = _contrib_state_writes(paths)
+    if state_writes:
+        reasons.append(
+            "Writes under state/ ("
+            + ", ".join(state_writes)
+            + '): Erik — "state belongs in brain, not contrib" '
+            "(auto-merge-analysis §3 cluster 2, contrib#1250)"
+        )
+
+    collisions = _contrib_basename_collisions(paths)
+    if collisions:
+        detail = "; ".join(
+            f"{basename} also in {', '.join(sorted(pkgs))}"
+            for basename, pkgs in sorted(collisions.items())
+        )
+        reasons.append(
+            "New module basename collides with an existing package under "
+            "packages/*/src (" + detail + "): Erik — \"please don't "
+            're-implement prior art" (auto-merge-analysis §3 cluster 2, '
+            "contrib#1219 gptme-wisdom-mcp/indexer.py + mcp_server.py "
+            "duplicating gptme-rag's)"
+        )
+
+    return reasons
+
+
+def _contrib_iter_json_documents(text: str) -> Iterator[Any]:
+    """Yield successive JSON values from paginated compact API/jq output.
+
+    Same technique as pm_dispatch_recovery.py's helper of the same name and
+    contrib#1626's gptme-core diff-shape detector — kept as a distinct copy
+    here (rather than importing that one) so the two additions stay
+    independent and can land/revert separately.
+    """
+    decoder = json.JSONDecoder()
+    idx = 0
+    n = len(text)
+    while idx < n:
+        while idx < n and text[idx].isspace():
+            idx += 1
+        if idx >= n:
+            break
+        try:
+            val, end = decoder.raw_decode(text, idx)
+        except json.JSONDecodeError:
+            break
+        yield val
+        idx = end
+
+
+def _fetch_contrib_pr_file_shapes(repo: str, number: int) -> list[dict[str, Any]]:
+    """Per-file status + patch text, for the agent-literal detector only.
+
+    Gated behind the cheaper path-only placement checks in evaluate_pr — only
+    reached once those (and the rest of contrib_classify_category) have
+    already left the PR otherwise eligible, so an ordinary internal-tooling
+    PR costs no extra API call.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/pulls/{number}/files",
+                "--paginate",
+                "--jq",
+                ".[] | {path: .filename, status: .status, patch: .patch}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [
+        doc
+        for doc in _contrib_iter_json_documents(result.stdout)
+        if isinstance(doc, dict)
+    ]
+
+
+def _contrib_added_lines(patch: str | None) -> list[str]:
+    """Added (`+`-prefixed, non-hunk-header) lines of a unified diff patch."""
+    if not patch:
+        return []
+    return [
+        line[1:]
+        for line in patch.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+
+
+def contrib_agent_literal_reasons(file_shapes: list[dict[str, Any]]) -> list[str]:
+    """Agent-name literals added in non-test code route to Erik.
+
+    Erik — "Bob shouldn't have his configuration in gptme-contrib"
+    (auto-merge-analysis §3 cluster 2, contrib#1088). Test fixtures
+    legitimately reference agent names (e.g. testing attribution logic), so
+    is_test_file() paths are excluded — same segment-not-substring reasoning
+    as the sensitive-path keyword-scan fix in is_sensitive_path.
+    """
+    hits: dict[str, set[str]] = {}
+    for entry in file_shapes:
+        path = _contrib_normalize(str(entry.get("path", "")))
+        if is_test_file(path):
+            continue
+        for line in _contrib_added_lines(cast("str | None", entry.get("patch"))):
+            for match in _CONTRIB_AGENT_LITERAL_RE.finditer(line):
+                hits.setdefault(match.group(1).lower(), set()).add(path)
+    if not hits:
+        return []
+    detail = "; ".join(
+        f'"{name}" in {", ".join(sorted(files))}'
+        for name, files in sorted(hits.items())
+    )
+    return [
+        "Agent-name literal in non-test code ("
+        + detail
+        + "): Erik — \"Bob shouldn't have his configuration in "
+        'gptme-contrib" (auto-merge-analysis §3 cluster 2, contrib#1088)'
+    ]
+
+
+def contrib_classify_category(
+    paths: list[str], repo: str
+) -> tuple[str | None, list[str]]:
+    """gptme-contrib override: classify_category's hard stops plus placement.
+
+    Delegates the remaining "what category shape is this" labeling to the
+    canonical classify_category (test-only / internal-tooling / mixed-allowed
+    / ...) unchanged — only two things differ from it here, both documented
+    in auto-merge-analysis.md §5 T2: (1) the spec-like-doc hard stop is
+    waived when the doc is paired with real package work in the same PR, and
+    (2) the new placement-rule hard stop below, which classify_category has
+    no way to express (packages/**, scripts/** are already-allowed
+    categories; the placement rule blocks a SUBSET of an allowed category by
+    diff shape, not by path). The keyword-based sensitive-path fix
+    (segment-, not substring-, matched) lives in is_sensitive_path itself, so
+    it applies to every repo, not just this one.
+    """
+    if not paths:
+        return None, ["PR has no changed files"]
+
+    repo_path_allowlist = _get_repo_path_allowlist()
+    if any(
+        is_sensitive_path(p)
+        and not is_repo_allowlisted_path(p, repo, repo_path_allowlist)
+        for p in paths
+    ):
+        return None, ["Touches sensitive/security/infra paths"]
+
+    if any(is_bot_config(p) for p in paths):
+        return None, ["Bot/CI config changes require human review under current policy"]
+
+    placement_reasons = _contrib_placement_route_reasons(paths)
+    if placement_reasons:
+        return None, placement_reasons
+
+    waived_docs = {
+        p
+        for p in paths
+        if is_doc_file(p) and is_spec_like_doc(p) and _contrib_spec_doc_waived(p, paths)
+    }
+    unwaived_spec_docs = [
+        p
+        for p in paths
+        if is_doc_file(p) and is_spec_like_doc(p) and p not in waived_docs
+    ]
+    if unwaived_spec_docs:
+        return None, ["Touches spec-like documentation requiring human review"]
+
+    remaining = [p for p in paths if p not in waived_docs]
+    if not remaining:
+        return "docs-only", []
+    category, reasons = classify_category(remaining, repo=repo)
+    if category is None:
+        return None, reasons
+    if waived_docs:
+        category = f"{category}+spec-doc-waived"
+    return category, reasons
 
 
 def _check_workspace_repo(
@@ -2989,6 +3427,21 @@ def evaluate_pr(
                 result.reasons.extend(shape_reasons)
             else:
                 result.category = "gptme-core-diff-shape-eligible"
+    elif repo == _GPTME_CONTRIB_REPO:
+        # gptme/gptme-contrib: classify_category's category shape plus the
+        # placement rule + spec-doc waiver (see contrib_classify_category's
+        # docstring). The agent-literal check needs patch text, so it is
+        # fetched lazily and only once the cheaper path-only checks above
+        # have already left the PR eligible.
+        category, category_reasons = contrib_classify_category(files, repo=repo)
+        result.category = category
+        result.reasons.extend(category_reasons)
+        if category is not None:
+            file_shapes = _fetch_contrib_pr_file_shapes(repo, number)
+            agent_literal_reasons = contrib_agent_literal_reasons(file_shapes)
+            if agent_literal_reasons:
+                result.category = None
+                result.reasons.extend(agent_literal_reasons)
     else:
         category, category_reasons = classify_category(files, repo=repo)
         result.category = category

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2235,14 +2235,26 @@ def is_sensitive_path(path: str) -> bool:
     # itself a compound of "<subject>_test"/"test_<subject>": "secrets_test.py"
     # (a test file about secrets handling, not a file that holds a secret) is
     # exactly the same shape and the scan cannot tell the two apart from the
-    # filename alone. is_test_file() already resolves this ambiguity by path
-    # component (segment), not substring — a test file's OWN name accidentally
-    # containing a sensitive word does not make the file sensitive. This only
-    # skips the keyword scan: the hard prefix/suffix/dotfile/private-key checks
-    # above (a real secret can still live at a test-looking path, e.g.
-    # "tests/fixtures/id_rsa") still apply unconditionally.
+    # filename alone.
+    #
+    # The early return only applies when the BASENAME itself is test-shaped
+    # (test_foo.py, foo_test.go, foo.spec.js). A file like tests/secrets.json
+    # or tests/fixtures/aws_keys.json is a test-directory member but carries a
+    # sensitive basename — the keyword scan must still run for it. The hard
+    # prefix/suffix/dotfile/private-key checks above still apply unconditionally
+    # for all paths (a real secret at tests/fixtures/id_rsa is caught there).
     if is_test_file(path):
-        return False
+        _name = path.replace("\\", "/").split("/")[-1]
+        _basename_is_test = (
+            _name.startswith(TEST_FILENAME_PREFIXES)
+            or any(marker in _name for marker in TEST_FILENAME_MARKERS)
+            or (
+                not SPEC_DOCUMENT_PREFIX_RE.match(_name)
+                and bool(SPEC_TEST_FILE_RE.search(_name))
+            )
+        )
+        if _basename_is_test:
+            return False
     # Use the original (pre-lowercase) path to preserve camelCase boundaries for
     # detection; e.g. "authToken.py" → "auth_token" catches the "auth" rule.
     original_components = path.replace("\\", "/").split("/")

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -3235,6 +3235,32 @@ def test_is_sensitive_path_still_blocks_real_sensitive_paths(path: str) -> None:
     assert self_merge_check.is_sensitive_path(path) is True
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/secrets.json",
+        "tests/fixtures/credentials.json",
+        "tests/fixtures/authToken.json",
+        "tests/deploy-config.yaml",
+    ],
+)
+def test_is_sensitive_path_test_dir_does_not_exempt_sensitive_basename(
+    path: str,
+) -> None:
+    """Living under a test directory does not exempt a file with a sensitive
+    basename from the keyword scan. Only files whose OWN NAME is test-shaped
+    (test_foo.py, foo_test.go, foo.spec.js) get the carve-out.
+
+    Regression for the P1 finding in contrib#1628: the early return in
+    is_sensitive_path was scoped to is_test_file(), which returns True for any
+    path under 'tests/', causing tests/secrets.json to bypass sensitive-path
+    detection entirely."""
+    assert (
+        self_merge_check.is_test_file(path) is True
+    ), "precondition: IS a test-dir member"
+    assert self_merge_check.is_sensitive_path(path) is True
+
+
 def test_contrib_agent_literal_in_non_test_code_routes() -> None:
     """contrib#1088-shaped case: an agent-name literal added to non-test
     code. Erik, verbatim: "Bob shouldn't have his configuration in

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -2587,15 +2587,13 @@ def test_gptme_core_new_hook_module_and_config_routes() -> None:
             "path": "gptme/hooks/__init__.py",
             "status": "modified",
             "patch": (
-                "@@ -1,3 +1,8 @@\n" "+register_hook(guardrails_hook, priority=200)\n"
+                "@@ -1,3 +1,8 @@\n+register_hook(guardrails_hook, priority=200)\n"
             ),
         },
         {
             "path": "gptme/hooks/guardrails.py",
             "status": "added",
-            "patch": (
-                "@@ -0,0 +1,677 @@\n" "+def guardrails_hook(...):\n" "+    pass\n"
-            ),
+            "patch": ("@@ -0,0 +1,677 @@\n+def guardrails_hook(...):\n+    pass\n"),
         },
         {
             "path": "gptme/config/models.py",
@@ -3023,6 +3021,7 @@ def test_evaluate_pr_other_repo_category_allowlist_unchanged() -> None:
         "Files not in any allowed self-merge category" in r for r in result.reasons
     )
     mock_shapes.assert_not_called()
+
 
 # --- gptme/gptme-contrib: placement rule + segment-matched sensitive paths +
 # spec-doc waiver ---

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -40,6 +40,18 @@ def _stub_external_merge_checks():
     with (
         patch.object(self_merge_check, "merge_permission", return_value=True),
         patch.object(self_merge_check, "ai_review_abstained", return_value=False),
+        # contrib_classify_category's agent-literal check makes its own live
+        # ``gh api .../files`` call once a gptme-contrib PR is otherwise
+        # eligible (see evaluate_pr). Default to "no added lines to scan" so
+        # ordinary evaluate_pr tests don't depend on GitHub access or on
+        # whatever PR #999 happens to contain; tests targeting the
+        # agent-literal check itself override this explicitly.
+        patch.object(
+            self_merge_check, "_fetch_contrib_pr_file_shapes", return_value=[]
+        ),
+        # Same for gptme/gptme's diff-shape fetch: only gptme-core tests
+        # that need real patch text override this.
+        patch.object(self_merge_check, "_fetch_pr_file_shapes", return_value=[]),
     ):
         yield
     self_merge_check.merge_permission.cache_clear()
@@ -2967,9 +2979,13 @@ def test_evaluate_pr_gptme_core_sensitive_path_still_blocks() -> None:
 
 
 def test_evaluate_pr_other_repo_category_allowlist_unchanged() -> None:
-    """gptme/gptme-contrib must still use classify_category's path-category
-    allowlist — the diff-shape override is gptme/gptme-only."""
-    files = [{"path": "gptme/util/reduce.py"}]
+    """gptme/gptme-contrib still uses classify_category for remaining files.
+
+    A top-level FILE (no slash) is not a new top-level directory, so the
+    contrib placement rule does not fire; the old path-category allowlist
+    is what disqualifies it. gptme-core's patch-text fetch must not run.
+    """
+    files = [{"path": "orphan_module.py"}]
     pr_data = _make_clean_pr_data(files=files)
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
@@ -3000,9 +3016,417 @@ def test_evaluate_pr_other_repo_category_allowlist_unchanged() -> None:
             999,
             workspace_repos=["gptme/gptme-contrib"],
         )
-    # gptme/util/reduce.py is not in any allowed category for contrib (no
-    # SELF_MERGE_ALLOWED_PATHS entry for it) — the old behaviour must persist.
+    # orphan_module.py is not in any allowed category for contrib — the
+    # path-category allowlist still applies to remaining (non-placement) files.
     assert not result.eligible
+    assert any(
+        "Files not in any allowed self-merge category" in r for r in result.reasons
+    )
+    mock_shapes.assert_not_called()
+
+# --- gptme/gptme-contrib: placement rule + segment-matched sensitive paths +
+# spec-doc waiver ---
+#
+# Erik (2026-09-07 corpus, auto-merge-analysis.md §3 cluster 2 / §5 T2).
+# Fixtures below are real file lists (`gh pr view --json files`, 9 calls
+# total across this task) for the corpus PRs named in
+# tasks/contrib-self-merge-placement-rule-and-segment-paths.md.
+
+
+def test_contrib_new_top_level_dir_cookbook_routes() -> None:
+    """contrib#1325 (CLOSED): a brand-new top-level cookbook/ directory.
+
+    Erik: "better placed in docs (core)" — a new top-level dir is exactly
+    the placement decision classify_category's path-category allowlist
+    cannot see (scripts/build-cookbook.py alone would be plain
+    internal-tooling)."""
+    files = [
+        "cookbook/.gitignore",
+        "cookbook/01-tool-use-basics.md",
+        "cookbook/README.md",
+        "scripts/build-cookbook.py",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is None
+    assert any("New top-level directory" in r and "cookbook" in r for r in reasons)
+
+
+def test_contrib_new_top_level_dir_knowledge_routes() -> None:
+    """contrib#1428 (CLOSED): a brand-new top-level knowledge/ directory.
+
+    Erik, verbatim: "the `knowledge` top-level directory shouldn't exist"."""
+    files = [
+        "knowledge/decks/agentic-presentation-demo.json",
+        "scripts/generate-presentation-html.py",
+        "skills/agentic-presentation/SKILL.md",
+        "tests/test_generate_presentation_html.py",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is None
+    assert any("New top-level directory" in r and "knowledge" in r for r in reasons)
+
+
+def test_contrib_basename_collision_wisdom_mcp_routes() -> None:
+    """contrib#1219 (MERGED): gptme-wisdom-mcp's indexer.py/mcp_server.py
+    duplicate basenames that already live under packages/gptme-rag/src/ (and
+    packages/gptme-wisdom/src/). Erik, verbatim: "please don't re-implement
+    prior art (gptme-rag)". classify_category alone would pass this PR —
+    packages/** is already-allowed internal-tooling; the collision is a diff
+    SHAPE, not a path category."""
+    files = [
+        "mypy.ini",
+        "packages/gptme-wisdom-mcp/Makefile",
+        "packages/gptme-wisdom-mcp/README.md",
+        "packages/gptme-wisdom-mcp/pyproject.toml",
+        "packages/gptme-wisdom-mcp/src/gptme_wisdom_mcp/__init__.py",
+        "packages/gptme-wisdom-mcp/src/gptme_wisdom_mcp/indexer.py",
+        "packages/gptme-wisdom-mcp/src/gptme_wisdom_mcp/mcp_server.py",
+        "packages/gptme-wisdom-mcp/src/gptme_wisdom_mcp/parsers.py",
+        "packages/gptme-wisdom-mcp/tests/test_indexer.py",
+        "uv.lock",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is None
+    collision_reasons = [r for r in reasons if "basename collides" in r]
+    assert collision_reasons, reasons
+    assert "indexer.py" in collision_reasons[0]
+    assert "mcp_server.py" in collision_reasons[0]
+    assert "gptme-rag" in collision_reasons[0]
+
+
+def test_contrib_new_package_alone_routes() -> None:
+    """A brand-new packages/<name>/ that does NOT collide with any existing
+    basename must still route on the new-package reason alone (isolates the
+    new-package rule from the basename-collision rule above)."""
+    files = [
+        "packages/gptme-totally-novel-thing/pyproject.toml",
+        "packages/gptme-totally-novel-thing/src/gptme_totally_novel_thing/__init__.py",
+        "packages/gptme-totally-novel-thing/src/gptme_totally_novel_thing/unique_widget.py",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is None
+    assert any(
+        "New packages/<name>/" in r and "gptme-totally-novel-thing" in r
+        for r in reasons
+    )
+
+
+def test_contrib_state_writes_route() -> None:
+    """Writes under state/ route to Erik. Erik, verbatim (contrib#1250):
+    "state belongs in brain, not contrib"."""
+    files = ["state/some-new-ledger.jsonl", "scripts/emit-ledger.py"]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is None
+    assert any("Writes under state/" in r for r in reasons)
+
+
+def test_contrib_loose_file_directly_under_packages_is_not_a_new_package() -> None:
+    """A file placed directly at packages/<file>, with no nested directory
+    (e.g. packages/README.md), must not be misread as a new package named
+    "README.md" — regression guard for the len(parts) >= 3 requirement."""
+    files = ["packages/README.md"]
+    new_pkgs = self_merge_check._contrib_new_packages(files)
+    assert new_pkgs == []
+
+
+def test_contrib_merged_untouched_runloops_fix_is_clean() -> None:
+    """contrib#1621 (merged by Erik untouched): an ordinary fix to an
+    existing package. No placement reason should fire — this is exactly the
+    class of PR the whole T2 policy exists to stop routing unnecessarily."""
+    files = [
+        "packages/gptme-runloops/src/gptme_runloops/run_item.py",
+        "packages/gptme-runloops/src/gptme_runloops/worker_records.py",
+        "packages/gptme-runloops/tests/test_worker_records_voice_postcall.py",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category == "internal-tooling", reasons
+    assert reasons == []
+
+
+def test_contrib_merged_untouched_voice_vision_fix_is_clean() -> None:
+    """contrib#1617 (merged by Erik untouched): same shape, different
+    package."""
+    files = [
+        "packages/gptme-voice/src/gptme_voice/vision.py",
+        "packages/gptme-voice/tests/test_vision.py",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category == "internal-tooling", reasons
+    assert reasons == []
+
+
+def test_contrib_spec_doc_waived_when_paired_with_package_impl() -> None:
+    """contrib#1576 (merged by Erik untouched, 73 identical refusals before
+    that): root README.md registers a package the SAME PR implements
+    end-to-end. Mirror table (auto-merge-analysis §5): 'Yes when the doc
+    lives inside a package the same PR implements.'"""
+    files = [
+        "README.md",
+        "packages/gptme-body-protocol/README.md",
+        "packages/gptme-body-protocol/src/gptme_body_protocol/__init__.py",
+        "packages/gptme-body-protocol/tests/test_protocol.py",
+    ]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is not None, reasons
+    assert category.endswith("+spec-doc-waived")
+    assert not any("spec-like" in r.lower() for r in reasons)
+
+
+def test_contrib_spec_doc_not_waived_when_doc_only() -> None:
+    """A doc-only PR touching a root SPEC_LIKE_DOCS file with nothing else in
+    the diff is NOT paired with package implementation work — must still
+    route to Erik, same as before this change."""
+    files = ["README.md"]
+    category, reasons = self_merge_check.contrib_classify_category(
+        files, "gptme/gptme-contrib"
+    )
+    assert category is None
+    assert any("spec-like" in r.lower() for r in reasons)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "secrets_test.py",
+        "tests/secrets_test.py",
+        "test_secrets.py",
+        "packages/foo/tests/test_secrets.py",
+        "tests/deploy_test.py",
+    ],
+)
+def test_is_sensitive_path_segment_not_substring_for_test_files(path: str) -> None:
+    """A test file's OWN name incidentally containing a sensitive word (e.g.
+    'secrets_test.py' — a test file ABOUT secrets handling, not a file that
+    HOLDS a secret) must not trip the keyword scan. Segment/path-shape
+    matching, not substring — task
+    tasks/contrib-self-merge-placement-rule-and-segment-paths.md item 2."""
+    assert self_merge_check.is_test_file(path) is True
+    assert self_merge_check.is_sensitive_path(path) is False
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "secrets/id_rsa",
+        "secrets/prod.env",
+        "scripts/deploy-prod.sh",
+        "packages/foo/authToken.py",
+    ],
+)
+def test_is_sensitive_path_still_blocks_real_sensitive_paths(path: str) -> None:
+    """The is_test_file() carve-out only applies to test files — a real
+    secret-bearing or sensitive path is unaffected."""
+    assert self_merge_check.is_sensitive_path(path) is True
+
+
+def test_contrib_agent_literal_in_non_test_code_routes() -> None:
+    """contrib#1088-shaped case: an agent-name literal added to non-test
+    code. Erik, verbatim: "Bob shouldn't have his configuration in
+    gptme-contrib"."""
+    file_shapes = [
+        {
+            "path": "packages/gptme-subscription/src/gptme_subscription/harness_models.py",
+            "status": "modified",
+            "patch": (
+                "@@ -10,6 +10,8 @@\n"
+                "+BOB_QUOTA_OVERRIDE_USD = 40.0  # Bob-specific quota bump\n"
+            ),
+        },
+    ]
+    reasons = self_merge_check.contrib_agent_literal_reasons(file_shapes)
+    assert any('"bob"' in r for r in reasons)
+
+
+def test_contrib_agent_literal_in_test_code_is_excluded() -> None:
+    """The same literal added to a test fixture (e.g. testing attribution
+    logic across agent names) must not route — only non-test code counts."""
+    file_shapes = [
+        {
+            "path": "packages/gptme-sessions/tests/test_attribution.py",
+            "status": "modified",
+            "patch": ("@@ -1,3 +1,5 @@\n+def test_bob_attribution():\n+    pass\n"),
+        },
+    ]
+    reasons = self_merge_check.contrib_agent_literal_reasons(file_shapes)
+    assert reasons == []
+
+
+def test_contrib_agent_literal_word_boundary_no_false_positive() -> None:
+    """ "erik" as a bound token must fire; a name that merely CONTAINS the
+    substring ("erikson") must not — word-boundary, not substring, matching."""
+    file_shapes = [
+        {
+            "path": "packages/gptme-example/src/gptme_example/scoring.py",
+            "status": "modified",
+            "patch": "@@ -1,3 +1,4 @@\n+ERIKSON_COEFFICIENT = 0.7\n",
+        },
+    ]
+    reasons = self_merge_check.contrib_agent_literal_reasons(file_shapes)
+    assert reasons == []
+
+
+def _evaluate_contrib(
+    files: list[dict[str, Any]],
+    file_shapes: list[dict[str, Any]],
+    *,
+    title: str = "fix(gptme-runloops): tighten worker record timeout",
+) -> Any:
+    pr_data = _make_clean_pr_data(
+        title=title,
+        files=files,
+        url="https://github.com/gptme/gptme-contrib/pull/999",
+    )
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": False, "unresolved": 0, "total": 0},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
+        patch.object(
+            self_merge_check, "_fetch_contrib_pr_file_shapes", return_value=file_shapes
+        ),
+    ):
+        return self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+
+def test_evaluate_pr_contrib_new_top_level_dir_not_eligible() -> None:
+    """End-to-end: CI green, AI review clean, but a new top-level dir in the
+    diff → NOT eligible, and _fetch_contrib_pr_file_shapes must not even be
+    called (the cheaper path-only placement check already disqualified it)."""
+    files = [
+        {"path": "cookbook/01-tool-use-basics.md"},
+        {"path": "scripts/build-cookbook.py"},
+    ]
+    with patch.object(self_merge_check, "_fetch_contrib_pr_file_shapes") as mock_shapes:
+        mock_shapes.return_value = []
+        result = _evaluate_contrib(files, [], title="feat(cookbook): add cookbook")
+    assert not result.eligible
+    assert any("New top-level directory" in r for r in result.reasons)
+    mock_shapes.assert_not_called()
+
+
+def test_evaluate_pr_contrib_agent_literal_end_to_end_not_eligible() -> None:
+    """End-to-end: an ordinary-looking internal-tooling diff (so the
+    path-only placement checks pass) with an agent-name literal added in the
+    patch text → NOT eligible."""
+    files = [{"path": "packages/gptme-runloops/src/gptme_runloops/scoring_helper.py"}]
+    file_shapes = [
+        {
+            "path": "packages/gptme-runloops/src/gptme_runloops/scoring_helper.py",
+            "status": "modified",
+            "patch": "@@ -1,3 +1,4 @@\n+BOB_SPECIFIC_WEIGHT = 1.5\n",
+        }
+    ]
+    result = _evaluate_contrib(files, file_shapes)
+    assert not result.eligible
+    assert any("Agent-name literal" in r for r in result.reasons)
+
+
+def test_evaluate_pr_contrib_clean_internal_tooling_is_eligible() -> None:
+    """End-to-end: contrib#1621-shaped PR (merged by Erik untouched) — clean
+    on every gate, no placement reason, no agent literal → eligible."""
+    files = [
+        {"path": "packages/gptme-runloops/src/gptme_runloops/run_item.py"},
+        {"path": "packages/gptme-runloops/tests/test_worker_records_voice_postcall.py"},
+    ]
+    file_shapes = [
+        {
+            "path": "packages/gptme-runloops/src/gptme_runloops/run_item.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+TIMEOUT_S = 30\n",
+        },
+        {
+            "path": "packages/gptme-runloops/tests/test_worker_records_voice_postcall.py",
+            "status": "modified",
+            "patch": "@@ -1,1 +1,2 @@\n+def test_x(): pass\n",
+        },
+    ]
+    result = _evaluate_contrib(files, file_shapes)
+    assert result.eligible, result.reasons
+    assert result.category == "internal-tooling"
+
+
+def test_evaluate_pr_other_repo_contrib_placement_rule_not_applied() -> None:
+    """A third repo (not gptme/gptme, not gptme/gptme-contrib) must not go
+    through contrib_classify_category — a path shaped exactly like the contrib
+    new-top-level-dir trigger must not produce that contrib-specific reason
+    text (or fetch contrib-only patch data). gptme/gptme cannot be the control
+    here: after #1626 it has its own diff-shape override.
+    """
+    files = [{"path": "totally_new_top_level_dir/foo.py"}]
+    pr_data = _make_clean_pr_data(
+        files=files, url="https://github.com/gptme/gptme-cloud/pull/999"
+    )
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": False, "unresolved": 0, "total": 0},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_ai_review_status",
+            return_value={"accepted": True, "detail": "AI review 5/5 at current head"},
+        ),
+        patch.object(self_merge_check, "_fetch_contrib_pr_file_shapes") as mock_shapes,
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-cloud",
+            999,
+            workspace_repos=["gptme/gptme-cloud"],
+        )
+    # "Files not in any allowed self-merge category" (plain classify_category)
+    # must fire instead of the contrib-specific "New top-level directory"
+    # reason — proves the repo-gated dispatch, not a coincidental verdict.
+    assert not result.eligible
+    assert not any("New top-level directory" in r for r in result.reasons)
     assert any(
         "Files not in any allowed self-merge category" in r for r in result.reasons
     )


### PR DESCRIPTION
## Why

Erik, 2026-09-07: *"I feel like I'm doing too much human review recently ...
learn from the cases where I haven't merged stuff ... so that those reasons
are embedded in the reviewer."* `knowledge/strategic/2026-09-07-auto-merge-analysis.md`
§3 cluster 2 / §5 T2: placement is the one real block class Erik has in
contrib — 129 untouched merges in 90 d, and `classify_category`'s path
categories (`packages/**`, `scripts/**` are already allowed) can't see it.
This needs the diff **shape**, not the path.

## Rules added (all route to Erik with the specific reason quoted)

| Rule | Trigger | Erik quote (corpus) |
|---|---|---|
| New top-level directory | a changed path's top segment isn't an existing repo-root entry | contrib#1428 *"the `knowledge` top-level directory shouldn't exist"* |
| New `packages/<name>/` | a changed path's package name isn't an existing `packages/*` dir | same cluster — a new package is exactly Erik's placement call |
| Agent-name literal | `bob`/`alice`/`gordon`/`sven`/`erik` added in non-test code (word-boundary, not substring) | contrib#1088 *"Bob shouldn't have his configuration in gptme-contrib"* |
| Writes under `state/` | path starts with `state/` | contrib#1250 *"state belongs in brain, not contrib"* |
| Basename collision | a new `packages/<name>/src/**/<file>.py` basename already exists under a *different* package's `src/` (denylist for `__init__.py`/`cli.py`/etc. to avoid boilerplate noise) | contrib#1219 *"please don't re-implement prior art (gptme-rag)"* — gptme-wisdom-mcp's `indexer.py`/`mcp_server.py` duplicate `gptme-rag`'s |

Plus two adjacent fixes named in the same corpus analysis:

- **Sensitive-path keyword scan, segment not substring**: `is_sensitive_path`'s
  compound-word scanner no longer trips on a *test* file's own name —
  `secrets_test.py` / `tests/deploy_test.py` are test files ABOUT
  secrets/deploy handling, not files that hold one. Matched via
  `is_test_file()` (already path-segment-anchored), not the filename
  substring. Applies repo-wide (every repo this script evaluates), since the
  bug lives in shared code. Real prefix/suffix/dotfile/private-key checks are
  unaffected — only the keyword-token scan is skipped for test paths.
- **Spec-like doc waiver**: the root `SPEC_LIKE_DOCS` hard stop (README.md
  etc.) is waived when the same PR also touches `packages/**` — i.e. the doc
  edit is registering a package the PR implements end-to-end, not a
  standalone doc PR. A doc-only PR still routes to Erik.

## Corpus verdicts (real file lists, `gh pr view --json files`)

Erik blocked on placement:
- **contrib#1325** (CLOSED, `cookbook/`) → routes: new top-level directory
- **contrib#1428** (CLOSED, `knowledge/`) → routes: new top-level directory
- **contrib#1219** (MERGED, gptme-wisdom-mcp) → routes: basename collision
  with `gptme-rag`'s `indexer.py`/`mcp_server.py`

Erik merged untouched (must stay eligible):
- **contrib#1621** (fix, `gptme-runloops`) → `internal-tooling`, zero reasons
- **contrib#1617** (feat, `gptme-voice`) → `internal-tooling`, zero reasons
- **contrib#1576** (root `README.md` + `gptme-body-protocol` package impl,
  73 identical refusals before Erik merged it manually) → waived,
  `...+spec-doc-waived`, doc-only variant of the same PR still routes

## Overlap with #1626

Both this PR and gptme/gptme-contrib#1626 (`gptme-core-selfmerge-diffshape`)
touch `classify_category(files, repo=repo)`'s call site in `evaluate_pr` and
add sibling "diff shape, not path category" detectors — #1626 for
`gptme/gptme`, this one for `gptme/gptme-contrib`. Same idea, disjoint repos
and helper names (`_GPTME_CORE_*`/`gptme_core_*` vs `_GPTME_CONTRIB_*`/
`contrib_*`), so both can land and revert independently — but the shared call
site means whichever merges second will need a small manual conflict
resolution (two `if repo == ...` branches replacing the same three original
lines), not a design conflict.

## Tests

`tests/test_self_merge_check.py`: 21 new tests — 3 corpus-grounded placement
blocks, 2 corpus-grounded clean/eligible cases, the spec-doc waiver (waived +
not-waived), a new-package isolation test, a loose-file-under-`packages/`
regression guard, the substring-false-positive parametrized set (+ a
still-blocks-real-sensitive-paths counter-set), 3 agent-literal tests
(non-test fires, test-code excluded, word-boundary "erikson" doesn't
false-positive), and 5 end-to-end `evaluate_pr` tests (including one proving
the patch-fetch is skipped once a cheap path-only check already disqualifies
the PR, and one proving another repo doesn't go through the contrib rule).
`308 passed` for the full `tests/test_self_merge_check.py` file. `ruff
check`/`ruff format --check` and `mypy --config-file mypy.ini` both clean.
`pr-quality-gate.py`: 94/100, OPEN (flags the expected #1626 overlap above,
non-blocking).
