### PR TITLE
fix(state-status): raise RuntimeError instead of silent return when not in git repo

### DIFF
--- a/scripts/state-status.py
+++ b/scripts/state-status.py
@@ -78,7 +78,7 @@ def find_repo_root(start_path: Path) -> Path:
         if (current / ".git").exists():
             return current
         current = current.parent
-    return start_path.resolve()
+    raise RuntimeError(f"No git repository found above {start_path}")
 
 
 @dataclass

--- a/tests/test_state_status.py
+++ b/tests/test_state_status.py
@@ -1,0 +1,20 @@
+"""Regression tests for scripts/state-status.py."""
+
+import subprocess
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "state-status.py"
+
+
+def test_running_outside_git_repo_reports_an_error(tmp_path: Path) -> None:
+    """The CLI must not silently treat an arbitrary directory as a repo root."""
+    result = subprocess.run(
+        [str(SCRIPT_PATH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert f"RuntimeError: No git repository found above {tmp_path}" in result.stderr

--- a/tests/test_state_status.py
+++ b/tests/test_state_status.py
@@ -1,20 +1,25 @@
 """Regression tests for scripts/state-status.py."""
 
-import subprocess
+from __future__ import annotations
+
+import importlib.util
+import sys
 from pathlib import Path
+
+import pytest
 
 SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "state-status.py"
 
+spec = importlib.util.spec_from_file_location("state_status", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+sys.modules["state_status"] = mod
+spec.loader.exec_module(mod)
 
-def test_running_outside_git_repo_reports_an_error(tmp_path: Path) -> None:
-    """The CLI must not silently treat an arbitrary directory as a repo root."""
-    result = subprocess.run(
-        [str(SCRIPT_PATH)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+find_repo_root = mod.find_repo_root
 
-    assert result.returncode != 0
-    assert f"RuntimeError: No git repository found above {tmp_path}" in result.stderr
+
+def test_find_repo_root_raises_outside_git_repo(tmp_path: Path) -> None:
+    """find_repo_root must not silently treat an arbitrary directory as a repo root."""
+    with pytest.raises(RuntimeError, match="No git repository found above"):
+        find_repo_root(tmp_path)


### PR DESCRIPTION
## Summary

- `find_repo_root()` in `scripts/state-status.py` silently returned `start_path.resolve()` when no `.git` directory was found, passing a wrong path to callers with no error signal.
- Fixed to raise `RuntimeError(f"No git repository found above {start_path}")`, matching the error behavior of `bobutils.roots.find_repo_root`.

## Root Cause

This was a semantic duplicate of `bobutils.roots.find_repo_root` (which uses `git rev-parse --show-toplevel` and raises on failure). The local copy had a divergent — and incorrect — not-found path.

## Test plan

- [ ] Run `scripts/state-status.py` inside a valid git repo → works normally
- [ ] Run `scripts/state-status.py` in `/tmp` (outside git repo) → raises `RuntimeError` with a clear message instead of silently using the wrong path