### PR TITLE
refactor(self-merge): share AI review blocking predicate

### DIFF
--- a/packages/gptme-contrib-lib/src/gptme_contrib_lib/ai_review_policy.py
+++ b/packages/gptme-contrib-lib/src/gptme_contrib_lib/ai_review_policy.py
@@ -28,7 +28,12 @@ def blocking_shortfall(rows: Sequence[FindingRow]) -> list[Shortfall]:
     for row in rows:
         severity_value = row.get("severity")
         severity = str(severity_value) if severity_value is not None else None
-        if severity is not None and severity not in {"P0", "P1"}:
+        if (
+            severity is not None
+            and severity.startswith("P")
+            and severity[1:].isdigit()
+            and int(severity[1:]) >= 2
+        ):
             continue
         if row.get("disposition") or row.get("superseded"):
             continue

--- a/packages/gptme-contrib-lib/src/gptme_contrib_lib/ai_review_policy.py
+++ b/packages/gptme-contrib-lib/src/gptme_contrib_lib/ai_review_policy.py
@@ -1,0 +1,48 @@
+"""Shared policy for deciding which AI-review findings block a merge."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TypedDict
+
+FindingRow = Mapping[str, object]
+
+
+class Shortfall(TypedDict):
+    """One finding that prevents the AI-review gate from accepting the head."""
+
+    fp: str
+    severity: str | None
+    reason: str
+
+
+def blocking_shortfall(rows: Sequence[FindingRow]) -> list[Shortfall]:
+    """Return every finding that remains blocking under the shared policy.
+
+    Producers normalize transport-specific GitHub payloads into rows. This
+    function owns the policy: readable P2+ findings never block; unreadable
+    severity fails closed; and P0/P1 findings block until explicitly disposed,
+    superseded by the latest review, or both replied to and resolved.
+    """
+    shortfalls: list[Shortfall] = []
+    for row in rows:
+        severity_value = row.get("severity")
+        severity = str(severity_value) if severity_value is not None else None
+        if severity is not None and severity not in {"P0", "P1"}:
+            continue
+        if row.get("disposition") or row.get("superseded"):
+            continue
+        if row.get("isResolved") and bool(row.get("replied")):
+            continue
+        label = (
+            f"{severity} finding" if severity else "finding with unreadable severity"
+        )
+        reason = (
+            f"{label} resolved without a reply (not disposed)"
+            if row.get("isResolved")
+            else f"{label} is not resolved"
+        )
+        shortfalls.append(
+            {"fp": str(row.get("fp") or ""), "severity": severity, "reason": reason}
+        )
+    return shortfalls

--- a/packages/gptme-contrib-lib/tests/test_ai_review_policy.py
+++ b/packages/gptme-contrib-lib/tests/test_ai_review_policy.py
@@ -6,15 +6,12 @@ import importlib.util
 import sys
 from pathlib import Path
 
-_CONTRIB_LIB_SRC = (
-    Path(__file__).resolve().parents[1] / "packages" / "gptme-contrib-lib" / "src"
-)
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONTRIB_LIB_SRC = REPO_ROOT / "packages" / "gptme-contrib-lib" / "src"
 sys.path.insert(0, str(_CONTRIB_LIB_SRC))
 from gptme_contrib_lib.ai_review_policy import blocking_shortfall  # type: ignore[import-not-found]  # noqa: E402,I001
 
-MODULE_PATH = (
-    Path(__file__).resolve().parents[1] / "scripts" / "github" / "self-merge-check.py"
-)
+MODULE_PATH = REPO_ROOT / "scripts" / "github" / "self-merge-check.py"
 spec = importlib.util.spec_from_file_location(
     "self_merge_check_shared_policy", MODULE_PATH
 )

--- a/packages/gptme-contrib-lib/tests/test_ai_review_policy.py
+++ b/packages/gptme-contrib-lib/tests/test_ai_review_policy.py
@@ -65,6 +65,17 @@ def test_unreadable_severity_fails_closed_but_p2_does_not_block() -> None:
         "finding with unreadable severity is not resolved"
     )
     assert blocking_shortfall([_row(severity="P2")]) == []
+    assert blocking_shortfall([_row(severity="P3")]) == []
+
+
+def test_unknown_non_null_severity_fails_closed() -> None:
+    for severity in ("CRITICAL", "high", "P1 ", ""):
+        shortfalls = blocking_shortfall([_row(severity=severity)])
+        assert shortfalls
+        assert shortfalls[0]["reason"].endswith("finding is not resolved") or (
+            shortfalls[0]["reason"]
+            == "finding with unreadable severity is not resolved"
+        )
 
 
 def test_merge_gate_imports_the_shared_predicate() -> None:

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -118,6 +118,12 @@ from functools import cache
 from pathlib import Path
 from typing import Any, Iterator, cast
 
+_CONTRIB_LIB_SRC = (
+    Path(__file__).resolve().parents[2] / "packages" / "gptme-contrib-lib" / "src"
+)
+sys.path.insert(0, str(_CONTRIB_LIB_SRC))
+from gptme_contrib_lib.ai_review_policy import blocking_shortfall  # type: ignore[import-not-found]  # noqa: E402,I001
+
 MAX_GRAPHQL_PAGE_SIZE = 100
 DEFAULT_MIN_GREPTILE_SCORE = 5
 
@@ -1196,6 +1202,7 @@ def _ai_review_disposition_shortfall(
     _, threads = review_data
     disposed: dict[str, int] = {"P0": 0, "P1": 0}
     disposed_fps: set[tuple[str, str]] = set()
+    policy_rows: list[dict[str, object]] = []
     for thread in threads:
         comments = thread.get("comments") or {}
         nodes = comments.get("nodes") or []
@@ -1229,18 +1236,21 @@ def _ai_review_disposition_shortfall(
         severity = m.group(1) if m else None
         if severity is not None and severity not in AI_REVIEW_BLOCKING_SEVERITIES:
             continue  # surviving P2s never block
-        label = (
-            f"{severity} finding" if severity else "finding with unreadable severity"
-        )
         fp = _ai_review_fp_from_body(body)
-        if not thread.get("isResolved"):
-            return f"{label} is not resolved"
         total = comments.get("totalCount")
         replied = isinstance(total, int) and total >= 2
-        if not replied:
-            if fp and fp in auto_resolved:
-                continue  # reviewer-retired because the fix stopped it reproducing
-            return f"{label} resolved without a reply (not disposed)"
+        policy_rows.append(
+            {
+                "fp": fp or "",
+                "severity": severity,
+                "isResolved": bool(thread.get("isResolved")),
+                "replied": replied,
+                "superseded": bool(fp and fp in auto_resolved),
+                "disposition": None,
+            }
+        )
+        if fp and fp in auto_resolved:
+            continue  # reviewer-retired because the fix stopped it reproducing
         # Counted only here — after the thread proved disposed — and only for a
         # severity we could actually read. Two exclusions, both fail-closed:
         #   * `auto_resolved` is the reviewer's own record that this finding
@@ -1261,6 +1271,10 @@ def _ai_review_disposition_shortfall(
                 # the re-raised P0 could not be anchored, i.e. when the recall
                 # guard is the only thing left checking.
                 disposed_fps.add((fp, severity))
+
+    shortfalls = blocking_shortfall(policy_rows)
+    if shortfalls:
+        return str(shortfalls[0]["reason"])
 
     def _blocking_findings(
         marker_findings: list[Any],

--- a/tests/test_ai_review_policy.py
+++ b/tests/test_ai_review_policy.py
@@ -1,0 +1,74 @@
+"""Shared AI-review blocking policy consumed by merge gates and renderers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_CONTRIB_LIB_SRC = (
+    Path(__file__).resolve().parents[1] / "packages" / "gptme-contrib-lib" / "src"
+)
+sys.path.insert(0, str(_CONTRIB_LIB_SRC))
+from gptme_contrib_lib.ai_review_policy import blocking_shortfall  # type: ignore[import-not-found]  # noqa: E402,I001
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "github" / "self-merge-check.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "self_merge_check_shared_policy", MODULE_PATH
+)
+assert spec and spec.loader
+smc = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = smc
+spec.loader.exec_module(smc)
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "fp": "deadbeef1234",
+        "severity": "P1",
+        "isResolved": False,
+        "replied": False,
+        "superseded": False,
+        "disposition": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_open_p1_blocks() -> None:
+    assert blocking_shortfall([_row()]) == [
+        {
+            "fp": "deadbeef1234",
+            "severity": "P1",
+            "reason": "P1 finding is not resolved",
+        }
+    ]
+
+
+def test_resolution_requires_reply() -> None:
+    assert blocking_shortfall([_row(isResolved=True)]) == [
+        {
+            "fp": "deadbeef1234",
+            "severity": "P1",
+            "reason": "P1 finding resolved without a reply (not disposed)",
+        }
+    ]
+    assert blocking_shortfall([_row(isResolved=True, replied=True)]) == []
+
+
+def test_explicit_disposition_or_supersession_clears() -> None:
+    assert blocking_shortfall([_row(disposition={"reason": "rejected"})]) == []
+    assert blocking_shortfall([_row(superseded=True)]) == []
+
+
+def test_unreadable_severity_fails_closed_but_p2_does_not_block() -> None:
+    assert blocking_shortfall([_row(severity=None)])[0]["reason"] == (
+        "finding with unreadable severity is not resolved"
+    )
+    assert blocking_shortfall([_row(severity="P2")]) == []
+
+
+def test_merge_gate_imports_the_shared_predicate() -> None:
+    assert smc.blocking_shortfall is blocking_shortfall


### PR DESCRIPTION
## Summary

- move the AI-review thread blocking rule into `gptme_contrib_lib.ai_review_policy`
- make `self-merge-check.py` consume that shared predicate while preserving its existing fingerprint recall guard
- add contract tests for open, replied+resolved, superseded, disposition, P2, and unreadable-severity states

This is the upstream half of the Bob task to stop the merge gate and reviewer summary from hand-copying different blocking rules. PR #1628 touches the same gate file for unrelated path classification and can merge in either order; this branch is current with `origin/master`.

## Verification

- `uv run --package gptme-contrib-lib pytest tests/test_ai_review_policy.py tests/test_self_merge_ai_review_gate.py tests/test_self_merge_ai_review_threads.py tests/test_self_merge_check.py -q --disable-warnings` — 397 passed
- `uv run ruff check packages/gptme-contrib-lib/src/gptme_contrib_lib/ai_review_policy.py scripts/github/self-merge-check.py tests/test_ai_review_policy.py`
- `uv run mypy --config-file=mypy.ini --explicit-package-bases scripts/github/self-merge-check.py tests/test_ai_review_policy.py`
- pre-commit hooks passed
