### PR TITLE
feat(gptmail): add 'gptmail agent watch' reply monitor (closes #1631)

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -41,6 +41,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1299,6 +1300,156 @@ def status(mailbox: str, all_mailboxes: bool) -> None:
     click.echo(f"Pending:  {len(pend)}")
     if stale:
         click.echo(f"Stale:    {len(stale)} (unreplied, aged out of reply window)")
+
+
+@agent.command()
+@click.option(
+    "--to",
+    "to_recipient",
+    default=None,
+    help="Watch for messages addressed to this recipient (default: self).",
+)
+@click.option(
+    "--from",
+    "from_agents",
+    default=None,
+    help="Comma-separated list of agents to watch (default: all SSH-reachable agents).",
+)
+@click.option(
+    "--interval",
+    default=45,
+    show_default=True,
+    type=int,
+    help="Poll interval in seconds.",
+)
+@click.option("--once", is_flag=True, help="Exit after the first new message.")
+@click.option(
+    "--pull",
+    "do_pull",
+    is_flag=True,
+    help="Invoke 'gptmail agent pull' after each hit to fetch the message locally.",
+)
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to watch.")
+@click.option("--all-mailboxes", is_flag=True, help="Watch across all mailboxes.")
+def watch(
+    to_recipient: str | None,
+    from_agents: str | None,
+    interval: int,
+    once: bool,
+    do_pull: bool,
+    mailbox: str,
+    all_mailboxes: bool,
+) -> None:
+    """Watch agents' outboxes for new messages (streaming reply monitor).
+
+    Baselines each watched agent's outbox count of messages addressed to --to,
+    then polls via SSH every --interval seconds. Emits one line per new message
+    so it composes with Claude Code's Monitor tool, launchd/systemd units, or a
+    plain terminal.
+
+    \b
+    Example — watch all agents for new messages to erik:
+        gptmail agent watch --to erik
+    Example — watch only alice and bob, exit on first reply:
+        gptmail agent watch --to erik --from alice,bob --once
+    """
+    agents = _load_agents()
+    recipient = (to_recipient or _self_name()).lower()
+
+    # Build the set of agents to watch.
+    if from_agents:
+        names = [a.strip().lower() for a in from_agents.split(",") if a.strip()]
+        unknown = [n for n in names if n not in agents]
+        for u in unknown:
+            click.echo(f"Warning: unknown agent '{u}' in --from, skipping.", err=True)
+        watch_agents = {n: agents[n] for n in names if n in agents}
+    else:
+        watch_agents = {k: v for k, v in agents.items() if k != recipient}
+
+    # Exclude pull-only or incompletely configured agents (no SSH).
+    skipped = [
+        name
+        for name, cfg in watch_agents.items()
+        if cfg.get("delivery") == "pull-only" or not all(cfg.get(k) for k in ("ssh", "workspace"))
+    ]
+    ssh_agents = {k: v for k, v in watch_agents.items() if k not in skipped}
+    if skipped:
+        click.echo(f"Note: skipping non-SSH agents: {', '.join(skipped)}", err=True)
+
+    if not ssh_agents:
+        click.echo("No SSH-reachable agents to watch.", err=True)
+        sys.exit(1)
+
+    mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
+
+    click.echo(
+        f"Watching {len(ssh_agents)} agent(s) for messages to {recipient} "
+        f"(interval: {interval}s)...",
+        err=True,
+    )
+
+    # Baseline: None = not yet successfully probed; set[str] = known filenames.
+    baselines: dict[str, set[str] | None] = {}
+    for agent_name, agent_cfg in ssh_agents.items():
+        rows = _remote_pending_rows(
+            agent_name,
+            agent_cfg,
+            recipient=recipient,
+            mailboxes=mailboxes,
+            all_mailboxes=all_mailboxes,
+        )
+        if rows is None:
+            click.echo(f"Warning: {agent_name} unreachable at baseline; will retry.", err=True)
+            baselines[agent_name] = None
+        else:
+            baselines[agent_name] = {str(row.get("file", "")) for row in rows if row.get("file")}
+
+    try:
+        while True:
+            time.sleep(interval)
+            for agent_name, agent_cfg in ssh_agents.items():
+                rows = _remote_pending_rows(
+                    agent_name,
+                    agent_cfg,
+                    recipient=recipient,
+                    mailboxes=mailboxes,
+                    all_mailboxes=all_mailboxes,
+                )
+                if rows is None:
+                    continue  # unreachable — skip and retry next poll
+                current = {str(row.get("file", "")) for row in rows if row.get("file")}
+                known = baselines.get(agent_name)
+                if known is None:
+                    # First successful probe after a failed baseline: set baseline, no event.
+                    baselines[agent_name] = current
+                    continue
+                new_rows = [row for row in rows if str(row.get("file", "")) not in known]
+                if not new_rows:
+                    continue
+                now_str = datetime.now(timezone.utc).strftime("%H:%M:%SZ")
+                old_count = len(known)
+                new_count = len(current)
+                for row in new_rows:
+                    subject = str(row.get("subject", "(no subject)"))
+                    filename = str(row.get("file", ""))
+                    click.echo(
+                        f"{now_str} NEW reply from {agent_name} "
+                        f"({old_count} -> {new_count}): {subject} ({filename})"
+                    )
+                baselines[agent_name] = current
+                if do_pull:
+                    try:
+                        subprocess.run(
+                            [sys.executable, "-m", "gptmail", "agent", "pull", "--as", recipient],
+                            check=False,
+                            timeout=60,
+                        )
+                    except (OSError, subprocess.TimeoutExpired) as e:
+                        click.echo(f"Warning: --pull failed: {e}", err=True)
+                if once:
+                    return
+    except KeyboardInterrupt:
+        click.echo("\nWatch stopped.", err=True)
 
 
 if __name__ == "__main__":

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -1348,10 +1348,10 @@ def watch(
     plain terminal.
 
     \b
-    Example — watch all agents for new messages to erik:
-        gptmail agent watch --to erik
-    Example — watch only alice and bob, exit on first reply:
-        gptmail agent watch --to erik --from alice,bob --once
+    Example — watch all agents for new messages to you (the default):
+        gptmail agent watch
+    Example — watch a subset of agents, exit on first reply:
+        gptmail agent watch --from peer1,peer2 --once
     """
     agents = _load_agents()
     recipient = (to_recipient or _self_name()).lower()

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -1092,3 +1092,222 @@ def test_ssh_control_path_different_targets_differ() -> None:
     p1 = agent_cli._ssh_control_path("alice@alice.lxc")
     p2 = agent_cli._ssh_control_path("bob@bob.lxc")
     assert p1 != p2
+
+
+# ---------------------------------------------------------------------------
+# watch command tests
+# ---------------------------------------------------------------------------
+
+
+def _make_row(filename: str, subject: str, sender: str = "bob", recipient: str = "erik") -> dict:
+    return {
+        "file": filename,
+        "subject": subject,
+        "from": sender,
+        "to": recipient,
+        "timestamp": "2026-09-07T12:00:00Z",
+    }
+
+
+def test_watch_detects_new_message_once(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """watch --once emits a formatted line when a new outbox message appears."""
+    calls: list[int] = [0]
+
+    def _fake_remote_rows(
+        agent_name: str,
+        agent_cfg: dict,
+        *,
+        recipient: str,
+        mailboxes: list,
+        all_mailboxes: bool,
+    ) -> list[dict]:
+        calls[0] += 1
+        if calls[0] == 1:
+            return []  # baseline: empty
+        # First poll: one new message
+        return [_make_row("20260907-120000-bob-Hello.md", "Hello from bob")]
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_rows)
+    monkeypatch.setattr(agent_cli.time, "sleep", lambda _: None)
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik", "--once"])
+    assert result.exit_code == 0, result.output
+    assert "NEW reply from bob" in result.output
+    assert "Hello from bob" in result.output
+    assert "20260907-120000-bob-Hello.md" in result.output
+    assert "(0 -> 1)" in result.output
+
+
+def test_watch_emits_count_transition_for_multiple_new_messages(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """watch shows old→new count when multiple messages appear at once."""
+    calls: list[int] = [0]
+
+    def _fake_remote_rows(
+        agent_name: str,
+        agent_cfg: dict,
+        *,
+        recipient: str,
+        mailboxes: list,
+        all_mailboxes: bool,
+    ) -> list[dict]:
+        calls[0] += 1
+        if calls[0] == 1:
+            return [_make_row("20260907-110000-bob-Earlier.md", "Earlier")]
+        return [
+            _make_row("20260907-110000-bob-Earlier.md", "Earlier"),
+            _make_row("20260907-120000-bob-Later.md", "Later"),
+        ]
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_rows)
+    monkeypatch.setattr(agent_cli.time, "sleep", lambda _: None)
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik", "--once"])
+    assert result.exit_code == 0, result.output
+    assert "Later" in result.output
+    assert "Earlier" not in result.output  # not new
+    assert "(1 -> 2)" in result.output
+
+
+def test_watch_baseline_failure_then_success_no_spurious_event(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If baseline fails, first successful poll establishes baseline (no event)."""
+    calls: list[int] = [0]
+    stop: list[bool] = [False]
+
+    def _fake_remote_rows(
+        agent_name: str,
+        agent_cfg: dict,
+        *,
+        recipient: str,
+        mailboxes: list,
+        all_mailboxes: bool,
+    ) -> list[dict] | None:
+        calls[0] += 1
+        if calls[0] == 1:
+            return None  # baseline probe fails
+        if calls[0] == 2:
+            stop[0] = True
+            return [_make_row("20260907-existing.md", "Existing")]
+        return []
+
+    def _fake_sleep(_: int) -> None:
+        if stop[0]:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_rows)
+    monkeypatch.setattr(agent_cli.time, "sleep", _fake_sleep)
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik"])
+    assert result.exit_code == 0, result.output
+    # The existing message on first successful probe must NOT generate an event.
+    assert "NEW reply" not in result.output
+    assert "Watch stopped." in result.output
+
+
+def test_watch_skips_pull_only_agents(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Agents with delivery=pull-only are excluded from the watch set."""
+    # Add a pull-only agent to the registry.
+    config_path = workspace / "messages" / "agents.yaml"
+    registry = yaml.safe_load(config_path.read_text())
+    registry["gordon"] = {"delivery": "pull-only"}
+    config_path.write_text(yaml.dump(registry))
+
+    probed: list[str] = []
+
+    def _fake_remote_rows(
+        agent_name: str,
+        agent_cfg: dict,
+        *,
+        recipient: str,
+        mailboxes: list,
+        all_mailboxes: bool,
+    ) -> list[dict]:
+        probed.append(agent_name)
+        return []
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_rows)
+    monkeypatch.setattr(
+        agent_cli.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt())
+    )
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik"])
+    assert result.exit_code == 0, result.output
+    assert "gordon" not in probed
+    assert "bob" in probed
+
+
+def test_watch_from_filter_restricts_agents(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--from limits watch to the named agents only."""
+    # Add gordon to the registry alongside bob.
+    config_path = workspace / "messages" / "agents.yaml"
+    registry = yaml.safe_load(config_path.read_text())
+    registry["gordon"] = {"ssh": "gordon@gordon", "workspace": "/gordon"}
+    config_path.write_text(yaml.dump(registry))
+
+    probed: list[str] = []
+
+    def _fake_remote_rows(
+        agent_name: str,
+        agent_cfg: dict,
+        *,
+        recipient: str,
+        mailboxes: list,
+        all_mailboxes: bool,
+    ) -> list[dict]:
+        probed.append(agent_name)
+        return []
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_rows)
+    monkeypatch.setattr(
+        agent_cli.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt())
+    )
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik", "--from", "bob"])
+    assert result.exit_code == 0, result.output
+    assert "bob" in probed
+    assert "gordon" not in probed
+
+
+def test_watch_warns_unknown_from_agent(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--from with an unknown agent name emits a warning and continues with known ones."""
+    probed: list[str] = []
+
+    def _fake_remote_rows(
+        agent_name: str,
+        agent_cfg: dict,
+        *,
+        recipient: str,
+        mailboxes: list,
+        all_mailboxes: bool,
+    ) -> list[dict]:
+        probed.append(agent_name)
+        return []
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_rows)
+    monkeypatch.setattr(
+        agent_cli.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt())
+    )
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik", "--from", "bob,nobody"])
+    assert result.exit_code == 0, result.output
+    assert "unknown agent 'nobody'" in result.output
+    assert "bob" in probed
+
+
+def test_watch_no_ssh_agents_exits_nonzero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """watch exits non-zero when there are no SSH-reachable agents to watch."""
+    messages = tmp_path / "messages"
+    (messages / "inbox").mkdir(parents=True)
+    (messages / "outbox").mkdir(parents=True)
+    (messages / "agents.yaml").write_text(yaml.dump({"erik": {"delivery": "pull-only"}}))
+    monkeypatch.setenv("AGENT_NAME", "alice")
+    monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
+
+    result = CliRunner().invoke(agent, ["watch", "--to", "erik"])
+    assert result.exit_code != 0
+    assert "No SSH-reachable agents" in result.output


### PR DESCRIPTION
## Summary

- Adds `gptmail agent watch` subcommand to `packages/gptmail/src/gptmail/agent_cli.py`
- Baselines each SSH-reachable agent's outbox of messages addressed to `--to`, then polls every `--interval` seconds (default 45)
- Emits one stdout line per new message: `HH:MM:SSZ NEW reply from <agent> (old -> new): <subject> (<filename>)` — composes with Claude Code's Monitor tool, launchd/systemd, or any harness reading stdout
- Supports `--to`, `--from` (comma-separated filter), `--interval`, `--once` (exit after first hit), `--pull` (invoke `gptmail agent pull` after each hit), `--mailbox`, `--all-mailboxes`
- Pull-only/unconfigured agents are skipped with a note; agents unreachable at baseline retry silently and establish their baseline on first successful poll (no spurious events)
- 7 new tests; no-email-imports guard still passes; 211 tests green

## Test plan

- [x] `uv run pytest packages/gptmail/tests/test_agent_cli.py -q` → 66 passed
- [x] `uv run pytest packages/gptmail/tests/test_agent_cli_no_email_imports.py` → 1 passed
- [x] `uv run pytest packages/gptmail/tests/ -q` → 211 passed

<!-- gptme-id:v1:gai_QTGC2eGWdyH5eLbuDSJK3Nfeq5BSV0Vp6Yldna9FVLO -->