### PR TITLE
feat(self-merge): waive AI-review abstention for safe gitlink bumps

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -58,7 +58,12 @@ falls back to requiring Greptile rather than approving:
   read as full consensus", so it does not satisfy this gate either. Get a
   qualifying review with a consensus re-review: `ai-review.py OWNER/REPO N --force`.
 - the reviewer did not abstain (a null score is "no verdict" — the submodule
-  pointer-bump case — and must never read as a pass)
+  pointer-bump case — and must never read as a pass). Abstention is never an
+  AI-review *pass*. A pointer-only gitlink bump may waive the AI-review
+  *requirement* when Greptile is 5/5 at the current head, the gitlink path is
+  already in SELF_MERGE_ALLOWED_PATHS, and the new SHA is backed by a merged
+  upstream PR (PR existence, not merge-base — squash-merge leaves the original
+  SHA unreachable). Branch-only pins stay blocked (gptme-cloud#850 / #898).
 - the marker comment was posted by the authenticated user. Anyone can write the
   marker string into a comment on our PR; only our own account posts a real one.
 
@@ -3181,6 +3186,194 @@ def _parse_self_merge_min_greptile_score() -> int:
     return DEFAULT_MIN_GREPTILE_SCORE
 
 
+_SUBPROJECT_COMMIT_RE = re.compile(r"^([+-])Subproject commit ([0-9a-f]{7,40})$")
+
+
+def parse_gitmodules(text: str) -> dict[str, str]:
+    """Map submodule path → url from a `.gitmodules` body."""
+    path_to_url: dict[str, str] = {}
+    current_path: str | None = None
+    current_url: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("[submodule"):
+            if current_path and current_url:
+                path_to_url[current_path] = current_url
+            current_path = None
+            current_url = None
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if key == "path":
+            current_path = value
+        elif key == "url":
+            current_url = value
+    if current_path and current_url:
+        path_to_url[current_path] = current_url
+    return path_to_url
+
+
+def github_repo_from_remote_url(url: str) -> str | None:
+    """owner/repo from a GitHub clone URL, or None if it is not GitHub."""
+    stripped = url.strip()
+    prefixes = (
+        "git@github.com:",
+        "https://github.com/",
+        "http://github.com/",
+        "ssh://git@github.com/",
+        "git://github.com/",
+    )
+    rest = None
+    for prefix in prefixes:
+        if stripped.startswith(prefix):
+            rest = stripped[len(prefix) :]
+            break
+    if rest is None:
+        return None
+    rest = rest.removesuffix(".git").removesuffix("/")
+    parts = rest.split("/")
+    if len(parts) != 2 or not all(parts):
+        return None
+    return f"{parts[0]}/{parts[1]}"
+
+
+def parse_pointer_only_gitlink(
+    file_shapes: list[dict[str, Any]],
+) -> tuple[str, str] | None:
+    """Single 160000 pointer bump → (path, new_sha), else None.
+
+    GitHub's patch for a gitlink is two `Subproject commit` lines. Any other
+    added/removed line means this is not pointer-only.
+    """
+    if len(file_shapes) != 1:
+        return None
+    entry = file_shapes[0]
+    path = str(entry.get("path") or "").replace("\\", "/").removeprefix("./")
+    if not path:
+        return None
+    patch = entry.get("patch")
+    if not isinstance(patch, str) or not patch.strip():
+        return None
+    added: list[str] = []
+    removed: list[str] = []
+    for line in patch.splitlines():
+        if (
+            line.startswith("@@")
+            or line.startswith("diff ")
+            or line.startswith("index ")
+            or line.startswith("---")
+            or line.startswith("+++")
+            or line.startswith("old mode ")
+            or line.startswith("new mode ")
+        ):
+            continue
+        match = _SUBPROJECT_COMMIT_RE.match(line)
+        if match:
+            sha = match.group(2)
+            if match.group(1) == "+":
+                added.append(sha)
+            else:
+                removed.append(sha)
+            continue
+        if line.startswith(("+", "-")):
+            return None
+    if len(added) != 1 or len(removed) != 1 or added[0] == removed[0]:
+        return None
+    return path, added[0]
+
+
+def fetch_gitmodules_text(repo: str) -> str | None:
+    return run_gh_checked(
+        [
+            "api",
+            f"repos/{repo}/contents/.gitmodules",
+            "-H",
+            "Accept: application/vnd.github.raw",
+        ]
+    )
+
+
+def commit_has_merged_upstream_pr(upstream_repo: str, sha: str) -> bool | None:
+    """Whether *sha* is associated with a merged PR in *upstream_repo*.
+
+    Uses PR association, not `merge-base --is-ancestor`. Squash-merge leaves
+    the original SHA unreachable from master, which is the healthy case
+    (gptme-cloud#901 / gptme#3742). A branch-only pin with no PR returns
+    False (gptme-cloud#898's 9da4505).
+
+    ``None`` means the lookup failed — callers must fail closed.
+    """
+    raw = run_gh_checked(
+        [
+            "api",
+            f"repos/{upstream_repo}/commits/{sha}/pulls",
+            "--jq",
+            ".[] | {number, merged_at}",
+        ]
+    )
+    if raw is None:
+        return None
+    for doc in _iter_json_documents(raw):
+        if isinstance(doc, dict) and doc.get("merged_at"):
+            return True
+    return False
+
+
+def pointer_only_gitlink_ai_review_waiver(
+    *,
+    repo: str,
+    number: int,
+    files: list[str],
+    greptile_is_fresh: bool,
+    greptile_unresolved: int,
+    greptile_score: int | None,
+) -> str | None:
+    """Waive the AI-review *requirement* for a safe pointer-only gitlink bump.
+
+    Returns a warning string when every condition holds, else None. This does
+    not make an abstention count as an AI-review pass — `fetch_ai_review_status`
+    still refuses `score: null`. It only stops that refusal from being a
+    permanent self-merge block when Greptile + allowlist + merged-upstream-PR
+    already cover the bump (gptme-cloud#901 vs #898/#850).
+    """
+    if not greptile_is_fresh or greptile_unresolved > 0:
+        return None
+    min_score = _parse_self_merge_min_greptile_score()
+    if type(greptile_score) is not int or greptile_score < min_score:
+        return None
+    if len(files) != 1:
+        return None
+    path = files[0]
+    if not is_repo_allowlisted_path(path, repo):
+        return None
+
+    parsed = parse_pointer_only_gitlink(_fetch_pr_file_shapes(repo, number))
+    if parsed is None:
+        return None
+    gitlink_path, new_sha = parsed
+    if gitlink_path != path:
+        return None
+
+    gitmodules = fetch_gitmodules_text(repo)
+    if not gitmodules:
+        return None
+    url = parse_gitmodules(gitmodules).get(gitlink_path)
+    if not url:
+        return None
+    upstream = github_repo_from_remote_url(url)
+    if not upstream:
+        return None
+    if commit_has_merged_upstream_pr(upstream, new_sha) is not True:
+        return None
+    return (
+        f"AI review waived: pointer-only gitlink {gitlink_path} → {new_sha[:12]} "
+        f"backed by a merged {upstream} PR; Greptile {greptile_score}/5 at current head"
+    )
+
+
 def evaluate_pr(
     repo: str, number: int, *, workspace_repos: list[str] | None
 ) -> CheckResult:
@@ -3355,6 +3548,8 @@ def evaluate_pr(
         and greptile_reviewed_sha is not None
         and _sha_matches_head(greptile_reviewed_sha, result.head_sha or "")
     )
+    greptile_score: int | None = None
+    greptile_unresolved = int(greptile.get("unresolved") or 0)
     if greptile.get("unknown"):
         # API failure: treat as stale/dark; AI review is the gate
         result.warnings.append(
@@ -3362,15 +3557,17 @@ def evaluate_pr(
         )
     elif greptile_is_fresh:
         # Branch 1: Greptile covers the current head → its 5/5 floor applies
-        score = greptile_summary_score(repo, number)
-        score_str = f"{score}/5" if score is not None else "n/a"
+        greptile_score = greptile_summary_score(repo, number)
+        score_str = f"{greptile_score}/5" if greptile_score is not None else "n/a"
         min_score = _parse_self_merge_min_greptile_score()
-        if greptile["unresolved"] > 0:
+        if greptile_unresolved > 0:
             result.reasons.append(
-                f"Greptile reviewed (score {score_str}); {greptile['unresolved']} unresolved thread(s)"
+                f"Greptile reviewed (score {score_str}); {greptile_unresolved} unresolved thread(s)"
             )
-        elif score is not None and score < min_score:
-            result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
+        elif greptile_score is not None and greptile_score < min_score:
+            result.reasons.append(
+                f"Greptile score {greptile_score}/5 below floor {min_score}/5"
+            )
         else:
             result.warnings.append(
                 f"Greptile reviewed (score {score_str}) at current head — floor satisfied"
@@ -3393,6 +3590,9 @@ def evaluate_pr(
     # `fetch_ai_review_status` covers abstention (score: null → not accepted)
     # and API failure (marker lookup failed → not accepted), so the old
     # separate `ai_review_abstained` check is no longer needed here.
+    # Pointer-only gitlink bumps are the remaining deadlock: the reviewer
+    # abstains by design, which used to make "AI review required" unsatisfiable
+    # even with Greptile 5/5 + an allowlisted path + a merged upstream PR.
     ai_review = fetch_ai_review_status(
         repo,
         number,
@@ -3409,10 +3609,21 @@ def evaluate_pr(
     elif ai_review["accepted"]:
         result.warnings.append(f"AI review accepted ({ai_review['detail']})")
     else:
-        reason = "AI review required"
-        if ai_review["detail"]:
-            reason += f": {ai_review['detail']}"
-        result.reasons.append(reason)
+        waiver = pointer_only_gitlink_ai_review_waiver(
+            repo=repo,
+            number=number,
+            files=files,
+            greptile_is_fresh=greptile_is_fresh,
+            greptile_unresolved=greptile_unresolved,
+            greptile_score=greptile_score,
+        )
+        if waiver:
+            result.warnings.append(waiver)
+        else:
+            reason = "AI review required"
+            if ai_review["detail"]:
+                reason += f": {ai_review['detail']}"
+            result.reasons.append(reason)
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/tests/test_self_merge_pointer_only_gitlink_waiver.py
+++ b/tests/test_self_merge_pointer_only_gitlink_waiver.py
@@ -1,0 +1,256 @@
+"""Pointer-only gitlink bumps must not deadlock on AI-review abstention.
+
+The reviewer abstains on submodule-pointer diffs (`score: null`,
+`submodule_only: true`). After gptme-cloud#850 that abstention is never an
+AI-review *pass*. Combined with the later "AI review is always required"
+gate, pointer-only bumps that already have Greptile 5/5, an allowlisted
+gitlink, and a merged upstream PR could never self-merge (gptme-cloud#899,
+#900, #901 — Erik merged them by hand).
+
+The waiver is the requirement, not the abstention: branch-only pins still
+block (gptme-cloud#898's 9da4505).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "github"
+    / "self-merge-check.py"
+)
+spec = importlib.util.spec_from_file_location("self_merge_check", MODULE_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"Could not load module from {MODULE_PATH}", allow_module_level=True)
+smc = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = smc
+spec.loader.exec_module(smc)
+
+
+HEAD_SHA = "12f455f000000000000000000000000000000000"
+OLD_SHA = "b3b4501d00000000000000000000000000000000"
+NEW_SHA = "110a4eec00000000000000000000000000000000"
+BRANCH_ONLY_SHA = "9da4505000000000000000000000000000000000"
+
+GITLINK_PATCH = (
+    f"@@ -1 +1 @@\n-Subproject commit {OLD_SHA}\n+Subproject commit {NEW_SHA}\n"
+)
+GITMODULES = """
+[submodule "gptme"]
+	path = gptme
+	url = git@github.com:gptme/gptme.git
+"""
+
+
+def test_parse_gitmodules_maps_path_to_url() -> None:
+    assert smc.parse_gitmodules(GITMODULES)["gptme"] == "git@github.com:gptme/gptme.git"
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("git@github.com:gptme/gptme.git", "gptme/gptme"),
+        ("https://github.com/gptme/gptme.git", "gptme/gptme"),
+        ("https://github.com/gptme/gptme", "gptme/gptme"),
+        ("https://example.com/gptme/gptme.git", None),
+    ],
+)
+def test_github_repo_from_remote_url(url: str, expected: str | None) -> None:
+    assert smc.github_repo_from_remote_url(url) == expected
+
+
+def test_parse_pointer_only_gitlink_accepts_subproject_commit_patch() -> None:
+    parsed = smc.parse_pointer_only_gitlink(
+        [{"path": "gptme", "status": "modified", "patch": GITLINK_PATCH}]
+    )
+    assert parsed == ("gptme", NEW_SHA)
+
+
+def test_parse_pointer_only_gitlink_rejects_mixed_diff() -> None:
+    mixed = GITLINK_PATCH + "+print('not a gitlink')\n"
+    assert (
+        smc.parse_pointer_only_gitlink(
+            [{"path": "gptme", "status": "modified", "patch": mixed}]
+        )
+        is None
+    )
+
+
+def test_parse_pointer_only_gitlink_rejects_multiple_files() -> None:
+    entry = {"path": "gptme", "status": "modified", "patch": GITLINK_PATCH}
+    assert smc.parse_pointer_only_gitlink([entry, entry]) is None
+
+
+def test_parse_pointer_only_gitlink_rejects_empty_patch() -> None:
+    assert (
+        smc.parse_pointer_only_gitlink(
+            [{"path": "gptme", "status": "modified", "patch": ""}]
+        )
+        is None
+    )
+
+
+def _pr_data(**overrides: object) -> dict[str, object]:
+    data: dict[str, object] = {
+        "number": 901,
+        "author": {"login": "TimeToBuildBob"},
+        "title": "chore(gptme): bump submodule to master after gptme#3742 merge",
+        "url": "https://github.com/gptme/gptme-cloud/pull/901",
+        "files": [{"path": "gptme"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "headRefOid": HEAD_SHA,
+        "mergeStateStatus": "CLEAN",
+        "labels": [],
+    }
+    data.update(overrides)
+    return data
+
+
+def _evaluate(
+    *,
+    files: list[dict[str, str]] | None = None,
+    greptile_score: int | None = 5,
+    greptile_fresh: bool = True,
+    greptile_unresolved: int = 0,
+    merged_upstream: bool | None = True,
+    gitmodules: str | None = GITMODULES,
+    gitlink_patch: str = GITLINK_PATCH,
+    allowed_paths: str = "gptme/gptme-cloud:gptme",
+    pr_overrides: dict[str, object] | None = None,
+) -> Any:
+    pr_data = _pr_data(**(pr_overrides or {}))
+    if files is not None:
+        pr_data["files"] = files
+    raw_files = pr_data["files"]
+    file_entries = raw_files if isinstance(raw_files, list) else []
+    file_paths = [
+        str(entry.get("path", "")) for entry in file_entries if isinstance(entry, dict)
+    ]
+    shapes = [
+        {"path": path, "status": "modified", "patch": gitlink_patch}
+        for path in file_paths
+    ]
+    greptile_sha = HEAD_SHA if greptile_fresh else "deadbeef"
+    with (
+        patch.dict("os.environ", {"SELF_MERGE_ALLOWED_PATHS": allowed_paths}),
+        patch.object(smc, "fetch_pr", return_value=pr_data),
+        patch.object(smc, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(smc, "merge_permission", return_value=True),
+        patch.object(smc, "_fetch_greptile_review_data", return_value=None),
+        patch.object(
+            smc,
+            "fetch_greptile_status",
+            return_value={
+                "has_review": True,
+                "unresolved": greptile_unresolved,
+                "total": 1,
+            },
+        ),
+        patch.object(smc, "greptile_summary_score", return_value=greptile_score),
+        patch.object(
+            smc, "greptile_summary_reviewed_commit", return_value=greptile_sha
+        ),
+        patch.object(
+            smc,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+        patch.object(
+            smc,
+            "fetch_ai_review_status",
+            return_value={
+                "accepted": False,
+                "detail": "AI reviewer abstained (no score)",
+            },
+        ),
+        patch.object(smc, "_fetch_pr_file_shapes", return_value=shapes),
+        patch.object(smc, "fetch_gitmodules_text", return_value=gitmodules),
+        patch.object(
+            smc, "commit_has_merged_upstream_pr", return_value=merged_upstream
+        ),
+    ):
+        return smc.evaluate_pr(
+            "gptme/gptme-cloud", 901, workspace_repos=["gptme/gptme-cloud"]
+        )
+
+
+def test_evaluate_pr_waives_ai_review_for_901_shape() -> None:
+    """Replay gptme-cloud#901: pointer-only gptme bump of a squash-merged PR."""
+    result = _evaluate()
+    assert result.eligible, result.reasons
+    assert any("AI review waived" in w for w in result.warnings)
+    assert not any("AI review required" in r for r in result.reasons)
+    assert result.category == "repo-allowlisted(gptme/gptme-cloud)"
+
+
+def test_evaluate_pr_blocks_branch_only_pin() -> None:
+    """Replay gptme-cloud#898's 9da4505: no merged upstream PR → still ineligible."""
+    branch_patch = (
+        f"@@ -1 +1 @@\n-Subproject commit {OLD_SHA}\n"
+        f"+Subproject commit {BRANCH_ONLY_SHA}\n"
+    )
+    result = _evaluate(merged_upstream=False, gitlink_patch=branch_patch)
+    assert not result.eligible
+    assert any("AI review required" in r for r in result.reasons)
+    assert not any("AI review waived" in w for w in result.warnings)
+
+
+def test_evaluate_pr_does_not_waive_when_greptile_is_dark() -> None:
+    result = _evaluate(greptile_fresh=False)
+    assert not result.eligible
+    assert any("AI review required" in r for r in result.reasons)
+
+
+def test_evaluate_pr_does_not_waive_unallowlisted_gitlink() -> None:
+    result = _evaluate(allowed_paths="gptme/gptme-cloud:other")
+    assert not result.eligible
+    assert any("AI review required" in r for r in result.reasons)
+
+
+def test_evaluate_pr_does_not_waive_mixed_diff() -> None:
+    result = _evaluate(
+        files=[{"path": "gptme"}, {"path": "README.md"}],
+        allowed_paths="gptme/gptme-cloud:gptme,gptme/gptme-cloud:README.md",
+    )
+    assert not result.eligible
+    assert any("AI review required" in r for r in result.reasons)
+
+
+def test_evaluate_pr_does_not_waive_unparseable_greptile_score() -> None:
+    """Waiver needs an explicit numeric 5/5, not Greptile-present-but-unscored."""
+    result = _evaluate(greptile_score=None)
+    assert not result.eligible
+    assert any("AI review required" in r for r in result.reasons)
+
+
+def test_commit_has_merged_upstream_pr_true_on_merged_payload() -> None:
+    payload = json.dumps({"number": 3742, "merged_at": "2026-09-07T20:43:31Z"})
+
+    def _gh(args: list[str], timeout: int = 30) -> str | None:
+        assert "gptme/gptme/commits/110a4eec/pulls" in " ".join(args)
+        return payload
+
+    with patch.object(smc, "run_gh_checked", _gh):
+        assert smc.commit_has_merged_upstream_pr("gptme/gptme", "110a4eec") is True
+
+
+def test_commit_has_merged_upstream_pr_false_when_no_prs() -> None:
+    with patch.object(smc, "run_gh_checked", lambda *a, **k: ""):
+        assert smc.commit_has_merged_upstream_pr("gptme/gptme", "9da4505") is False
+
+
+def test_commit_has_merged_upstream_pr_unknown_on_api_failure() -> None:
+    with patch.object(smc, "run_gh_checked", lambda *a, **k: None):
+        assert smc.commit_has_merged_upstream_pr("gptme/gptme", "110a4eec") is None


### PR DESCRIPTION
## Why

Pointer-only submodule bumps deadlock the self-merge gate after gptme-cloud#850. The reviewer abstains on a gitlink (`score: null`, `submodule_only: true`), and `fetch_ai_review_status` correctly refuses to treat that as a pass. Combined with the later \"AI review is always required\" rule, PRs that already have Greptile 5/5, an allowlisted gitlink, and a merged upstream commit can never self-merge. gptme-cloud#899/#900/#901 were the live cases; they needed a human merge.

This does **not** treat abstention as an AI-review pass. It waives the *requirement* when every independent quality check already holds.

## What

In `self-merge-check.py`, if AI review is not accepted, waive that reason when all of:

1. the diff is a single `Subproject commit` gitlink bump
2. Greptile is 5/5 at the current head (numeric score, not unscored presence)
3. the gitlink path is in `SELF_MERGE_ALLOWED_PATHS`
4. the new SHA is associated with a **merged** upstream PR (`/commits/{sha}/pulls`, not `merge-base --is-ancestor` — squash-merge leaves the original SHA unreachable)

Fail closed on lookup failure. Branch-only pins stay blocked.

## Replay

- gptme-cloud#901 shape (gptme pin of squash-merged gptme#3742): eligible once CI is green
- gptme-cloud#898's `9da4505` (no upstream PR): still ineligible
- Greptile dark / unallowlisted path / mixed diff: still ineligible
- `fetch_ai_review_status` still rejects `score: null`

#1626 and #1628 already landed eligibility-by-shape / placement. This is not a third eligibility category.

## Tests

`tests/test_self_merge_pointer_only_gitlink_waiver.py` — 18 passed, plus existing abstention/gate tests.

Head: `a61e09e720e486d91d35b0f2e4bed2b073a6fe95`