### PR TITLE
fix(sessions): persist Grok context and cached usage

### DIFF
--- a/packages/gptme-sessions/README.md
+++ b/packages/gptme-sessions/README.md
@@ -46,6 +46,14 @@ stats = store.stats()
 print(f"Success rate: {stats['success_rate']:.0%}")
 ```
 
+Grok Build usage records retain `sys_prompt_tokens` (the first observed prompt,
+including cached input) and `context_peak_tokens` (the largest per-call prompt).
+These are stored alongside session input, output, cache-read, cache-creation,
+and total token counts, so analytics do not need to reparse the trajectory.
+The terminal `end.usage` provides cumulative totals, never context size. An
+incomplete stream uses its observed per-call totals; older streams with only
+an `end` record leave context metrics unknown.
+
 ### CLI
 
 ```bash

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2989,25 +2989,52 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
 def extract_usage_grok(msgs: list[dict]) -> dict:
     """Extract token usage from Grok Build streaming-json trajectories.
 
-    Reads from the final 'end' record which has cumulative session totals.
+    Per-turn ``usage`` records provide first/peak context, including caches.
+    The final ``end`` record provides cumulative totals, never context size;
+    incomplete streams retain the totals observed in their usage records.
     Model name comes from the modelUsage dict (keyed by model id).
     Terminal ``stopReason`` (e.g. ``end_turn``) is copied onto ``stop_reason``
     so post_session / sync can persist the harness-native stop signal.
     """
+    token_fields = {
+        "input_tokens": "input_tokens",
+        "output_tokens": "output_tokens",
+        "cache_read_input_tokens": "cache_read_tokens",
+        "cache_creation_input_tokens": "cache_creation_tokens",
+    }
+    totals = dict.fromkeys(token_fields.values(), 0)
+    observed = set()
+    result: dict = {}
+    for record in msgs:
+        if record.get("type") != "usage":
+            continue
+        usage_data = record.get("usage")
+        if not isinstance(usage_data, dict):
+            continue
+        turn_context = 0
+        for source, field in token_fields.items():
+            value = _as_int(usage_data.get(source))
+            if value is not None and value >= 0:
+                observed.add(field)
+                totals[field] += value
+                if field != "output_tokens":
+                    turn_context += value
+        if turn_context > 0:
+            result.setdefault("sys_prompt_tokens", turn_context)
+            result["context_peak_tokens"] = max(result.get("context_peak_tokens", 0), turn_context)
+
     for record in reversed(msgs):
         if record.get("type") != "end":
             continue
         usage_data = record.get("usage") or {}
-        result: dict = {}
-        input_tokens = usage_data.get("input_tokens")
-        output_tokens = usage_data.get("output_tokens")
-        cache_read = usage_data.get("cache_read_input_tokens")
-        if isinstance(input_tokens, int) and input_tokens > 0:
-            result["input_tokens"] = input_tokens
-        if isinstance(output_tokens, int) and output_tokens > 0:
-            result["output_tokens"] = output_tokens
-        if isinstance(cache_read, int) and cache_read > 0:
-            result["cache_read_input_tokens"] = cache_read
+        for source, field in token_fields.items():
+            value = _as_int(usage_data.get(source))
+            if value is not None and value >= 0:
+                observed.add(field)
+                totals[field] = value
+        total_tokens = _as_int(usage_data.get("total_tokens"))
+        if total_tokens is not None and total_tokens > 0:
+            result["total_tokens"] = total_tokens
         model_usage = record.get("modelUsage") or {}
         if model_usage:
             model_name = next(iter(model_usage), None)
@@ -3016,9 +3043,11 @@ def extract_usage_grok(msgs: list[dict]) -> dict:
         raw_stop = record.get("stopReason")
         if isinstance(raw_stop, str) and raw_stop:
             result["stop_reason"] = raw_stop
-        if result:
-            return result
-    return {}
+        break
+    result.update({field: value for field, value in totals.items() if field in observed})
+    if observed:
+        result.setdefault("total_tokens", sum(totals.values()))
+    return result
 
 
 def extract_from_path(jsonl_path: Path) -> dict:

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -1,5 +1,6 @@
 """Tests for post_session context_tier plumbing and signal fallbacks."""
 
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -370,6 +371,56 @@ def test_post_session_populates_productivity_grade(tmp_path: Path):
 
     records = store.load_all()
     assert records[0].grades == {"productivity": 0.68}
+
+
+def test_post_session_grok_usage_survives_without_trajectory(tmp_path: Path):
+    """Real Grok usage must survive extraction, storage, and trajectory loss."""
+    trajectory = tmp_path / "grok.jsonl"
+    turns = [
+        {
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        },
+        {
+            "input_tokens": 20,
+            "output_tokens": 30,
+            "cache_read_input_tokens": 100,
+            "cache_creation_input_tokens": 0,
+        },
+    ]
+    totals = {key: sum(turn[key] for turn in turns) for key in turns[0]}
+    records = [
+        {"type": "available_commands", "commands": []},
+        *({"type": "usage", "usage": turn} for turn in turns),
+        {
+            "type": "end",
+            "usage": {**totals, "total_tokens": 260},
+            "modelUsage": {"grok-build": totals},
+            "stopReason": "end_turn",
+        },
+    ]
+    trajectory.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+    sessions_dir = tmp_path / "sessions"
+    post_session(
+        store=SessionStore(sessions_dir=sessions_dir),
+        harness="grok-build",
+        model="grok-build",
+        duration_seconds=60,
+        trajectory_path=trajectory,
+    )
+
+    trajectory.unlink()
+    record = SessionStore(sessions_dir=sessions_dir).load_all()[0]
+    assert record.sys_prompt_tokens == 100
+    assert record.context_peak_tokens == 120
+    assert record.input_tokens == 120
+    assert record.output_tokens == 40
+    assert record.cache_read_tokens == 100
+    assert record.cache_creation_tokens == 0
+    assert record.token_count == 260
+    assert record.stop_reason == "end_turn"
 
 
 def test_post_session_persists_usage_fields(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -296,6 +296,72 @@ def test_extract_usage_grok_reads_from_end_record():
     assert usage["output_tokens"] == 114
     assert usage["model"] == "grok-4.5-build"
     assert usage["stop_reason"] == "end_turn"
+    assert "sys_prompt_tokens" not in usage
+    assert "context_peak_tokens" not in usage
+
+
+def test_extract_usage_grok_context_from_turns_totals_from_end():
+    msgs = [
+        _available_commands(),
+        {"type": "usage", "usage": {"input_tokens": 100, "output_tokens": 10}},
+        {
+            "type": "usage",
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 1000,
+                "cache_read_input_tokens": 100,
+                "cache_creation_input_tokens": 30,
+            },
+        },
+        # A smaller turn after compaction must not replace the peak.
+        {"type": "usage", "usage": {"input_tokens": 50, "output_tokens": 10}},
+        {
+            **_end_record(input_tokens=4000, output_tokens=1020),
+            "usage": {
+                "input_tokens": 4000,
+                "output_tokens": 1020,
+                "cache_read_input_tokens": 5000,
+                "cache_creation_input_tokens": 300,
+            },
+        },
+    ]
+    usage = extract_usage_grok(msgs)
+    assert usage["sys_prompt_tokens"] == 100
+    assert usage["context_peak_tokens"] == 150
+    assert usage["input_tokens"] == 4000
+    assert usage["output_tokens"] == 1020
+    assert usage["cache_read_tokens"] == 5000
+    assert usage["cache_creation_tokens"] == 300
+    assert usage["total_tokens"] == 10320
+    assert usage["stop_reason"] == "end_turn"
+
+
+def test_extract_usage_grok_incomplete_stream_keeps_observed_usage():
+    msgs = [
+        _available_commands(),
+        {"type": "usage", "usage": None},
+        {"type": "usage", "usage": {}},
+        {
+            "type": "usage",
+            "usage": {"input_tokens": 100, "output_tokens": 10},
+        },
+        {
+            "type": "usage",
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 30,
+                "cache_read_input_tokens": 100,
+            },
+        },
+    ]
+    usage = extract_usage_grok(msgs)
+    assert usage["sys_prompt_tokens"] == 100
+    assert usage["context_peak_tokens"] == 120
+    assert usage["input_tokens"] == 120
+    assert usage["output_tokens"] == 40
+    assert usage["cache_read_tokens"] == 100
+    assert usage["total_tokens"] == 260
+    assert "stop_reason" not in usage
 
 
 def test_extract_usage_grok_stop_reason_without_usage():
@@ -335,7 +401,8 @@ def test_extract_usage_grok_cache_read_tokens_included():
         },
     ]
     usage = extract_usage_grok(msgs)
-    assert usage["cache_read_input_tokens"] == 29184
+    assert usage["cache_read_tokens"] == 29184
+    assert usage["total_tokens"] == 30234
 
 
 def test_background_task_commit_via_task_output():


### PR DESCRIPTION
Grok Build session records lost first/peak context measurements and cached-input accounting because the extractor read only cumulative `end` usage and returned cache counts under a field the recorder did not consume.

Extract first/peak prompt size from per-call usage, normalize cache fields to the session-record schema, and retain observed zero counters. Terminal usage remains authoritative for session totals; interrupted streams preserve their observed per-call totals, while legacy end-only streams leave context unknown. A real post-session/store regression verifies that the metrics survive without the source trajectory.

Validation: all 1,465 gptme-sessions tests pass with `GPTME_CC_EXTRA_PROJECTS_DIRS` unset to isolate tests from host archives; repository pre-commit checks pass. Replayed three completed Grok logs and verified exact agreement with independently summed usage and per-call context.
