### PR TITLE
test(gptmail): preserve local read state on agent pull re-fetch

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -1080,7 +1080,10 @@ def _fetch_from_agent(
                 )
             continue
         if dest.exists():
-            continue  # Already fetched — deduplicate by mailbox and filename.
+            # Skip-if-exists is load-bearing: local inbox copies carry
+            # read/replied stamps that the sender's outbox never has.
+            # Recopying would silently reset tracking (gptme/gptme-contrib#1476).
+            continue
         dest.parent.mkdir(parents=True, exist_ok=True)
         # The row's mailbox field tells us which remote outbox subfolder to look in.
         row_mailbox = _normalize_mailbox(str(row.get("mailbox") or fallback_mailbox))

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -3,6 +3,7 @@
 Covers the missing human-side delivery introduced in issue #1476:
 - ``pull`` fetches messages from SSH-reachable agents' outboxes into local inbox
 - ``pull`` deduplicates by filename (re-pull is idempotent)
+- ``pull`` skip-if-exists preserves local ``read``/``replied`` stamps on re-pull
 - ``pull --json`` emits machine-readable count + file list
 - ``pull --notify-cmd`` invokes the hook with NEW_COUNT + SUMMARY env vars
 - ``pull --dry-run`` shows what would be fetched without writing
@@ -205,6 +206,42 @@ def test_pull_deduplicates_on_repull(pull_workspace: Path) -> None:
 
     local_inbox = pull_workspace / "erik" / "messages" / "inbox"
     assert len(list(local_inbox.glob("*.md"))) == 1, "only one copy must exist"
+
+
+def test_pull_preserves_local_read_state_on_repull(pull_workspace: Path) -> None:
+    """Re-pull must not clobber local read/replied stamps (gptme/gptme-contrib#1476).
+
+    Read/replied state lives only in the local inbox copy; the sender's outbox
+    never carries it. Skip-if-exists is the required guard: a recopy would
+    silently reset tracking even if filenames are stable.
+    """
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(
+        gordon_outbox, sender="gordon", recipient="erik", subject="Decision request"
+    )
+
+    first = CliRunner().invoke(agent, ["pull"])
+    assert first.exit_code == 0, first.output
+
+    local = pull_workspace / "erik" / "messages" / "inbox" / name
+    assert local.exists()
+
+    marked = CliRunner().invoke(agent, ["read", name])
+    assert marked.exit_code == 0, marked.output
+    assert "read: true" in local.read_text()
+
+    # Remote outbox is still the unread original; rewrite it so a recopy
+    # would be observable (new body, no read stamp).
+    remote = gordon_outbox / name
+    remote.write_text(remote.read_text() + "\nUpdated upstream body.\n")
+
+    second = CliRunner().invoke(agent, ["pull"])
+    assert second.exit_code == 0, second.output
+    assert "No new messages." in second.output
+
+    text = local.read_text()
+    assert "read: true" in text
+    assert "Updated upstream body." not in text
 
 
 def test_pull_json_output(pull_workspace: Path) -> None:


### PR DESCRIPTION
## Why

Erik's design constraint on gptme/gptme-contrib#1476: read/replied state lives only in the local inbox copy. A pull that recopies remote outbox files over existing local ones silently resets tracking.

`gptmail agent pull` already skip-if-exists (filenames are content-stable). This PR pins that contract with the regression he asked for, and documents why the skip is load-bearing — not just a dedup convenience.

`watch --pull` shells out to `gptmail agent pull`, so it inherits the same guard. Frontmatter-merge (refresh remote body while preserving local `read`/`replied`) is left for if/when messages become mutable upstream.

## Test plan

- [x] `pytest packages/gptmail/tests/test_agent_pull.py` — 34 passed, including `test_pull_preserves_local_read_state_on_repull`
- [x] pull → `gptmail agent read` → mutate remote outbox → pull again → local still `read: true`, remote body not copied

