### PR TITLE
feat(gptme-voice): trace ASR, TTS first-audio, and utterance round-trip

### DIFF
--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -120,6 +120,18 @@ Keys are loaded from gptme config (`~/.config/gptme/config.toml` or
 
 No need to export them as shell env vars if they're already configured in gptme.
 
+### Voice latency tracing
+
+Set `GPTME_VOICE_LATENCY_SINK` to a file path or `-` (stdout). Each utterance
+emits one JSONL `utterance_trace` with:
+
+- `asr_ms` — VAD speech_stopped → user transcript completed
+- `tts_first_audio_ms` — `response.created` → first audio chunk
+- `round_trip_ms` — speech_stopped → first audio chunk
+
+`send_audio` is counted (`input_audio_chunks`) but is not the round-trip clock;
+Twilio streams PCM continuously.
+
 ## Architecture
 
 - **openai_client.py** - WebSocket client for OpenAI Realtime API with VAD, audio streaming, and event handling
@@ -129,6 +141,7 @@ No need to export them as shell env vars if they're already configured in gptme.
 - **vision.py** - Correlated camera-frame requests, edge-event handling, and host-side VLM inference
 - **audio.py** - Audio format conversion (PCM ↔ μ-law for Twilio)
 - **client.py** - Local client with mic/speaker I/O and feedback loop prevention
+- **latency.py** - Per-utterance ASR / TTS-first-audio / round-trip tracing
 
 ## Limitations
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/__init__.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/__init__.py
@@ -6,6 +6,7 @@ and gptme tool bridge for voice conversations.
 """
 
 from .audio import AudioConverter
+from .latency import UtteranceTrace, VoiceLatencyTrace
 from .openai_client import OpenAIRealtimeClient
 from .server import VoiceServer
 from .tool_bridge import GptmeToolBridge
@@ -15,4 +16,6 @@ __all__ = [
     "OpenAIRealtimeClient",
     "GptmeToolBridge",
     "AudioConverter",
+    "UtteranceTrace",
+    "VoiceLatencyTrace",
 ]

--- a/packages/gptme-voice/src/gptme_voice/realtime/latency.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/latency.py
@@ -1,0 +1,207 @@
+"""Utterance-level latency tracing for gptme-voice realtime sessions.
+
+Measures the three Phase 2 stages from OpenAI/xAI realtime events:
+
+- ASR: ``speech_stopped`` → user transcript completed
+- TTS first audio: ``response.created`` → first ``response.audio.delta``
+- Round-trip: ``speech_stopped`` → first audio chunk
+
+``send_audio`` is instrumented as an input-chunk counter, not a turn clock.
+Twilio and the local client stream PCM continuously, so using those frames as
+t0 would report ~20ms of "latency". Server VAD events are the turn boundary.
+
+Set ``GPTME_VOICE_LATENCY_SINK`` to a file path or ``-`` (stdout) to emit
+JSONL ``utterance_trace`` events from a live call.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, TextIO
+
+_SPEECH_STARTED = "input_audio_buffer.speech_started"
+_SPEECH_STOPPED = "input_audio_buffer.speech_stopped"
+_ASR_DONE = "conversation.item.input_audio_transcription.completed"
+_RESPONSE_CREATED = "response.created"
+_AUDIO_DELTA = frozenset({"response.audio.delta", "response.output_audio.delta"})
+_AUDIO_DONE = frozenset({"response.audio.done", "response.output_audio.done"})
+_RESPONSE_DONE = "response.done"
+
+
+def _round_ms(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(value, 2)
+
+
+@dataclass
+class UtteranceTrace:
+    """Timing breakdown for one user utterance → agent reply."""
+
+    asr_ms: float | None = None
+    tts_first_audio_ms: float | None = None
+    round_trip_ms: float | None = None
+    response_created_ms: float | None = None
+    audio_done_ms: float | None = None
+    input_audio_chunks: int = 0
+    source: str = "realtime_events"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": "utterance_trace",
+            "asr_ms": _round_ms(self.asr_ms),
+            "tts_first_audio_ms": _round_ms(self.tts_first_audio_ms),
+            "round_trip_ms": _round_ms(self.round_trip_ms),
+            "response_created_ms": _round_ms(self.response_created_ms),
+            "audio_done_ms": _round_ms(self.audio_done_ms),
+            "input_audio_chunks": self.input_audio_chunks,
+            "source": self.source,
+        }
+
+    def to_jsonl(self) -> str:
+        return json.dumps(self.to_dict())
+
+
+class VoiceLatencyTrace:
+    """Collects per-utterance latency from realtime client hooks/events.
+
+    Usage::
+
+        trace = VoiceLatencyTrace(sink="voice-latency.jsonl")
+        client = OpenAIRealtimeClient(..., latency_trace=trace)
+        ...
+        print(trace.last_trace.to_jsonl())
+    """
+
+    def __init__(
+        self,
+        sink: str | TextIO | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.sink = sink
+        self._clock = clock or time.perf_counter
+        self.traces: list[UtteranceTrace] = []
+        self._reset_open()
+
+    def _now(self) -> float:
+        return self._clock()
+
+    def _reset_open(self) -> None:
+        self._t_speech_started: float | None = None
+        self._t_speech_stopped: float | None = None
+        self._t_asr_done: float | None = None
+        self._t_response_created: float | None = None
+        self._t_first_audio: float | None = None
+        self._t_audio_done: float | None = None
+        self._input_chunks = 0
+
+    def _turn_anchor(self) -> float | None:
+        """User-finished-speaking time, falling back to speech start."""
+        if self._t_speech_stopped is not None:
+            return self._t_speech_stopped
+        return self._t_speech_started
+
+    def observe_send_audio(self) -> None:
+        """Hook for ``OpenAIRealtimeClient.send_audio``.
+
+        Counts inbound PCM chunks. Does not start the round-trip clock —
+        continuous media frames are not utterance boundaries.
+        """
+        self._input_chunks += 1
+
+    def observe_event(self, event_type: str) -> None:
+        """Hook for ``OpenAIRealtimeClient._handle_event``."""
+        now = self._now()
+        if event_type == _SPEECH_STARTED:
+            if self._t_first_audio is not None:
+                self._finalize()
+            elif self._t_speech_started is not None:
+                self._reset_open()
+            self._t_speech_started = now
+            return
+        if event_type == _SPEECH_STOPPED:
+            self._t_speech_stopped = now
+            return
+        if event_type == _ASR_DONE:
+            self._t_asr_done = now
+            return
+        if event_type == _RESPONSE_CREATED:
+            self._t_response_created = now
+            return
+        if event_type in _AUDIO_DELTA:
+            if self._t_first_audio is None:
+                self._t_first_audio = now
+            return
+        if event_type in _AUDIO_DONE:
+            self._t_audio_done = now
+            return
+        if event_type == _RESPONSE_DONE:
+            self._finalize()
+
+    def _finalize(self) -> None:
+        anchor = self._turn_anchor()
+        if anchor is None and self._t_first_audio is None and self._t_asr_done is None:
+            self._reset_open()
+            return
+
+        asr_anchor = (
+            self._t_speech_stopped
+            if self._t_speech_stopped is not None
+            else self._t_speech_started
+        )
+        trace = UtteranceTrace(input_audio_chunks=self._input_chunks)
+        if self._t_asr_done is not None and asr_anchor is not None:
+            trace.asr_ms = (self._t_asr_done - asr_anchor) * 1000
+        if self._t_first_audio is not None and self._t_response_created is not None:
+            trace.tts_first_audio_ms = (
+                self._t_first_audio - self._t_response_created
+            ) * 1000
+        if self._t_first_audio is not None and anchor is not None:
+            trace.round_trip_ms = (self._t_first_audio - anchor) * 1000
+        if self._t_response_created is not None and anchor is not None:
+            trace.response_created_ms = (self._t_response_created - anchor) * 1000
+        if self._t_audio_done is not None and anchor is not None:
+            trace.audio_done_ms = (self._t_audio_done - anchor) * 1000
+
+        if any(
+            value is not None
+            for value in (trace.asr_ms, trace.tts_first_audio_ms, trace.round_trip_ms)
+        ):
+            self.traces.append(trace)
+            self._emit(trace)
+        self._reset_open()
+
+    def _emit(self, trace: UtteranceTrace) -> None:
+        if self.sink is None:
+            return
+        line = trace.to_jsonl() + "\n"
+        if isinstance(self.sink, str):
+            if self.sink == "-":
+                sys.stdout.write(line)
+                sys.stdout.flush()
+            else:
+                with open(self.sink, "a", encoding="utf-8") as handle:
+                    handle.write(line)
+        else:
+            self.sink.write(line)
+            self.sink.flush()
+
+    @property
+    def last_trace(self) -> UtteranceTrace | None:
+        return self.traces[-1] if self.traces else None
+
+
+def latency_trace_from_env(
+    getenv: Callable[[str], str | None] | None = None,
+) -> VoiceLatencyTrace | None:
+    """Build a sink-enabled tracer from ``GPTME_VOICE_LATENCY_SINK``."""
+    import os
+
+    resolver = getenv or (lambda name: os.environ.get(name))
+    sink = resolver("GPTME_VOICE_LATENCY_SINK")
+    if not sink:
+        return None
+    return VoiceLatencyTrace(sink=sink)

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -17,6 +17,8 @@ from typing import Any, Callable, Literal
 import websockets  # type: ignore
 from gptme.config import get_config, get_project_config
 
+from .latency import VoiceLatencyTrace
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_INSTRUCTIONS = "You are a helpful assistant with access to tools via gptme."
@@ -270,6 +272,7 @@ class OpenAIRealtimeClient:
         on_function_call: Callable[[str, dict], Any] | None = None,
         on_speech_started: Callable[[], None] | None = None,
         hold_initial_response: bool = False,
+        latency_trace: VoiceLatencyTrace | None = None,
     ):
         self.api_key = api_key or _get_openai_api_key()
         if not self.api_key:
@@ -372,6 +375,7 @@ class OpenAIRealtimeClient:
         self.on_user_transcript = on_user_transcript
         self.on_function_call = on_function_call
         self.on_speech_started = on_speech_started
+        self.latency_trace = latency_trace
 
         self._ws: websockets.WebSocketClientProtocol | None = None
         self._receive_task: asyncio.Task | None = None
@@ -810,6 +814,9 @@ class OpenAIRealtimeClient:
         silent calls on cold starts / fast reconnects where Twilio's first
         media frames race ahead of the provider's session handshake.
         """
+        if self.latency_trace is not None:
+            self.latency_trace.observe_send_audio()
+
         if self._session_ready is None or not self._session_ready.is_set():
             # Session not confirmed yet — buffer the chunk, bounded so a
             # never-arriving ready signal cannot leak memory.
@@ -918,6 +925,8 @@ class OpenAIRealtimeClient:
     async def _handle_event(self, event: dict) -> None:
         """Handle an event from OpenAI Realtime API."""
         event_type = event.get("type", "")
+        if self.latency_trace is not None:
+            self.latency_trace.observe_event(event_type)
         # Only transcript-carrying events reset the drain idle timer; VAD and
         # lifecycle events must not extend the teardown window unnecessarily.
         if self._event_notice is not None and event_type in _TRANSCRIPT_EVENT_TYPES:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -37,6 +37,7 @@ from ..body import body_adapter_from_env, body_tool_schemas
 from ..handoff import HandoffWriter
 from ..vision import VisionSessionBridge, vision_tool_schema
 from .audio import AudioConverter
+from .latency import latency_trace_from_env
 from .openai_client import (
     OpenAIRealtimeClient,
     SessionConfig,
@@ -2684,17 +2685,22 @@ class VoiceServer:
         **kwargs,
     ) -> OpenAIRealtimeClient:
         """Instantiate the realtime client for the configured provider."""
+        latency_trace = kwargs.pop("latency_trace", None)
+        if latency_trace is None:
+            latency_trace = latency_trace_from_env(_get_config_env)
         if self.provider == _PROVIDER_GROK:
             return XAIRealtimeClient(
                 api_key=self._api_key,
                 session_config=session_config,
                 hold_initial_response=hold_initial_response,
+                latency_trace=latency_trace,
                 **kwargs,
             )
         return OpenAIRealtimeClient(
             api_key=self._api_key,
             session_config=session_config,
             hold_initial_response=hold_initial_response,
+            latency_trace=latency_trace,
             **kwargs,
         )
 

--- a/packages/gptme-voice/tests/test_latency.py
+++ b/packages/gptme-voice/tests/test_latency.py
@@ -1,0 +1,195 @@
+import io
+import json
+from pathlib import Path
+
+import pytest
+from gptme_voice.realtime.latency import (
+    VoiceLatencyTrace,
+    latency_trace_from_env,
+)
+from gptme_voice.realtime.openai_client import OpenAIRealtimeClient
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _drive_utterance(trace: VoiceLatencyTrace, clock: FakeClock) -> None:
+    trace.observe_event("input_audio_buffer.speech_started")
+    clock.advance(1.0)
+    trace.observe_send_audio()
+    trace.observe_send_audio()
+    trace.observe_event("input_audio_buffer.speech_stopped")
+    clock.advance(0.4)
+    trace.observe_event("conversation.item.input_audio_transcription.completed")
+    clock.advance(0.1)
+    trace.observe_event("response.created")
+    clock.advance(0.2)
+    trace.observe_event("response.audio.delta")
+    clock.advance(0.8)
+    trace.observe_event("response.audio.done")
+    trace.observe_event("response.done")
+
+
+def test_utterance_breakdown_from_realtime_events() -> None:
+    clock = FakeClock()
+    sink = io.StringIO()
+    trace = VoiceLatencyTrace(sink=sink, clock=clock)
+
+    _drive_utterance(trace, clock)
+
+    last = trace.last_trace
+    assert last is not None
+    assert last.asr_ms == pytest.approx(400.0)
+    assert last.tts_first_audio_ms == pytest.approx(200.0)
+    assert last.round_trip_ms == pytest.approx(700.0)
+    assert last.response_created_ms == pytest.approx(500.0)
+    assert last.audio_done_ms == pytest.approx(1500.0)
+    assert last.input_audio_chunks == 2
+    assert last.source == "realtime_events"
+
+    emitted = json.loads(sink.getvalue().strip())
+    assert emitted["type"] == "utterance_trace"
+    assert emitted["asr_ms"] == 400.0
+    assert emitted["tts_first_audio_ms"] == 200.0
+    assert emitted["round_trip_ms"] == 700.0
+
+
+def test_send_audio_does_not_start_round_trip_clock() -> None:
+    clock = FakeClock()
+    trace = VoiceLatencyTrace(clock=clock)
+
+    trace.observe_send_audio()
+    clock.advance(5.0)
+    trace.observe_event("input_audio_buffer.speech_started")
+    clock.advance(0.2)
+    trace.observe_event("input_audio_buffer.speech_stopped")
+    clock.advance(0.3)
+    trace.observe_event("response.created")
+    clock.advance(0.1)
+    trace.observe_event("response.output_audio.delta")
+    trace.observe_event("response.done")
+
+    last = trace.last_trace
+    assert last is not None
+    assert last.round_trip_ms == pytest.approx(400.0)
+    assert last.input_audio_chunks == 1
+
+
+def test_asr_can_arrive_after_first_audio() -> None:
+    clock = FakeClock()
+    trace = VoiceLatencyTrace(clock=clock)
+
+    trace.observe_event("input_audio_buffer.speech_started")
+    clock.advance(0.5)
+    trace.observe_event("input_audio_buffer.speech_stopped")
+    clock.advance(0.2)
+    trace.observe_event("response.created")
+    clock.advance(0.1)
+    trace.observe_event("response.audio.delta")
+    clock.advance(0.4)
+    trace.observe_event("conversation.item.input_audio_transcription.completed")
+    trace.observe_event("response.done")
+
+    last = trace.last_trace
+    assert last is not None
+    assert last.asr_ms == pytest.approx(700.0)
+    assert last.round_trip_ms == pytest.approx(300.0)
+
+
+def test_barge_in_finalizes_previous_utterance() -> None:
+    clock = FakeClock()
+    trace = VoiceLatencyTrace(clock=clock)
+
+    trace.observe_event("input_audio_buffer.speech_started")
+    clock.advance(0.2)
+    trace.observe_event("input_audio_buffer.speech_stopped")
+    clock.advance(0.1)
+    trace.observe_event("response.created")
+    clock.advance(0.1)
+    trace.observe_event("response.audio.delta")
+    clock.advance(0.5)
+    trace.observe_event("input_audio_buffer.speech_started")
+
+    assert len(trace.traces) == 1
+    assert trace.traces[0].round_trip_ms == pytest.approx(200.0)
+
+    clock.advance(0.2)
+    trace.observe_event("input_audio_buffer.speech_stopped")
+    clock.advance(0.1)
+    trace.observe_event("response.created")
+    clock.advance(0.05)
+    trace.observe_event("response.audio.delta")
+    trace.observe_event("response.done")
+
+    assert len(trace.traces) == 2
+    assert trace.last_trace is not None
+    assert trace.last_trace.round_trip_ms == pytest.approx(150.0)
+
+
+def test_file_sink_appends_jsonl(tmp_path: Path) -> None:
+    sink = tmp_path / "latency.jsonl"
+    clock = FakeClock()
+    trace = VoiceLatencyTrace(sink=str(sink), clock=clock)
+    _drive_utterance(trace, clock)
+
+    lines = sink.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["round_trip_ms"] == 700.0
+
+
+def test_latency_trace_from_env_disabled_by_default() -> None:
+    assert latency_trace_from_env(getenv=lambda _name: None) is None
+
+
+def test_latency_trace_from_env_uses_sink() -> None:
+    trace = latency_trace_from_env(
+        getenv=lambda name: "-" if name.endswith("SINK") else None
+    )
+    assert trace is not None
+    assert trace.sink == "-"
+
+
+def test_client_hooks_record_utterance_breakdown() -> None:
+    async def _exercise() -> None:
+        clock = FakeClock()
+        trace = VoiceLatencyTrace(clock=clock)
+        client = OpenAIRealtimeClient(api_key="test-key", latency_trace=trace)
+        client._session_ready = None
+
+        await client.send_audio(b"\x00\x01")
+        await client._handle_event({"type": "input_audio_buffer.speech_started"})
+        clock.advance(0.5)
+        await client.send_audio(b"\x02\x03")
+        await client._handle_event({"type": "input_audio_buffer.speech_stopped"})
+        clock.advance(0.25)
+        await client._handle_event(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "transcript": "hello",
+            }
+        )
+        clock.advance(0.05)
+        await client._handle_event({"type": "response.created"})
+        clock.advance(0.15)
+        await client._handle_event({"type": "response.audio.delta", "delta": ""})
+        await client._handle_event({"type": "response.done"})
+
+        last = trace.last_trace
+        assert last is not None
+        assert last.asr_ms == pytest.approx(250.0)
+        assert last.tts_first_audio_ms == pytest.approx(150.0)
+        assert last.round_trip_ms == pytest.approx(450.0)
+        assert last.input_audio_chunks == 2
+
+    import asyncio
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary

Phase 2 of the voice latency profiler: instrument the stable gptme-voice realtime hooks so a call can emit a per-utterance JSONL breakdown.

- **ASR** — `input_audio_buffer.speech_stopped` → user transcript completed
- **TTS first audio** — `response.created` → first `response.audio.delta`
- **Round-trip** — speech_stopped → first audio chunk

`send_audio` is counted (`input_audio_chunks`) but is **not** the round-trip clock. Twilio and the local client stream PCM continuously, so using those frames as t0 would report ~20ms of fake latency. Server VAD events are the turn boundary.

## Usage

```bash
GPTME_VOICE_LATENCY_SINK=voice-latency.jsonl gptme-voice-server
# or stdout:
GPTME_VOICE_LATENCY_SINK=- gptme-voice-server
```

Each utterance appends one JSONL `utterance_trace`. In-process, pass `latency_trace=VoiceLatencyTrace(...)` to `OpenAIRealtimeClient`.

## Tests

`uv run --package gptme-voice pytest packages/gptme-voice/tests/test_latency.py packages/gptme-voice/tests/test_openai_client.py` — 45 passed.

## Not in this PR

Live OpenAI/Twilio call (CI has no voice runtime). The client-hook test drives the same `_handle_event` / `send_audio` path a real call uses.