### PR TITLE
fix(activity-gate): treat fully-disposed AI findings as clean

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -468,7 +468,9 @@ class ProjectMonitoringRun(BaseRunLoop):
         standing P1 at head sat undispatched for ~2.5 days behind three
         self-authored comments). Non-empty findings[] whose marker sha matches
         the current head = the reviewer's latest verdict on this exact code
-        still needs a response, regardless of who commented last.
+        still needs a response, regardless of who commented last — unless
+        every listed finding has a disposition (rejected/fixed/accepted).
+        The frozen score does not move on disposition; the map does.
 
         A stale marker sha (agent pushed since the review) does not count:
         the push is fresh activity in its own right and the review sweep will
@@ -487,12 +489,25 @@ class ProjectMonitoringRun(BaseRunLoop):
             state = json.loads(payload)
         except (ValueError, TypeError):
             return False
-        if not state.get("findings"):
+        findings = state.get("findings")
+        if not findings:
             return False
         marker_sha = state.get("sha") or ""
         if head_sha and marker_sha and not head_sha.startswith(marker_sha):
             return False
-        return True
+        # Disposed findings are settled — the frozen score/findings[] stay as
+        # the historical record of that pass. gptme/gptme#3755: a rejected P2
+        # kept dispatching because this predicate ignored the dispositions map.
+        dispositions = state.get("dispositions")
+        if not isinstance(dispositions, dict):
+            dispositions = {}
+        for finding in findings:
+            if not isinstance(finding, dict):
+                return True
+            fp = finding.get("fp")
+            if not fp or fp not in dispositions:
+                return True
+        return False
 
     def _last_activity_is_self_response(
         self,

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -505,7 +505,13 @@ class ProjectMonitoringRun(BaseRunLoop):
             if not isinstance(finding, dict):
                 return True
             fp = finding.get("fp")
-            if not fp or fp not in dispositions:
+            # Fail-closed: missing/non-string fp, or a null/non-object
+            # disposition entry, is still outstanding. jq uses
+            # `($d[.fp] // null) | type != "object"`; `fp in dispositions`
+            # would treat `"fp": null` as settled.
+            if not isinstance(fp, str) or not fp:
+                return True
+            if not isinstance(dispositions.get(fp), dict):
                 return True
         return False
 

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -588,6 +588,13 @@ def test_disposed_findings_are_not_standing(workspace):
         '"findings": ["not-an-object"], "dispositions": {}} -->'
     )
     assert run._marker_has_standing_findings(malformed, _HEAD_3638) is True
+    null_disp = (
+        "## AI code review\n\nreview body...\n\n"
+        '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 4, '
+        '"findings": [{"fp": "aaaa", "severity": "P2"}], '
+        '"dispositions": {"aaaa": null}} -->'
+    )
+    assert run._marker_has_standing_findings(null_disp, _HEAD_3638) is True
 
 
 def test_is_last_activity_by_self_stale_marker_findings(workspace):

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -556,6 +556,27 @@ def test_quoted_standing_marker_is_not_standing_findings(workspace):
         assert run._is_last_activity_by_self("gptme/gptme", 1549) is True
 
 
+def test_disposed_findings_are_not_standing(workspace):
+    """gptme#3755: rejected findings must not keep last-activity inbound."""
+    run = ProjectMonitoringRun(workspace, author=SELF)
+    marker = (
+        "## AI code review\n\nreview body...\n\n"
+        '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 4, '
+        '"findings": [{"fp": "543152f97269", "severity": "P2"}], '
+        '"dispositions": {"543152f97269": {"fp": "543152f97269", '
+        '"reason": "rejected"}}} -->'
+    )
+    assert run._marker_has_standing_findings(marker, _HEAD_3638) is False
+    mixed = (
+        "## AI code review\n\nreview body...\n\n"
+        '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 3, '
+        '"findings": [{"fp": "aaaa", "severity": "P1"}, '
+        '{"fp": "bbbb", "severity": "P2"}], '
+        '"dispositions": {"bbbb": {"fp": "bbbb", "reason": "rejected"}}} -->'
+    )
+    assert run._marker_has_standing_findings(mixed, _HEAD_3638) is True
+
+
 def test_is_last_activity_by_self_stale_marker_findings(workspace):
     """Marker findings recorded against an OLDER head do not count: the push
     since the review is fresh activity and the sweep will re-review it."""

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -575,6 +575,19 @@ def test_disposed_findings_are_not_standing(workspace):
         '"dispositions": {"bbbb": {"fp": "bbbb", "reason": "rejected"}}} -->'
     )
     assert run._marker_has_standing_findings(mixed, _HEAD_3638) is True
+    no_fp = (
+        "## AI code review\n\nreview body...\n\n"
+        '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 4, '
+        '"findings": [{"severity": "P2"}], '
+        '"dispositions": {}} -->'
+    )
+    assert run._marker_has_standing_findings(no_fp, _HEAD_3638) is True
+    malformed = (
+        "## AI code review\n\nreview body...\n\n"
+        '<!-- bob-ai-review {"sha": "7bb89e6c544c", "score": 4, '
+        '"findings": ["not-an-object"], "dispositions": {}} -->'
+    )
+    assert run._marker_has_standing_findings(malformed, _HEAD_3638) is True
 
 
 def test_is_last_activity_by_self_stale_marker_findings(workspace):

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -491,7 +491,7 @@ has_actionable_update() {
                        type != "object"
                        or (.fp | type) != "string"
                        or .fp == ""
-                       or (($d[.fp] // null) == null)
+                       or (($d[.fp] // null) | type) != "object"
                      )]
                      | length > 0
                  )
@@ -1092,7 +1092,7 @@ ai_review_verdict() {
                     type != "object"
                     or (.fp | type) != "string"
                     or .fp == ""
-                    or (($d[.fp] // null) == null)
+                    or (($d[.fp] // null) | type) != "object"
                   )] | length
               end
         ' 2>/dev/null)

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -485,6 +485,11 @@ has_actionable_update() {
           else (.sha // "") as $sha
             | if (((.findings // []) | length) > 0)
                  and ($sha != "") and ($head | startswith($sha))
+                 and (
+                   (.dispositions // {}) as $d
+                   | [.findings[] | select(.fp != null and ($d[.fp] // null) == null)]
+                     | length > 0
+                 )
               then "yes" else "no" end
           end
     ' 2>/dev/null)
@@ -1060,6 +1065,28 @@ ai_review_verdict() {
     score=$(printf '%s' "$marker" | jq -r '.score // empty' 2>/dev/null)
     if [ -n "$score" ] && [ "$score" != "null" ]; then
         if [ "$score" -ge 5 ] 2>/dev/null; then
+            echo "clean"
+            return 0
+        fi
+        # Fully disposed findings at this head are not outstanding work.
+        # The frozen `score` is the historical record of that pass and does
+        # not move when a finding is rejected on its thread (rerender updates
+        # the human header + dispositions map only). gptme/gptme#3755: score
+        # 4, one P2 already rejected, threads resolved, still dispatched every
+        # cooldown hour. Round cap (#3646) only fires after history length > 5,
+        # so an explicit disposition must be enough on its own.
+        # Old markers omit findings[]; do not treat that as "all disposed".
+        local outstanding
+        outstanding=$(printf '%s' "$marker" | jq -r '
+            (.findings // null) as $f
+            | if ($f | type) != "array" or ($f | length) == 0 then
+                empty
+              else
+                (.dispositions // {}) as $d
+                | [$f[] | select(.fp != null and ($d[.fp] // null) == null)] | length
+              end
+        ' 2>/dev/null)
+        if [ "$outstanding" = "0" ]; then
             echo "clean"
             return 0
         fi

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -487,7 +487,12 @@ has_actionable_update() {
                  and ($sha != "") and ($head | startswith($sha))
                  and (
                    (.dispositions // {}) as $d
-                   | [.findings[] | select(.fp != null and ($d[.fp] // null) == null)]
+                   | [.findings[] | select(
+                       type != "object"
+                       or (.fp | type) != "string"
+                       or .fp == ""
+                       or (($d[.fp] // null) == null)
+                     )]
                      | length > 0
                  )
               then "yes" else "no" end
@@ -1083,7 +1088,12 @@ ai_review_verdict() {
                 empty
               else
                 (.dispositions // {}) as $d
-                | [$f[] | select(.fp != null and ($d[.fp] // null) == null)] | length
+                | [$f[] | select(
+                    type != "object"
+                    or (.fp | type) != "string"
+                    or .fp == ""
+                    or (($d[.fp] // null) == null)
+                  )] | length
               end
         ' 2>/dev/null)
         if [ "$outstanding" = "0" ]; then

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -232,6 +232,34 @@ def test_disposed_standing_findings_are_silenced():
     assert not _actionable_pr(pr)
 
 
+def test_standing_findings_without_fp_stay_actionable():
+    """A finding missing ``fp`` is still inbound work, even with last-actor=self."""
+    marker = (
+        "## AI code review\n\n"
+        f'{MARKER} {{"sha": "7bb89e6c544c", "score": 4, '
+        f'"findings": [{{"severity": "P2"}}], '
+        f'"dispositions": {{}}}} -->'
+    )
+    pr = {
+        "number": 3755,
+        "headRefOid": HEAD,
+        "comments": [
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-09-08T14:12:16Z",
+                "body": marker,
+            },
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-09-08T14:40:00Z",
+                "body": "Looked into this; no code change.",
+            },
+        ],
+        "latestReviews": [],
+    }
+    assert _actionable_pr(pr)
+
+
 def test_quoted_standing_marker_reply_is_silenced():
     """A later self-reply that blockquotes the standing marker is not itself
     reviewer state. Without a complete-line marker comment, last-actor=self

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -260,6 +260,34 @@ def test_standing_findings_without_fp_stay_actionable():
     assert _actionable_pr(pr)
 
 
+def test_standing_findings_with_null_disposition_stay_actionable():
+    """A null disposition entry is not a settlement — last-actor=self still inbound."""
+    marker = (
+        "## AI code review\n\n"
+        f'{MARKER} {{"sha": "7bb89e6c544c", "score": 4, '
+        f'"findings": [{{"fp": "aaaa", "severity": "P2"}}], '
+        f'"dispositions": {{"aaaa": null}}}} -->'
+    )
+    pr = {
+        "number": 3755,
+        "headRefOid": HEAD,
+        "comments": [
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-09-08T14:12:16Z",
+                "body": marker,
+            },
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-09-08T14:40:00Z",
+                "body": "Looked into this; no code change.",
+            },
+        ],
+        "latestReviews": [],
+    }
+    assert _actionable_pr(pr)
+
+
 def test_quoted_standing_marker_reply_is_silenced():
     """A later self-reply that blockquotes the standing marker is not itself
     reviewer state. Without a complete-line marker comment, last-actor=self

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -199,6 +199,39 @@ def test_standing_marker_findings_at_head_actionable():
     assert _actionable_pr(_pr_3638_shape())
 
 
+def test_disposed_standing_findings_are_silenced():
+    """gptme#3755: a rejected finding is not inbound work.
+
+    Frozen findings[] stays populated; the dispositions map is the current
+    state. Last actor is self (closed-loop comment) and must stay silenced.
+    """
+    fp = "543152f97269"
+    marker = (
+        "## AI code review\n\n"
+        f'{MARKER} {{"sha": "7bb89e6c544c", "score": 4, '
+        f'"findings": [{{"fp": "{fp}", "severity": "P2"}}], '
+        f'"dispositions": {{"{fp}": {{"fp": "{fp}", "reason": "rejected"}}}}}} -->'
+    )
+    pr = {
+        "number": 3755,
+        "headRefOid": HEAD,
+        "comments": [
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-09-08T14:12:16Z",
+                "body": marker,
+            },
+            {
+                "author": {"login": BOT},
+                "createdAt": "2026-09-08T14:40:00Z",
+                "body": "Looked into this; P2 already rejected. No code change.",
+            },
+        ],
+        "latestReviews": [],
+    }
+    assert not _actionable_pr(pr)
+
+
 def test_quoted_standing_marker_reply_is_silenced():
     """A later self-reply that blockquotes the standing marker is not itself
     reviewer state. Without a complete-line marker comment, last-actor=self

--- a/tests/test_activity_gate_greptile_dark.py
+++ b/tests/test_activity_gate_greptile_dark.py
@@ -131,7 +131,12 @@ def _pr(head_sha: str = TEST_HEAD_SHA) -> dict:
 
 
 def _bob_ai_review_comment(
-    sha: str, score: int = 4, *, n_history: int | None = None
+    sha: str,
+    score: int = 4,
+    *,
+    n_history: int | None = None,
+    findings: list[dict] | None = None,
+    dispositions: dict | None = None,
 ) -> dict:
     """A comment carrying Bob's ai-review marker (no Greptile signature).
 
@@ -139,18 +144,20 @@ def _bob_ai_review_comment(
     current round, matching the live reviewer). Default ``None`` keeps the
     original compact marker so existing tests stay byte-identical.
     """
+    payload: dict = {"sha": sha, "score": score}
     if n_history:
-        history = [
+        payload["history"] = [
             {"sha": f"{sha[:6]}{i:02d}", "score": score, "findings": 1}
             for i in range(n_history)
         ]
-        marker = json.dumps(
-            {"sha": sha, "score": score, "history": history},
-            separators=(",", ":"),
-        )
-        body = f"<!-- bob-ai-review {marker} -->"
-    else:
+    if findings is not None:
+        payload["findings"] = findings
+    if dispositions is not None:
+        payload["dispositions"] = dispositions
+    if findings is None and dispositions is None and not n_history:
         body = f'<!-- bob-ai-review {{"sha": "{sha}", "score": {score}}} -->'
+    else:
+        body = f"<!-- bob-ai-review {json.dumps(payload, separators=(',', ':'))} -->"
     return {
         "id": 111,
         "user": {"login": BOT},
@@ -717,6 +724,92 @@ def test_dark_branch_high_dark_score_dirty_ai_emits_needs_fix() -> None:
         assert (
             improvement_items == []
         ), f"no improvement item expected when AI verdict is dirty; got: {improvement_items}"
+
+
+def test_fully_disposed_findings_are_clean() -> None:
+    """Score 4 with every listed finding disposed is clean before the round cap.
+
+    gptme/gptme#3755: Greptile 5/5, our reviewer 4/5 with one P2 already
+    rejected on its thread, history length 5 (cap not yet fired). Frozen
+    score stayed 4, so the gate re-emitted reviewer_needs_fix every hour.
+    """
+    import time
+
+    short_sha = TEST_HEAD_SHA[:10]
+    fp = "543152f97269"
+    fixture = {
+        "prs": [_pr()],
+        "comments": [
+            _bob_ai_review_comment(
+                short_sha,
+                score=4,
+                n_history=5,
+                findings=[{"fp": fp, "severity": "P2"}],
+                dispositions={fp: {"fp": fp, "reason": "rejected"}},
+            )
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        state_file = _state_file(state_dir)
+        old_ts = int(time.time()) - 7200
+        state_file.write_text(f":{old_ts}:{TEST_HEAD_SHA}:dirty")
+
+        result = _run_gate(tmp, fixture, state_dir=state_dir)
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _greptile_items(result)
+        assert items == [], (
+            f"fully-disposed findings must not emit; got {items}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        fields = state_file.read_text().strip().split(":")
+        assert fields[3] == "clean", (
+            f"verdict field must be clean after full disposition; "
+            f"got: {state_file.read_text()!r}"
+        )
+
+
+def test_undisposed_findings_stay_dirty_before_round_cap() -> None:
+    """A listed finding without a disposition still dispatches at score 4."""
+    import time
+
+    short_sha = TEST_HEAD_SHA[:10]
+    fixture = {
+        "prs": [_pr()],
+        "comments": [
+            _bob_ai_review_comment(
+                short_sha,
+                score=4,
+                n_history=5,
+                findings=[{"fp": "543152f97269", "severity": "P2"}],
+            )
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        state_file = _state_file(state_dir)
+        old_ts = int(time.time()) - 7200
+        state_file.write_text(f":{old_ts}:{TEST_HEAD_SHA}:dirty")
+
+        result = _run_gate(tmp, fixture, state_dir=state_dir)
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _greptile_items(result)
+        assert any(
+            i.get("type") in ("greptile_needs_fix", "reviewer_needs_fix") for i in items
+        ), (
+            f"undisposed score-4 finding before round cap must emit; got {items}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
 
 
 def test_round_capped_p2_score_4_is_clean() -> None:

--- a/tests/test_activity_gate_greptile_dark.py
+++ b/tests/test_activity_gate_greptile_dark.py
@@ -812,6 +812,50 @@ def test_undisposed_findings_stay_dirty_before_round_cap() -> None:
         )
 
 
+def test_findings_without_fp_stay_dirty_before_round_cap() -> None:
+    """A listed finding missing ``fp`` is outstanding, not vacuously disposed.
+
+    The jq path used to count only findings that already had a fingerprint,
+    so ``findings: [{"severity": "P2"}]`` produced outstanding=0 and cleaned
+    a score-4 marker. Python's standing-findings check is fail-closed here.
+    """
+    import time
+
+    short_sha = TEST_HEAD_SHA[:10]
+    fixture = {
+        "prs": [_pr()],
+        "comments": [
+            _bob_ai_review_comment(
+                short_sha,
+                score=4,
+                n_history=5,
+                findings=[{"severity": "P2"}],
+                dispositions={},
+            )
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        state_file = _state_file(state_dir)
+        old_ts = int(time.time()) - 7200
+        state_file.write_text(f":{old_ts}:{TEST_HEAD_SHA}:dirty")
+
+        result = _run_gate(tmp, fixture, state_dir=state_dir)
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _greptile_items(result)
+        assert any(
+            i.get("type") in ("greptile_needs_fix", "reviewer_needs_fix") for i in items
+        ), (
+            f"finding without fp must stay dirty; got {items}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
 def test_round_capped_p2_score_4_is_clean() -> None:
     """Score 4 with history length > 5 (round cap already applied) is clean.
 

--- a/tests/test_activity_gate_greptile_dark.py
+++ b/tests/test_activity_gate_greptile_dark.py
@@ -856,6 +856,50 @@ def test_findings_without_fp_stay_dirty_before_round_cap() -> None:
         )
 
 
+def test_null_disposition_stays_dirty_before_round_cap() -> None:
+    """A listed finding whose disposition value is JSON null is outstanding.
+
+    ``fp in dispositions`` would treat ``{"aaaa": null}`` as settled; jq's
+    ``($d[.fp] // null) == null`` already counted it outstanding. Require an
+    object disposition entry in both paths.
+    """
+    import time
+
+    short_sha = TEST_HEAD_SHA[:10]
+    fixture = {
+        "prs": [_pr()],
+        "comments": [
+            _bob_ai_review_comment(
+                short_sha,
+                score=4,
+                n_history=5,
+                findings=[{"fp": "aaaa", "severity": "P2"}],
+                dispositions={"aaaa": None},
+            )
+        ],
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        state_file = _state_file(state_dir)
+        old_ts = int(time.time()) - 7200
+        state_file.write_text(f":{old_ts}:{TEST_HEAD_SHA}:dirty")
+
+        result = _run_gate(tmp, fixture, state_dir=state_dir)
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _greptile_items(result)
+        assert any(
+            i.get("type") in ("greptile_needs_fix", "reviewer_needs_fix") for i in items
+        ), (
+            f"null disposition must stay dirty; got {items}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
 def test_round_capped_p2_score_4_is_clean() -> None:
     """Score 4 with history length > 5 (round cap already applied) is clean.
 


### PR DESCRIPTION
## Summary

`ai_review_verdict` treated a frozen score < 5 as dirty even when every listed finding already had a disposition. gptme/gptme#3755 sat at Greptile 5/5 with a rejected P2 and still emitted `reviewer_needs_fix` every cooldown hour — the round cap from gptme/gptme#3646 only fires after history length > 5.

If the marker records a non-empty `findings[]` and every fingerprint is in `dispositions`, the verdict is now clean. Same rule in the standing-findings checks so a closed-loop self-comment is not inbound work. Old compact markers that omit `findings[]` still use the score/round-cap path.

## Test plan

- [x] `test_fully_disposed_findings_are_clean`
- [x] `test_undisposed_findings_stay_dirty_before_round_cap`
- [x] `test_round_capped_p2_score_4_is_clean` (existing)
- [x] `test_disposed_standing_findings_are_silenced`
- [x] `test_disposed_findings_are_not_standing`
