### PR TITLE
feat(gptme-voice): expose BodyAdapter machine-readable characteristics

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/body/__init__.py
+++ b/packages/gptme-voice/src/gptme_voice/body/__init__.py
@@ -11,9 +11,12 @@ from .adapter import (
     CAP_MOVE,
     CAP_ROTATE,
     BodyAdapter,
+    BodyCharacteristics,
     NullAdapter,
     body_adapter_from_env,
     body_tool_schemas,
+    conservative_mobile_characteristics,
+    no_locomotion_characteristics,
 )
 from .remote_adapter import RemoteAdapter
 
@@ -23,8 +26,11 @@ __all__ = [
     "CAP_MOVE",
     "CAP_ROTATE",
     "BodyAdapter",
+    "BodyCharacteristics",
     "NullAdapter",
     "RemoteAdapter",
     "body_adapter_from_env",
     "body_tool_schemas",
+    "conservative_mobile_characteristics",
+    "no_locomotion_characteristics",
 ]

--- a/packages/gptme-voice/src/gptme_voice/body/adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/adapter.py
@@ -8,14 +8,18 @@ final authority — a dropped brain link must always leave the body safe.
 
 Capabilities gate which voice tools get registered for a session:
 a tabletop puck (NullAdapter, no capabilities) exposes no motion tools at
-all, so the model cannot try to fly a desk ornament.
+all, so the model cannot try to fly a desk ornament. ``characteristics()``
+is the machine-readable envelope (limits, geofence, endurance reserve,
+link-loss) so the model can see *how far* as well as *whether*. PX4 0 on a
+limit param means disabled/unlimited and must never be advertised.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Protocol, runtime_checkable
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -25,6 +29,125 @@ CAP_MOVE = "move"  # horizontal translation (goto/move/return home)
 CAP_ROTATE = "rotate"  # yaw control
 CAP_ALTITUDE = "altitude"  # vertical control (takeoff/land/up-down)
 CAP_INTERACT = "interact"  # trigger the body's default local interaction
+
+# Conservative static envelope. PX4 geofence 0 means "disabled" (unlimited);
+# we never advertise unlimited. These match the tool-bridge session clamps.
+FALLBACK_MAX_ALTITUDE_M = 30.0
+FALLBACK_MAX_RADIUS_M = 50.0
+FALLBACK_MAX_SPEED_MPS = 5.0
+FALLBACK_LINK_LOSS_TIMEOUT_S = 10.0
+FALLBACK_RESERVE_RTL_PERCENT = 25.0
+
+LinkLossAction = Literal[
+    "none", "hold", "rtl", "land", "terminate", "disarm", "unknown"
+]
+
+
+@dataclass(frozen=True)
+class FlightEnvelope:
+    max_altitude_m: float
+    max_radius_m: float
+    max_horizontal_speed_mps: float
+
+
+@dataclass(frozen=True)
+class Geofence:
+    enabled: bool
+    max_radius_m: float
+    max_altitude_m: float
+
+
+@dataclass(frozen=True)
+class Endurance:
+    remaining_s: float | None
+    reserve_rtl_percent: float
+    battery_remaining_percent: float | None = None
+
+
+@dataclass(frozen=True)
+class LinkLossBehavior:
+    action: LinkLossAction
+    timeout_s: float | None
+    authority: str
+
+
+@dataclass(frozen=True)
+class BodyCharacteristics:
+    """Machine-readable body limits. Informs goal selection; does not replace
+    autopilot enforcement."""
+
+    locomotion: bool
+    envelope: FlightEnvelope | None
+    geofence: Geofence | None
+    endurance: Endurance | None
+    link_loss: LinkLossBehavior
+    source: str
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def no_locomotion_characteristics(
+    *,
+    source: str = "declared",
+    notes: str | None = "No locomotion: no envelope, no geofence, no endurance.",
+    authority: str = "none",
+) -> dict[str, Any]:
+    return BodyCharacteristics(
+        locomotion=False,
+        envelope=None,
+        geofence=None,
+        endurance=None,
+        link_loss=LinkLossBehavior(action="none", timeout_s=None, authority=authority),
+        source=source,
+        notes=notes,
+    ).to_dict()
+
+
+def conservative_mobile_characteristics(
+    *,
+    source: str = "fallback",
+    notes: str | None = None,
+    authority: str = "px4",
+    link_loss_action: LinkLossAction = "rtl",
+    link_loss_timeout_s: float | None = FALLBACK_LINK_LOSS_TIMEOUT_S,
+    reserve_rtl_percent: float = FALLBACK_RESERVE_RTL_PERCENT,
+    battery_remaining_percent: float | None = None,
+    envelope: FlightEnvelope | None = None,
+    geofence: Geofence | None = None,
+) -> dict[str, Any]:
+    env = envelope or FlightEnvelope(
+        max_altitude_m=FALLBACK_MAX_ALTITUDE_M,
+        max_radius_m=FALLBACK_MAX_RADIUS_M,
+        max_horizontal_speed_mps=FALLBACK_MAX_SPEED_MPS,
+    )
+    fence = geofence or Geofence(
+        enabled=False,
+        max_radius_m=env.max_radius_m,
+        max_altitude_m=env.max_altitude_m,
+    )
+    return BodyCharacteristics(
+        locomotion=True,
+        envelope=env,
+        geofence=fence,
+        endurance=Endurance(
+            remaining_s=None,
+            reserve_rtl_percent=reserve_rtl_percent,
+            battery_remaining_percent=battery_remaining_percent,
+        ),
+        link_loss=LinkLossBehavior(
+            action=link_loss_action,
+            timeout_s=link_loss_timeout_s,
+            authority=authority,
+        ),
+        source=source,
+        notes=notes
+        or (
+            "Conservative static envelope; remaining flight time is unknown "
+            "without a fitted power model. Autopilot failsafes remain final."
+        ),
+    ).to_dict()
 
 
 @runtime_checkable
@@ -68,6 +191,8 @@ class BodyAdapter(Protocol):
 
     def telemetry(self) -> dict[str, Any]: ...
 
+    def characteristics(self) -> dict[str, Any]: ...
+
 
 class NullAdapter:
     """Body with no locomotion — the tabletop puck.
@@ -88,6 +213,11 @@ class NullAdapter:
 
     def telemetry(self) -> dict[str, Any]:
         return {"body": self.name, "mobile": False}
+
+    def characteristics(self) -> dict[str, Any]:
+        return no_locomotion_characteristics(
+            notes="Tabletop puck: no locomotion, no envelope, no geofence.",
+        )
 
     async def _unsupported(self) -> dict[str, Any]:
         return {"error": "This body has no locomotion."}
@@ -139,10 +269,11 @@ def body_tool_schemas(adapter: BodyAdapter | None) -> list[dict]:
             "type": "function",
             "name": "body_status",
             "description": (
-                "Read the physical body's current state: position, altitude, "
-                "battery, heading, flight mode. Use it before motion commands "
-                "and whenever the caller asks where the body is or how it is "
-                "doing."
+                "Read the physical body's current state and its machine-readable "
+                "limits: position, altitude, battery, heading, flight mode, plus "
+                "the flight envelope, geofence, endurance reserve, and declared "
+                "link-loss behavior. Use characteristics before planning motion. "
+                "Limits inform goal selection; the autopilot still enforces them."
             ),
             "parameters": {"type": "object", "properties": {}},
         }

--- a/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/mavsdk_adapter.py
@@ -16,11 +16,162 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+from collections.abc import Mapping
 from typing import Any
+
+from .adapter import (
+    FALLBACK_LINK_LOSS_TIMEOUT_S,
+    FALLBACK_MAX_ALTITUDE_M,
+    FALLBACK_MAX_RADIUS_M,
+    FALLBACK_MAX_SPEED_MPS,
+    FALLBACK_RESERVE_RTL_PERCENT,
+    FlightEnvelope,
+    Geofence,
+    LinkLossAction,
+    conservative_mobile_characteristics,
+)
 
 logger = logging.getLogger(__name__)
 
 _EARTH_M_PER_DEG_LAT = 111_320.0
+
+# PX4 params that populate the characteristics descriptor. A geofence
+# distance of 0 means "disabled" (unlimited) — never advertise that.
+_PX4_PARAM_NAMES = (
+    "GF_MAX_HOR_DIST",
+    "GF_MAX_VER_DIST",
+    "MPC_XY_VEL_MAX",
+    "NAV_RCL_ACT",
+    "NAV_DLL_ACT",
+    "COM_RC_LOSS_T",
+    "COM_DL_LOSS_T",
+    "BAT_LOW_THR",
+)
+
+_PX4_FAILSAFE_ACTION: dict[int, LinkLossAction] = {
+    0: "none",
+    1: "hold",
+    2: "rtl",
+    3: "land",
+    4: "terminate",
+    5: "disarm",
+}
+
+
+def _finite_positive(value: object) -> float | None:
+    """Return a finite number > 0, else None.
+
+    PX4 uses 0 on several limit params to mean 'disabled' / unlimited.
+    Those must degrade to the conservative fallback, never pass through.
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        return None
+    return number
+
+
+def _px4_failsafe_action(value: object) -> LinkLossAction | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    if float(value) != int(value):
+        return None
+    return _PX4_FAILSAFE_ACTION.get(int(value))
+
+
+def characteristics_from_px4_params(
+    params: Mapping[str, float | int],
+    *,
+    battery_remaining_percent: float | None = None,
+) -> dict[str, Any]:
+    """Build a characteristics dict from PX4 params.
+
+    Missing, non-finite, or non-positive limit params fall back to the
+    conservative static envelope. ``source`` is ``px4-params`` when every
+    limit we care about was present, else ``mixed`` or ``fallback``.
+    """
+    gaps: list[str] = []
+
+    radius_raw = _finite_positive(params.get("GF_MAX_HOR_DIST"))
+    altitude_raw = _finite_positive(params.get("GF_MAX_VER_DIST"))
+    if radius_raw is None:
+        gaps.append("GF_MAX_HOR_DIST")
+    if altitude_raw is None:
+        gaps.append("GF_MAX_VER_DIST")
+    radius = radius_raw if radius_raw is not None else FALLBACK_MAX_RADIUS_M
+    altitude = altitude_raw if altitude_raw is not None else FALLBACK_MAX_ALTITUDE_M
+    fence_enabled = radius_raw is not None or altitude_raw is not None
+
+    speed = _finite_positive(params.get("MPC_XY_VEL_MAX"))
+    if speed is None:
+        gaps.append("MPC_XY_VEL_MAX")
+        speed = FALLBACK_MAX_SPEED_MPS
+
+    # Brain-link loss is closer to datalink loss than RC loss. PX4 action 0
+    # means "disabled"; a flying body must not advertise "none".
+    dll = _px4_failsafe_action(params.get("NAV_DLL_ACT"))
+    rcl = _px4_failsafe_action(params.get("NAV_RCL_ACT"))
+    if dll is None:
+        gaps.append("NAV_DLL_ACT")
+    if rcl is None:
+        gaps.append("NAV_RCL_ACT")
+    action: LinkLossAction = "rtl"
+    for candidate in (dll, rcl):
+        if candidate is not None and candidate != "none":
+            action = candidate
+            break
+
+    timeout = _finite_positive(params.get("COM_DL_LOSS_T"))
+    if timeout is None:
+        timeout = _finite_positive(params.get("COM_RC_LOSS_T"))
+    if timeout is None:
+        gaps.append("COM_DL_LOSS_T")
+        timeout = FALLBACK_LINK_LOSS_TIMEOUT_S
+
+    reserve = _finite_positive(params.get("BAT_LOW_THR"))
+    if reserve is None:
+        gaps.append("BAT_LOW_THR")
+        reserve_percent = FALLBACK_RESERVE_RTL_PERCENT
+    else:
+        # BAT_LOW_THR is 0-1; the descriptor advertises percent.
+        reserve_percent = reserve * 100.0 if reserve <= 1.0 else reserve
+
+    if not gaps:
+        source = "px4-params"
+        notes = "Populated from live PX4 parameters. Autopilot failsafes remain final."
+    elif len(gaps) >= 5:
+        source = "fallback"
+        notes = (
+            "PX4 param read missed the envelope; using conservative static "
+            "limits. Autopilot failsafes remain final."
+        )
+    else:
+        source = "mixed"
+        notes = (
+            "Some PX4 params were missing or disabled (0 = unlimited); "
+            f"fell back for: {', '.join(gaps)}. Autopilot failsafes remain final."
+        )
+
+    return conservative_mobile_characteristics(
+        source=source,
+        notes=notes,
+        authority="px4",
+        link_loss_action=action,
+        link_loss_timeout_s=timeout,
+        reserve_rtl_percent=reserve_percent,
+        battery_remaining_percent=battery_remaining_percent,
+        envelope=FlightEnvelope(
+            max_altitude_m=altitude,
+            max_radius_m=radius,
+            max_horizontal_speed_mps=speed,
+        ),
+        geofence=Geofence(
+            enabled=fence_enabled,
+            max_radius_m=radius,
+            max_altitude_m=altitude,
+        ),
+    )
 
 
 def body_to_ned(
@@ -76,6 +227,9 @@ class MavsdkAdapter:
         self._in_air: bool | None = None
         self._flight_mode: str | None = None
         self._armed: bool | None = None
+        # Characteristics cache. Tests can set _param_overrides to skip MAVSDK I/O.
+        self._param_overrides: dict[str, float | int] | None = None
+        self._characteristics: dict[str, Any] = conservative_mobile_characteristics()
 
     async def ensure_connected(self) -> None:
         async with self._connection_lock:
@@ -110,6 +264,7 @@ class MavsdkAdapter:
                 self._system = system
                 self._start_telemetry_cache()
                 self._connected = True
+                await self._load_characteristics()
                 logger.info("MavsdkAdapter connected")
 
     def _start_telemetry_cache(self) -> None:
@@ -180,6 +335,7 @@ class MavsdkAdapter:
         self._in_air = None
         self._flight_mode = None
         self._armed = None
+        self._characteristics = conservative_mobile_characteristics()
         current = asyncio.current_task()
         for task in self._telemetry_tasks:
             if task is not current:
@@ -247,6 +403,91 @@ class MavsdkAdapter:
             "flight_mode": self._flight_mode,
             "armed": self._armed,
         }
+
+    def characteristics(self) -> dict[str, Any]:
+        payload = dict(self._characteristics)
+        endurance = payload.get("endurance")
+        if isinstance(endurance, dict):
+            endurance = dict(endurance)
+            remaining = self._battery.get("remaining_percent")
+            if remaining is not None:
+                endurance["battery_remaining_percent"] = remaining
+            payload["endurance"] = endurance
+        return payload
+
+    async def _load_characteristics(self) -> None:
+        if self._param_overrides is not None:
+            raw: dict[str, float | int] = dict(self._param_overrides)
+        else:
+            raw = await self._read_px4_params()
+        self._characteristics = characteristics_from_px4_params(
+            raw,
+            battery_remaining_percent=self._battery.get("remaining_percent"),
+        )
+
+    async def _read_px4_params(self) -> dict[str, float | int]:
+        system = self._system
+        if system is None:
+            return {}
+        collected = await self._read_all_px4_params(system)
+        if collected is not None:
+            return {
+                name: collected[name] for name in _PX4_PARAM_NAMES if name in collected
+            }
+        raw: dict[str, float | int] = {}
+        for name in _PX4_PARAM_NAMES:
+            value = await self._get_param(system, name)
+            if value is not None:
+                raw[name] = value
+        return raw
+
+    @staticmethod
+    async def _read_all_px4_params(system: Any) -> dict[str, float | int] | None:
+        getter = getattr(getattr(system, "param", None), "get_all_params", None)
+        if not callable(getter):
+            return None
+        try:
+            all_params = await asyncio.wait_for(getter(), timeout=5.0)
+        except Exception:
+            logger.debug(
+                "MAVSDK get_all_params failed; falling back to per-name reads",
+                exc_info=True,
+            )
+            return None
+        collected: dict[str, float | int] = {}
+        for group in (
+            getattr(all_params, "int_params", None),
+            getattr(all_params, "float_params", None),
+        ):
+            if not group:
+                continue
+            for param in group:
+                name = getattr(param, "name", None)
+                value = getattr(param, "value", None)
+                if (
+                    isinstance(name, str)
+                    and isinstance(value, int | float)
+                    and not isinstance(value, bool)
+                ):
+                    collected[name] = value
+        return collected
+
+    @staticmethod
+    async def _get_param(system: Any, name: str) -> float | int | None:
+        param = getattr(system, "param", None)
+        if param is None:
+            return None
+        for getter_name in ("get_param_float", "get_param_int"):
+            getter = getattr(param, getter_name, None)
+            if not callable(getter):
+                continue
+            try:
+                value = await asyncio.wait_for(getter(name), timeout=1.0)
+            except Exception:
+                continue
+            if isinstance(value, int | float) and not isinstance(value, bool):
+                return value
+        return None
 
     async def takeoff(self, altitude_m: float) -> dict[str, Any]:
         async with self._command_lock:

--- a/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
+++ b/packages/gptme-voice/src/gptme_voice/body/remote_adapter.py
@@ -15,6 +15,11 @@ from gptme_body_protocol import (
     require_handshake_ok,
 )
 
+from .adapter import (
+    conservative_mobile_characteristics,
+    no_locomotion_characteristics,
+)
+
 # Body-node wire capabilities mapped to gptme-voice's model-facing capabilities.
 _WIRE_TO_ADAPTER_CAPABILITY = {
     "move": "move",
@@ -142,6 +147,25 @@ class RemoteAdapter:
 
     def telemetry(self) -> dict[str, Any]:
         return self._telemetry.copy()
+
+    def characteristics(self) -> dict[str, Any]:
+        # The body-node wire protocol does not yet export an envelope. Never
+        # advertise unlimited: a mobile remote body gets the conservative
+        # static descriptor; a non-mobile one declares no locomotion.
+        if self.capabilities & {"move", "rotate", "altitude"}:
+            return conservative_mobile_characteristics(
+                source="fallback",
+                authority="body-node",
+                notes=(
+                    "Remote body-node does not export characteristics yet; "
+                    "conservative static envelope. The body node owns local safety."
+                ),
+            )
+        return no_locomotion_characteristics(
+            source="declared",
+            authority="body-node",
+            notes="Remote body has no locomotion capabilities.",
+        )
 
     @staticmethod
     def _validated_telemetry(response: dict[str, Any]) -> dict[str, Any]:

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -1003,7 +1003,11 @@ class GptmeToolBridge:
         caps = adapter.capabilities
         try:
             if name == "body_status":
-                return {"status": "ok", "telemetry": adapter.telemetry()}
+                return {
+                    "status": "ok",
+                    "telemetry": adapter.telemetry(),
+                    "characteristics": adapter.characteristics(),
+                }
             if name == "body_stop" and "move" in caps:
                 return await _call(adapter.stop())
             if name == "body_return_home" and "move" in caps:

--- a/packages/gptme-voice/tests/test_body_tools.py
+++ b/packages/gptme-voice/tests/test_body_tools.py
@@ -9,8 +9,20 @@ from gptme_voice.body import (
     NullAdapter,
     body_adapter_from_env,
     body_tool_schemas,
+    conservative_mobile_characteristics,
+    no_locomotion_characteristics,
 )
-from gptme_voice.body.mavsdk_adapter import body_to_ned, offset_latlon
+from gptme_voice.body.adapter import (
+    FALLBACK_MAX_ALTITUDE_M,
+    FALLBACK_MAX_RADIUS_M,
+    FALLBACK_MAX_SPEED_MPS,
+    FALLBACK_RESERVE_RTL_PERCENT,
+)
+from gptme_voice.body.mavsdk_adapter import (
+    body_to_ned,
+    characteristics_from_px4_params,
+    offset_latlon,
+)
 from gptme_voice.realtime.tool_bridge import GptmeToolBridge
 
 
@@ -48,6 +60,11 @@ class FakeAdapter:
             else None
         )
         return {"body": "fake", "in_air": self.in_air, "position": position}
+
+    def characteristics(self) -> dict[str, Any]:
+        if self.capabilities & {"move", "rotate", "altitude"}:
+            return conservative_mobile_characteristics(source="declared")
+        return no_locomotion_characteristics()
 
     async def takeoff(self, altitude_m: float) -> dict:
         self.calls.append(("takeoff", (altitude_m,)))
@@ -142,6 +159,8 @@ def test_bridge_status_and_stop(loop):
     status = _call(bridge, "body_status")
     assert status["status"] == "ok"
     assert status["telemetry"]["body"] == "fake"
+    assert status["characteristics"]["locomotion"] is True
+    assert status["characteristics"]["envelope"]["max_altitude_m"] > 0
     stop = _call(bridge, "body_stop")
     assert stop["status"] == "holding"
     assert ("stop", ()) in adapter.calls
@@ -311,6 +330,13 @@ def test_null_adapter_motion_reports_unsupported(loop):
     result = asyncio.get_event_loop().run_until_complete(null.stop())
     assert "error" in result
     assert null.telemetry()["mobile"] is False
+    characteristics = null.characteristics()
+    assert characteristics["locomotion"] is False
+    assert characteristics["envelope"] is None
+    assert characteristics["geofence"] is None
+    assert characteristics["endurance"] is None
+    assert characteristics["link_loss"]["action"] == "none"
+    assert characteristics["source"] == "declared"
 
 
 # --- env factory --------------------------------------------------------
@@ -542,7 +568,7 @@ def test_mavsdk_telemetry_failure_marks_disconnected(loop):
         flight_mode = staticmethod(waiting_stream)
         armed = staticmethod(waiting_stream)
 
-    async def run() -> tuple[bool, dict[str, Any], list[asyncio.Task]]:
+    async def run() -> tuple[bool, dict[str, Any], list[asyncio.Task], dict[str, Any]]:
         adapter = MavsdkAdapter("unused")
         adapter._system = type("System", (), {"telemetry": Telemetry()})()
         adapter._connected = True
@@ -550,9 +576,115 @@ def test_mavsdk_telemetry_failure_marks_disconnected(loop):
         adapter._start_telemetry_cache()
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        return adapter._connected, adapter._position, adapter._telemetry_tasks
+        return (
+            adapter._connected,
+            adapter._position,
+            adapter._telemetry_tasks,
+            adapter.characteristics(),
+        )
 
-    connected, position, tasks = loop.run_until_complete(run())
+    connected, position, tasks, characteristics = loop.run_until_complete(run())
     assert connected is False
     assert position == {}
     assert tasks == []
+    assert characteristics["source"] == "fallback"
+
+
+def _assert_finite_envelope(payload: dict[str, Any]) -> None:
+    envelope = payload["envelope"]
+    assert envelope is not None
+    for key in ("max_altitude_m", "max_radius_m", "max_horizontal_speed_mps"):
+        value = envelope[key]
+        assert isinstance(value, int | float) and not isinstance(value, bool)
+        assert value > 0
+        assert value != float("inf")
+    assert payload["link_loss"]["action"] != "none"
+
+
+def test_px4_params_populate_envelope():
+    payload = characteristics_from_px4_params(
+        {
+            "GF_MAX_HOR_DIST": 80.0,
+            "GF_MAX_VER_DIST": 25.0,
+            "MPC_XY_VEL_MAX": 8.0,
+            "NAV_DLL_ACT": 2,
+            "NAV_RCL_ACT": 1,
+            "COM_DL_LOSS_T": 12,
+            "BAT_LOW_THR": 0.2,
+        },
+        battery_remaining_percent=67.0,
+    )
+    _assert_finite_envelope(payload)
+    assert payload["source"] == "px4-params"
+    assert payload["locomotion"] is True
+    assert payload["envelope"]["max_radius_m"] == 80.0
+    assert payload["envelope"]["max_altitude_m"] == 25.0
+    assert payload["envelope"]["max_horizontal_speed_mps"] == 8.0
+    assert payload["geofence"]["enabled"] is True
+    assert payload["link_loss"]["action"] == "rtl"
+    assert payload["link_loss"]["timeout_s"] == 12.0
+    assert payload["link_loss"]["authority"] == "px4"
+    assert payload["endurance"]["reserve_rtl_percent"] == pytest.approx(20.0)
+    assert payload["endurance"]["battery_remaining_percent"] == 67.0
+    assert payload["endurance"]["remaining_s"] is None
+
+
+def test_px4_zero_geofence_is_not_unlimited():
+    payload = characteristics_from_px4_params(
+        {
+            "GF_MAX_HOR_DIST": 0,
+            "GF_MAX_VER_DIST": 0,
+            "MPC_XY_VEL_MAX": 12.0,
+            "NAV_DLL_ACT": 0,
+            "NAV_RCL_ACT": 0,
+        }
+    )
+    _assert_finite_envelope(payload)
+    assert payload["source"] == "mixed"
+    assert payload["envelope"]["max_radius_m"] == FALLBACK_MAX_RADIUS_M
+    assert payload["envelope"]["max_altitude_m"] == FALLBACK_MAX_ALTITUDE_M
+    assert payload["envelope"]["max_horizontal_speed_mps"] == 12.0
+    assert payload["geofence"]["enabled"] is False
+    assert payload["link_loss"]["action"] == "rtl"
+
+
+def test_px4_missing_params_use_conservative_fallback():
+    payload = characteristics_from_px4_params({})
+    _assert_finite_envelope(payload)
+    assert payload["source"] == "fallback"
+    assert payload["envelope"]["max_altitude_m"] == FALLBACK_MAX_ALTITUDE_M
+    assert payload["envelope"]["max_radius_m"] == FALLBACK_MAX_RADIUS_M
+    assert payload["envelope"]["max_horizontal_speed_mps"] == FALLBACK_MAX_SPEED_MPS
+    assert payload["endurance"]["reserve_rtl_percent"] == FALLBACK_RESERVE_RTL_PERCENT
+    assert payload["link_loss"]["action"] == "rtl"
+
+
+def test_mavsdk_characteristics_from_overrides_and_live_battery(loop):
+    from gptme_voice.body.mavsdk_adapter import MavsdkAdapter
+
+    adapter = MavsdkAdapter("unused")
+    adapter._param_overrides = {
+        "GF_MAX_HOR_DIST": 40.0,
+        "GF_MAX_VER_DIST": 15.0,
+        "MPC_XY_VEL_MAX": 6.0,
+        "NAV_DLL_ACT": 3,
+        "NAV_RCL_ACT": 2,
+        "COM_DL_LOSS_T": 8,
+        "BAT_LOW_THR": 0.3,
+    }
+    loop.run_until_complete(adapter._load_characteristics())
+    first = adapter.characteristics()
+    assert first["envelope"]["max_radius_m"] == 40.0
+    assert first["link_loss"]["action"] == "land"
+    assert first["endurance"]["battery_remaining_percent"] is None
+
+    adapter._battery = {"remaining_percent": 41.5}
+    assert adapter.characteristics()["endurance"]["battery_remaining_percent"] == 41.5
+
+
+def test_bridge_null_adapter_surfaces_no_locomotion_characteristics(loop):
+    bridge = GptmeToolBridge(body_adapter=NullAdapter())
+    status = _call(bridge, "body_status")
+    assert status["status"] == "ok"
+    assert status["characteristics"]["locomotion"] is False
+    assert status["characteristics"]["envelope"] is None

--- a/packages/gptme-voice/tests/test_mavsdk_sitl_integration.py
+++ b/packages/gptme-voice/tests/test_mavsdk_sitl_integration.py
@@ -41,6 +41,14 @@ def test_full_flight_via_bridge():
                 break
             await asyncio.sleep(1)
         assert status["telemetry"]["position"], "no position fix from SITL"
+        characteristics = status["characteristics"]
+        assert characteristics["locomotion"] is True
+        envelope = characteristics["envelope"]
+        assert envelope["max_altitude_m"] > 0
+        assert envelope["max_radius_m"] > 0
+        assert envelope["max_horizontal_speed_mps"] > 0
+        assert characteristics["link_loss"]["action"] != "none"
+        assert characteristics["source"] in {"px4-params", "mixed", "fallback"}
 
         # takeoff
         result = await call("body_takeoff", {"altitude_m": 2.5})

--- a/packages/gptme-voice/tests/test_remote_adapter.py
+++ b/packages/gptme-voice/tests/test_remote_adapter.py
@@ -59,6 +59,11 @@ def test_remote_adapter_handshake_capabilities_and_goal_translation() -> None:
         try:
             await adapter.ensure_connected()
             assert adapter.capabilities == {"move", "rotate", "interact"}
+            characteristics = adapter.characteristics()
+            assert characteristics["locomotion"] is True
+            assert characteristics["envelope"]["max_altitude_m"] > 0
+            assert characteristics["source"] == "fallback"
+            assert characteristics["link_loss"]["authority"] == "body-node"
             assert await adapter.move(2.0, -0.5, 0.0) == {
                 "type": "command_result",
                 "command_id": "remote-0001",


### PR DESCRIPTION
## Summary

`BodyAdapter` already advertised capability strings (`move`, `rotate`, `altitude`, `interact`) so a tabletop puck cannot be told to fly. That answers *whether* the body can move. It never answered *how far*.

`body_status` now also returns a typed characteristics descriptor:

- flight envelope (max altitude, max radius, max horizontal speed)
- geofence bounds and whether PX4 has one enabled
- endurance reserve (RTL battery percent); remaining flight time is `null` without a fitted power model
- declared link-loss behavior

The descriptor informs goal selection. It does **not** replace PX4 failsafes.

## Behavior

- `NullAdapter` declares no locomotion (no envelope, no geofence, link-loss `none`)
- `MavsdkAdapter` reads live PX4 params (`GF_MAX_*`, `MPC_XY_VEL_MAX`, `NAV_DLL_ACT` / `NAV_RCL_ACT`, `COM_*_LOSS_T`, `BAT_LOW_THR`) on connect
- Param-read failure, non-finite values, and PX4 `0` (disabled = unlimited) degrade to conservative finite fallbacks (30 m alt / 50 m radius / 5 m/s / RTL). Never advertise unlimited
- `RemoteAdapter` uses the same conservative envelope until the body-node protocol exports one
- Tool bridge includes `characteristics` next to `telemetry` on `body_status`

## Tests

- Unit coverage for NullAdapter, PX4 populate, zero-geofence-is-not-unlimited, missing-param fallback, live battery overlay, and bridge surfacing
- SITL integration asserts a finite envelope when `BODY_SITL_URL` is set (skipped in CI)

`uv run pytest packages/gptme-voice/tests/ -q` → **349 passed, 2 skipped**

## Out of scope

- Enforcing the envelope in the brain (PX4 remains the authority)
- MHS wire format / remaining-flight-time power model
- Extending the body-node protocol to carry characteristics