### PR TITLE
feat(gptodo): add draft state for in-progress plans

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -53,9 +53,10 @@ _STATE_ORDER = {
     "ready_for_review": 2,
     "todo": 3,
     "backlog": 4,
-    "someday": 5,
-    "done": 6,
-    "cancelled": 7,
+    "draft": 5,
+    "someday": 6,
+    "done": 7,
+    "cancelled": 8,
 }
 
 

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -778,7 +778,7 @@ tr:hover { background: var(--accent-dim); }
           {% if task.state == 'waiting' and task.waiting_for %}<div class="task-hint">⏳ {{ task.waiting_for }}</div>{% endif %}
           {% if task.age_label %}<div class="task-hint">{{ task.age_label }}</div>{% endif %}
         </td>
-        <td><span class="tag {% if task.state in ('active', 'ready_for_review') %}tag-active{% elif task.state in ('waiting', 'todo') %}tag-medium{% elif task.state in ('backlog', 'someday') %}tag-source{% elif task.state in ('done', 'cancelled') %}tag-deprecated{% endif %}">{{ task.state }}</span></td>
+        <td><span class="tag {% if task.state in ('active', 'ready_for_review') %}tag-active{% elif task.state in ('waiting', 'todo') %}tag-medium{% elif task.state in ('backlog', 'someday', 'draft') %}tag-source{% elif task.state in ('done', 'cancelled') %}tag-deprecated{% endif %}">{{ task.state }}</span></td>
         <td>{% if task.priority %}<span class="tag {% if task.priority == 'high' %}tag-active{% elif task.priority == 'medium' %}tag-medium{% endif %}">{{ task.priority }}</span>{% endif %}</td>
         <td>{% for t in task.tags %}<span class="tag tag-category">{{ t }}</span>{% endfor %}</td>
         <td>{% if task.assigned_to %}{{ task.assigned_to }}{% endif %}</td>

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/task.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/task.html
@@ -135,7 +135,7 @@ header h1 {
 <header>
   <h1>{{ task.title }}</h1>
   <div class="meta">
-    <span class="tag {% if task.state in ('active', 'ready_for_review') %}tag-active{% elif task.state in ('waiting', 'todo') %}tag-medium{% elif task.state in ('backlog', 'someday') %}tag-source{% elif task.state in ('done', 'cancelled') %}tag-deprecated{% endif %}">{{ task.state }}</span>
+    <span class="tag {% if task.state in ('active', 'ready_for_review') %}tag-active{% elif task.state in ('waiting', 'todo') %}tag-medium{% elif task.state in ('backlog', 'someday', 'draft') %}tag-source{% elif task.state in ('done', 'cancelled') %}tag-deprecated{% endif %}">{{ task.state }}</span>
     {% if task.priority %}<span class="tag {% if task.priority == 'high' %}tag-active{% elif task.priority == 'medium' %}tag-medium{% endif %}">{{ task.priority }}</span>{% endif %}
     {% if task.task_type %}<span class="tag">{{ task.task_type }}</span>{% endif %}
     {% for t in task.tags %}<span class="tag tag-category">{{ t }}</span>{% endfor %}

--- a/packages/gptme-rag/src/gptme_rag/task_retrieval.py
+++ b/packages/gptme-rag/src/gptme_rag/task_retrieval.py
@@ -49,12 +49,12 @@ TASK_OPEN_STATES: frozenset[str] = frozenset(
         "active",
         "waiting",
         "ready_for_review",
-        "draft",
         "someday",
         "new",
         "paused",
     }
 )
+# `draft` is a held in-progress plan, not open work. Do not add it here.
 TASK_CLOSED_STATES: frozenset[str] = frozenset({"done", "cancelled", "archived"})
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-rag/src/gptme_rag/task_retrieval.py
+++ b/packages/gptme-rag/src/gptme_rag/task_retrieval.py
@@ -43,7 +43,17 @@ TASK_TRAILING_RATIO: float = 0.55
 MAX_TASKS_PER_QUERY: int = 3
 
 TASK_OPEN_STATES: frozenset[str] = frozenset(
-    {"backlog", "todo", "active", "waiting", "ready_for_review", "someday", "new", "paused"}
+    {
+        "backlog",
+        "todo",
+        "active",
+        "waiting",
+        "ready_for_review",
+        "draft",
+        "someday",
+        "new",
+        "paused",
+    }
 )
 TASK_CLOSED_STATES: frozenset[str] = frozenset({"done", "cancelled", "archived"})
 

--- a/packages/gptodo/README.md
+++ b/packages/gptodo/README.md
@@ -197,7 +197,7 @@ Task files should use frontmatter metadata:
 
 ```yaml
 ---
-state: active      # backlog, todo, active, ready_for_review, waiting, someday, done, cancelled, expired
+state: active      # draft, backlog, todo, active, ready_for_review, waiting, someday, done, cancelled, expired
 priority: high     # low, medium, high
 task_type: project # project (multi-step) or action (single-step)
 assigned_to: bob   # agent name
@@ -214,25 +214,27 @@ Task description...
 
 ## State Semantics
 
-The nine canonical states and what they *mean* — not just what they're
+The ten canonical states and what they *mean* — not just what they're
 called. The autonomous loop drifts when "active" gets used as an opaque
 "recently touched" tag; enforcing the semantics is the point of the
 `gptodo transitions` table and the `--force` gate on `gptodo edit --set state`.
 
 | State              | Meaning                                                                                                    | In `next`/`ready`? |
 | ------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------ |
+| `draft`            | In-progress plan, filed so it isn't lost, but **not released** to the fleet. Use while a planning session is still writing the plan. | No                 |
 | `backlog`          | Queued, not yet triaged. Default for newly-created tasks.                                                  | Yes                |
 | `todo`             | Triaged and ready to start; unclaimed; nothing is blocking work.                                           | Yes                |
-| `active`           | A human or agent is working on it **right now**. Should be paired with `assigned_to` and `assigned_at`.    | No (already owned) |
+| `active`           | A human or agent is working on it **right now**. Should be paired with `assigned_to` and `assigned_at`.    | Yes (already owned; still listed) |
 | `waiting`          | Blocked on an external event (a date, a reply, an approval, a gate firing). Should carry `wait:` and/or `waiting_for:` explaining *what* it's waiting for. | No             |
-| `ready_for_review` | Work done, awaiting operator sign-off before `done`. Should reference a commit or PR in the body.          | No                 |
+| `ready_for_review` | Work done, awaiting operator sign-off before `done`. Should reference a commit or PR in the body.          | No (query `--state ready_for_review`) |
 | `someday`          | Parked idea; may or may not ever be picked up. Explicitly excluded from `next`/`ready` (GTD someday/maybe). | No                 |
 | `done`             | Terminal. Work merged / criterion met.                                                                     | No (terminal)      |
 | `cancelled`        | Terminal. Will not be picked up; rationale in body.                                                        | No (terminal)      |
 | `expired`          | Soft-terminal. Auto-applied by `gptodo expire` when a `backlog`/`todo`/`someday` task has sat quiet longer than the expire window (default 90d since `created`). Revive to `backlog`/`todo` without `--force`. | No |
 
 Legacy deprecated aliases (still accepted with a warning): `new` → `backlog`,
-`paused` → `backlog`.
+`paused` → `backlog`. **`paused` is not a hold** — it normalizes to `backlog`
+and is claimable. Do not file in-progress plans as `paused`; use `draft`.
 
 ### Common confusions to avoid
 
@@ -251,23 +253,35 @@ Legacy deprecated aliases (still accepted with a warning): `new` → `backlog`,
   transition it to `active` via `gptodo claim` (which also records
   `assigned_to`).
 - **`someday` is not the same as `backlog`.** `backlog` says "we'll get to
-  this"; `someday` says "maybe never, but keep it around". Only `someday`
-  is excluded from `gptodo next`/`ready`.
+  this"; `someday` says "maybe never, but keep it around".
+- **`draft` is not `someday` and not `paused`.** `draft` says "complete,
+  approved-or-approvable plan, deliberately not yet released." `someday` is
+  GTD maybe-never. `paused` is a deprecated alias that **normalizes to
+  `backlog`** — it is not a guard and eager agents will claim it. File
+  in-progress plans as `draft`. Both `draft` and `someday` are excluded
+  from `gptodo next`/`ready` and from `gptodo claim`.
 
 ### Legal transitions
 
 ```mermaid
 stateDiagram-v2
     [*] --> backlog
+    [*] --> draft
+    draft --> backlog : released
+    draft --> todo : released
+    draft --> cancelled
     backlog --> todo
+    backlog --> draft
     backlog --> someday
     backlog --> cancelled
     todo --> active
     todo --> backlog
+    todo --> draft
     todo --> someday
     todo --> cancelled
     active --> ready_for_review
     active --> waiting
+    active --> draft
     active --> someday
     active --> done
     active --> cancelled

--- a/packages/gptodo/src/gptodo/checker.py
+++ b/packages/gptodo/src/gptodo/checker.py
@@ -90,11 +90,12 @@ class CheckerConfig:
 # a normal path, not a policy break), but it is excluded from `next`/`ready`
 # so the queue doesn't grow unboundedly.
 VALID_TRANSITIONS: dict[str, list[str]] = {
-    "backlog": ["todo", "someday", "cancelled", "expired"],
-    "todo": ["active", "backlog", "someday", "cancelled", "expired"],
-    "active": ["ready_for_review", "waiting", "someday", "done", "cancelled"],
+    "backlog": ["todo", "draft", "someday", "cancelled", "expired"],
+    "todo": ["active", "backlog", "draft", "someday", "cancelled", "expired"],
+    "active": ["ready_for_review", "waiting", "draft", "someday", "done", "cancelled"],
     "ready_for_review": ["active", "done", "cancelled"],  # Can go back to active if review fails
     "waiting": ["active", "someday", "cancelled"],
+    "draft": ["backlog", "todo", "cancelled"],  # Release the plan, or drop it
     "someday": [
         "backlog",
         "todo",

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -178,6 +178,7 @@ BROWSE_DEFAULT_STATES = [
 BROWSE_FILTER_STATES = [
     "backlog",
     "someday",
+    "draft",
     "todo",
     "active",
     "waiting",
@@ -221,7 +222,7 @@ def cli(verbose, tasks_dir):
     - Link checking and task integrity verification
 
     Frontmatter fields (set via `gptodo edit TASK --set field value`):
-        state: backlog|todo|active|waiting|ready_for_review|done|cancelled|someday
+        state: backlog|todo|active|waiting|ready_for_review|done|cancelled|someday|draft
         priority: high|medium|low
         task_type: project|action
         assigned_to: bob|erik|alice|gordon (or any string)
@@ -544,6 +545,8 @@ def explain_readiness(task_id: str) -> None:
         check("state", False, f"terminal state ({state}) — work is complete or cancelled")
     elif state == "someday":
         check("state", False, "someday — explicitly deferred, not in ready pool")
+    elif state == "draft":
+        check("state", False, "draft — in-progress plan, not released to the ready pool")
     elif state == "waiting":
         waiting_for = str(task.metadata.get("waiting_for") or "").strip()
         detail = f"waiting_for={waiting_for!r}" if waiting_for else "state=waiting"
@@ -1064,13 +1067,14 @@ choice=$(printf 'date\\npriority\\nmodified\\nname' | fzf --no-sort --header 'So
     # Filter picker: sub-fzf to choose state filter
     Path(sd, "filter-picker.sh").write_text(
         f"""#!/bin/sh
-choice=$(printf 'open tasks (default)\\nall states\\nbacklog only\\nsomeday only\\ntodo only\\nactive only\\nwaiting only\\nready for review only' \\
+choice=$(printf 'open tasks (default)\\nall states\\nbacklog only\\nsomeday only\\ndraft only\\ntodo only\\nactive only\\nwaiting only\\nready for review only' \\
   | fzf --no-sort --header 'Filter by state:')
 case "$choice" in
   "open tasks"*) printf '' > "{sd}/state";;
   "all"*) printf 'all' > "{sd}/state";;
   "backlog"*) printf 'backlog' > "{sd}/state";;
   "someday"*) printf 'someday' > "{sd}/state";;
+  "draft"*) printf 'draft' > "{sd}/state";;
   "todo"*) printf 'todo' > "{sd}/state";;
   "active"*) printf 'active' > "{sd}/state";;
   "waiting"*) printf 'waiting' > "{sd}/state";;
@@ -1082,7 +1086,7 @@ esac
     # State change: sub-fzf to pick new state, then call gptodo edit
     Path(sd, "state-change.sh").write_text(
         """#!/bin/sh
-choice=$(printf 'backlog\\nsomeday\\ntodo\\nactive\\nwaiting\\nready_for_review\\ndone\\ncancelled' \\
+choice=$(printf 'backlog\\nsomeday\\ndraft\\ntodo\\nactive\\nwaiting\\nready_for_review\\ndone\\ncancelled' \\
   | fzf --no-sort --header 'Set state to:')
 [ -n "$choice" ] && gptodo edit "$1" --set state "$choice"
 """
@@ -1101,6 +1105,7 @@ action=$(printf '%s\\n' \\
   'Filter: all states' \\
   'Filter: backlog only' \\
   'Filter: someday only' \\
+  'Filter: draft only' \\
   'Filter: todo only' \\
   'Filter: active only' \\
   'Filter: waiting only' \\
@@ -1108,6 +1113,7 @@ action=$(printf '%s\\n' \\
   '───────────────────' \\
   'Change state -> backlog' \\
   'Change state -> someday' \\
+  'Change state -> draft' \\
   'Change state -> todo' \\
   'Change state -> active' \\
   'Change state -> waiting' \\
@@ -1131,12 +1137,14 @@ case "$action" in
   "Filter: all"*) printf 'all' > "{sd}/state";;
   "Filter: backlog"*) printf 'backlog' > "{sd}/state";;
   "Filter: someday"*) printf 'someday' > "{sd}/state";;
+  "Filter: draft"*) printf 'draft' > "{sd}/state";;
   "Filter: todo"*) printf 'todo' > "{sd}/state";;
   "Filter: active"*) printf 'active' > "{sd}/state";;
   "Filter: waiting"*) printf 'waiting' > "{sd}/state";;
   "Filter: ready for review"*) printf 'ready_for_review' > "{sd}/state";;
   "Change state"*"backlog") gptodo edit "$task" --set state backlog;;
   "Change state"*"someday") gptodo edit "$task" --set state someday;;
+  "Change state"*"draft") gptodo edit "$task" --set state draft;;
   "Change state"*"todo") gptodo edit "$task" --set state todo;;
   "Change state"*"active") gptodo edit "$task" --set state active;;
   "Change state"*"waiting") gptodo edit "$task" --set state waiting;;
@@ -3251,7 +3259,14 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
 
 
 # States that cannot be claimed (already terminal or deliberately deferred/blocked).
-_CLAIM_REFUSED_STATES = {"waiting", "ready_for_review", "someday", "done", "cancelled"}
+_CLAIM_REFUSED_STATES = {
+    "waiting",
+    "ready_for_review",
+    "draft",
+    "someday",
+    "done",
+    "cancelled",
+}
 # States that get auto-promoted to active on claim.
 _CLAIM_PROMOTABLE_STATES = {"backlog", "todo"}
 
@@ -3313,7 +3328,7 @@ def claim(task_id: str, agent_override: str | None):
 
     Sets ``state: active`` (for backlog/todo), records ``assigned_to`` and
     ``assigned_at``, and refuses to claim waiting / ready_for_review /
-    someday / terminal tasks.
+    draft / someday / terminal tasks.
 
     Agent name resolution: --agent flag, then GPTODO_AGENT_NAME env var,
     then [agent].name from gptme.toml (lowercased), else "agent".
@@ -3351,7 +3366,8 @@ def claim(task_id: str, agent_override: str | None):
     if current_state in _CLAIM_REFUSED_STATES:
         console.print(
             f"[red]Refusing to claim {task.id}: state is '{current_state}'. "
-            "Resolve the blocker (or revive from someday) before claiming.[/]"
+            "Release from draft, resolve the blocker, or revive from someday "
+            "before claiming.[/]"
         )
         sys.exit(1)
 
@@ -3520,14 +3536,24 @@ def _get_claimed_task_ids(repo_root: Path) -> set[str]:
 @click.option(
     "--state",
     type=click.Choice(
-        ["backlog", "todo", "active", "ready_for_review", "someday", "both", "actionable"]
+        [
+            "backlog",
+            "todo",
+            "active",
+            "ready_for_review",
+            "someday",
+            "draft",
+            "both",
+            "actionable",
+        ]
     ),
     default="both",
     help=(
         "Filter by task state. 'both' = backlog+todo+active (default). "
         "'actionable' = backlog+todo+active+ready_for_review (everything locally workable). "
         "'ready_for_review' = only tasks awaiting local review/verification. "
-        "'someday' = explicitly query deferred tasks."
+        "'someday' = explicitly query deferred tasks. "
+        "'draft' = explicitly query in-progress plans (not released)."
     ),
 )
 @click.option(
@@ -3621,6 +3647,8 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
         filtered_tasks = [task for task in all_tasks if task.state == "ready_for_review"]
     elif state == "someday":
         filtered_tasks = [task for task in all_tasks if task.state == "someday"]
+    elif state == "draft":
+        filtered_tasks = [task for task in all_tasks if task.state == "draft"]
     elif state == "actionable":
         filtered_tasks = [
             task
@@ -5754,6 +5782,7 @@ def list_all_locks(cleanup: bool, output_json: bool):
             "active",
             "ready_for_review",
             "waiting",
+            "draft",
             "someday",
             "done",
             "cancelled",
@@ -7138,6 +7167,7 @@ def transitions_cmd(output_json: bool):
         console.print("\n[dim]State flow: backlog → todo → active → ready_for_review → done[/]")
         console.print("[dim]Alternate: active → waiting → active → done[/]")
         console.print("[dim]Deferred:  any → someday → backlog/todo (revive when ready)[/]")
+        console.print("[dim]Draft:     backlog/todo/active → draft → backlog/todo (release)[/]")
 
 
 @cli.command("lint")

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -76,13 +76,14 @@ class DirectoryConfig:
 # Deprecated state aliases - these map to their canonical state
 # Used by normalize_state() to provide backward compatibility
 #
-# Note: `someday` is intentionally NOT in this list. It is a canonical state
-# that means "deferred indefinitely, not currently actionable" and is excluded
-# from `gptodo next` / `gptodo ready` selection. This preserves the GTD
-# someday/maybe distinction so plateau-pivot decisions stick.
+# Note: `someday` and `draft` are intentionally NOT in this list. Both are
+# canonical states excluded from `gptodo next` / `gptodo ready` selection.
+# `someday` is GTD someday/maybe (deferred indefinitely). `draft` is an
+# in-progress plan that has been filed but not released to the fleet.
+# `paused` is NOT a hold — it normalizes to `backlog` and is claimable.
 DEPRECATED_STATE_ALIASES: dict[str, str] = {
     "new": "backlog",  # new → backlog (untriaged work)
-    "paused": "backlog",  # paused → backlog (intentionally deferred)
+    "paused": "backlog",  # paused → backlog. NOT a guard — selectors will pick it up.
 }
 
 
@@ -123,6 +124,7 @@ def get_canonical_states() -> list[str]:
         "active",
         "ready_for_review",
         "waiting",
+        "draft",
         "someday",
         "done",
         "cancelled",
@@ -404,16 +406,19 @@ CONFIGS = {
         # - active: being actively worked on
         # - ready_for_review: work done, awaiting review/verification (Issue #255)
         # - waiting: blocked on external response
+        # - draft: in-progress plan, filed but not released; NOT eligible for `next`/`ready`
         # - someday: deferred indefinitely, NOT eligible for `next`/`ready` (GTD someday/maybe)
         # - done: completed
         # - cancelled: won't do
-        # Also accepts deprecated aliases: new, paused (with warnings)
+        # Also accepts deprecated aliases: new, paused (with warnings).
+        # `paused` is NOT a hold — it normalizes to backlog and is claimable.
         states=[
             "backlog",
             "todo",
             "active",
             "ready_for_review",  # Issue #255: review state before done
             "waiting",
+            "draft",  # in-progress plan; excluded from next/ready/claim
             "someday",
             "done",
             "cancelled",
@@ -455,6 +460,7 @@ STATE_STYLES = {
     "active": ("blue", "active"),
     "ready_for_review": ("bright_yellow", "review"),  # Issue #255
     "waiting": ("magenta", "waiting"),
+    "draft": ("bright_magenta", "draft"),  # in-progress plan; excluded from next/ready
     "someday": ("dim", "someday"),  # canonical: GTD someday/maybe (excluded from next/ready)
     "done": ("green", "done"),
     "cancelled": ("red", "cancelled"),
@@ -486,6 +492,7 @@ STATE_EMOJIS = {
     "active": "🏃",
     "ready_for_review": "👀",  # Issue #255: review state
     "waiting": "⏳",
+    "draft": "📝",  # in-progress plan; excluded from next/ready
     "someday": "💭",  # canonical: GTD someday/maybe
     "done": "✅",
     "cancelled": "❌",

--- a/packages/gptodo/tests/test_claim.py
+++ b/packages/gptodo/tests/test_claim.py
@@ -136,7 +136,7 @@ def test_claim_waiting_task_refuses(workspace: Path) -> None:
     assert "assigned_at" not in meta
 
 
-@pytest.mark.parametrize("state", ["done", "cancelled", "ready_for_review", "someday"])
+@pytest.mark.parametrize("state", ["done", "cancelled", "ready_for_review", "someday", "draft"])
 def test_claim_terminal_or_deferred_refuses(workspace: Path, state: str) -> None:
     path = write_task(workspace, f"{state}-task", state=state, created="2026-04-26T00:00:00+00:00")
 

--- a/packages/gptodo/tests/test_draft_state.py
+++ b/packages/gptodo/tests/test_draft_state.py
@@ -1,0 +1,192 @@
+"""Acceptance tests for the `draft` task state.
+
+Draft is the hold for in-progress plans: filed so the plan isn't lost, but
+excluded from ready/next/claim so eager agents cannot jump on unfinished work.
+`paused` is *not* this hold — it normalizes to backlog.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptodo.checker import VALID_TRANSITIONS
+from gptodo.cli import cli
+from gptodo.frontmatter_compat import frontmatter
+from gptodo.utils import get_canonical_states, load_tasks, normalize_state
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> Path:
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    path = tasks_dir / f"{name}.md"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _ready_ids(tmp_path: Path, *args: str) -> list[str]:
+    result = CliRunner().invoke(cli, ["ready", *args, "--json"])
+    assert result.exit_code == 0, result.output
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    return [t["id"] for t in payload["ready_tasks"]]
+
+
+def test_draft_is_canonical_not_normalized() -> None:
+    assert "draft" in get_canonical_states()
+    assert normalize_state("draft", warn=False) == "draft"
+
+
+def test_paused_is_not_a_guard() -> None:
+    """`paused` still normalizes to backlog — it is not a draft/hold alias."""
+    assert normalize_state("paused", warn=False) == "backlog"
+
+
+def test_draft_transitions_out_to_backlog_todo_cancelled() -> None:
+    assert set(VALID_TRANSITIONS["draft"]) == {"backlog", "todo", "cancelled"}
+
+
+def test_ready_excludes_draft_tasks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "Bob"\n')
+    write_task(
+        tasks_dir,
+        "in-progress-plan",
+        state="draft",
+        created="2026-09-08T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "real-task",
+        state="backlog",
+        created="2026-09-08T01:00:00",
+        priority="low",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    ids = _ready_ids(tmp_path, "--state", "both")
+    assert "in-progress-plan" not in ids
+    assert "real-task" in ids
+
+    ids = _ready_ids(tmp_path, "--state", "actionable")
+    assert "in-progress-plan" not in ids
+    assert "real-task" in ids
+
+
+def test_ready_draft_explicit_query_returns_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "in-progress-plan", state="draft", created="2026-09-08T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    ids = _ready_ids(tmp_path, "--state", "draft")
+    assert ids == ["in-progress-plan"]
+
+
+def test_next_skips_draft_even_when_higher_priority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "in-progress-plan",
+        state="draft",
+        created="2026-09-08T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "real-task",
+        state="backlog",
+        created="2026-09-08T01:00:00",
+        priority="low",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["next", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["next_task"]["id"] == "real-task"
+
+
+def test_claim_refuses_draft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "Bob"\n')
+    path = write_task(tasks_dir, "in-progress-plan", state="draft", created="2026-09-08T00:00:00")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GPTODO_AGENT_NAME", raising=False)
+
+    result = CliRunner().invoke(cli, ["claim", "in-progress-plan", "--agent", "bob"])
+    assert result.exit_code != 0
+    assert "Refusing to claim" in result.output
+    meta = dict(frontmatter.load(path).metadata)
+    assert meta["state"] == "draft"
+    assert "assigned_to" not in meta
+    assert "assigned_at" not in meta
+
+
+def test_status_renders_draft_distinctly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "Bob"\n')
+    write_task(tasks_dir, "in-progress-plan", state="draft", created="2026-09-08T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "in-progress-plan" in result.output
+    assert "📝" in result.output
+    assert "DRAFT" in result.output.upper()
+
+
+def test_status_compact_excludes_draft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "active-task", state="active", created="2026-09-08T00:00:00")
+    write_task(tasks_dir, "in-progress-plan", state="draft", created="2026-09-08T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["status", "--compact"])
+    assert result.exit_code == 0, result.output
+    assert "active-task" in result.output
+    assert "in-progress-plan" not in result.output
+
+
+def test_legal_release_from_draft(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "in-progress-plan", state="draft", created="2026-09-08T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["edit", "in-progress-plan", "--set", "state", "todo"])
+    assert result.exit_code == 0, result.output
+    assert "illegal" not in result.output.lower()
+    assert load_tasks(tasks_dir)[0].metadata["state"] == "todo"
+
+
+def test_add_accepts_draft_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "tasks").mkdir()
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "Bob"\n')
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["add", "Planning still in flight", "--state", "draft"])
+    assert result.exit_code == 0, result.output
+    tasks = load_tasks(tmp_path / "tasks")
+    assert len(tasks) == 1
+    assert tasks[0].metadata["state"] == "draft"

--- a/packages/gptodo/tests/test_expire.py
+++ b/packages/gptodo/tests/test_expire.py
@@ -115,6 +115,7 @@ def test_expire_multiple_task_states(tmp_path: Path, monkeypatch) -> None:
     _write(tasks_dir, "old-review", "ready_for_review", _iso(200))
     _write(tasks_dir, "old-done", "done", _iso(200))
     _write(tasks_dir, "old-cancelled", "cancelled", _iso(200))
+    _write(tasks_dir, "old-draft", "draft", _iso(200))
 
     monkeypatch.chdir(tmp_path)
     result = CliRunner().invoke(cli, ["expire"])
@@ -129,6 +130,7 @@ def test_expire_multiple_task_states(tmp_path: Path, monkeypatch) -> None:
     assert by_name["old-review"].metadata["state"] == "ready_for_review"
     assert by_name["old-done"].metadata["state"] == "done"
     assert by_name["old-cancelled"].metadata["state"] == "cancelled"
+    assert by_name["old-draft"].metadata["state"] == "draft"
 
 
 # ---------- --state filter -----------------------------------------------------

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -94,6 +94,19 @@ def test_explain_someday_task(tmp_path: Path, monkeypatch) -> None:
     assert "VERDICT: NOT READY" in out
 
 
+def test_explain_draft_task(tmp_path: Path, monkeypatch) -> None:
+    """A draft task should report NOT READY (in-progress plan, not released)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "in-progress-plan", state="draft", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "in-progress-plan")
+
+    assert "draft" in out
+    assert "VERDICT: NOT READY" in out
+
+
 def test_explain_blocked_by_dependency(tmp_path: Path, monkeypatch) -> None:
     """A task with an incomplete dependency should report NOT READY with dep info."""
     tasks_dir = tmp_path / "tasks"

--- a/packages/gptodo/tests/test_status_compact.py
+++ b/packages/gptodo/tests/test_status_compact.py
@@ -63,7 +63,7 @@ def test_status_compact_includes_ready_for_review_tasks(tmp_path: Path, monkeypa
 
 
 def test_status_compact_excludes_hidden_states(tmp_path: Path, monkeypatch) -> None:
-    """Compact mode must not show waiting, done, cancelled, or someday tasks."""
+    """Compact mode must not show waiting, done, cancelled, someday, or draft tasks."""
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
@@ -71,6 +71,7 @@ def test_status_compact_excludes_hidden_states(tmp_path: Path, monkeypatch) -> N
     write_task(tasks_dir, "done-task", state="done", created="2026-01-01T00:00:00")
     write_task(tasks_dir, "cancelled-task", state="cancelled", created="2026-01-01T00:00:00")
     write_task(tasks_dir, "someday-task", state="someday", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "draft-task", state="draft", created="2026-01-01T00:00:00")
 
     output = _run_status_compact(tmp_path, monkeypatch)
 
@@ -79,6 +80,7 @@ def test_status_compact_excludes_hidden_states(tmp_path: Path, monkeypatch) -> N
     assert "done-task" not in output
     assert "cancelled-task" not in output
     assert "someday-task" not in output
+    assert "draft-task" not in output
 
 
 def test_status_no_double_blank_under_header(tmp_path: Path, monkeypatch) -> None:

--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -41,6 +41,7 @@ VALID_STATES = {
         "done",
         "cancelled",
         "someday",
+        "draft",
     ],
     "tweets": ["new", "queued", "approved", "posted"],
 }


### PR DESCRIPTION
## Why

A filed task is indistinguishable from released work, so the fleet claims phases of a plan that is still being written. Erik asked whether gptodo should grow a `draft` state or people should use `paused`.

`paused` cannot be that hold: it normalizes to `backlog` and is claimable. `someday` is the wrong meaning (GTD maybe-never, not "staged for release"). A `draft: true` flag would add a second axis of selectability that every selector must honor.

## What

Canonical `draft` state:

- Excluded from `gptodo ready` / `gptodo next` (query `--state draft` to inspect)
- `gptodo claim` refuses it (same set as `someday`)
- Compact status hides it; full status renders it as 📝 DRAFT
- Not auto-expired (in-progress plans are not stale backlog)
- Legal exits: `draft → backlog | todo | cancelled`
- `paused` is documented as **not a guard**

Also: dashboard sort/tag, precommit validator, RAG `TASK_OPEN_STATES` deliberately does **not** include `draft` (held, not open work).

## Tests

- `packages/gptodo/tests/test_draft_state.py` (11 cases)
- claim / expire / compact status / explain coverage

## Review

Local AI review of `b7d1d9ae` vs `origin/master`: 5/5, 0 open findings.