### PR TITLE
fix(gptmail): detect trusted BCC via envelope headers

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -103,6 +103,78 @@ def _format_address_header(value: str) -> str:
     return formataddr((name, addr))
 
 
+# Envelope headers that survive BCC stripping. Gmail's IMAP copy of a blind
+# copy has Delivered-To set to the agent and no Bcc header.
+_ENVELOPE_RECIPIENT_HEADERS = (
+    "Delivered-To",
+    "X-Original-To",
+    "Envelope-To",
+    "X-Envelope-To",
+)
+
+# Headers preserved when importing a maildir message into markdown. Recipient
+# provenance must survive sync or get_unreplied_emails cannot see a BCC.
+_SYNC_HEADERS = (
+    "MIME-Version",
+    "From",
+    "To",
+    "Cc",
+    "Bcc",
+    *_ENVELOPE_RECIPIENT_HEADERS,
+    "Date",
+    "Subject",
+    "Message-ID",
+    "In-Reply-To",
+    "References",
+    "Content-Type",
+)
+
+
+def _header_values_ci(headers: dict[str, str], names: tuple[str, ...]) -> list[str]:
+    """Return header values matching ``names``, case-insensitively."""
+    lookup = {key.lower(): value for key, value in headers.items()}
+    return [
+        lookup[name.lower()] for name in names if name.lower() in lookup and lookup[name.lower()]
+    ]
+
+
+def _header_mentions_agent(values: list[str], own_emails: tuple[str, ...]) -> bool:
+    """True if any address in ``values`` is one of the agent's own addresses."""
+    if not values or not own_emails:
+        return False
+    addrs = {addr.lower() for _, addr in getaddresses(values) if addr}
+    if addrs:
+        return bool(addrs.intersection(own_emails))
+    blob = " ".join(values).lower()
+    return any(own in blob for own in own_emails)
+
+
+def inbound_recipient_role(headers: dict[str, str], own_emails: tuple[str, ...]) -> str | None:
+    """Classify how a message was addressed to the agent.
+
+    Inspects header fields only — a ``To:`` line in the body is not evidence.
+
+    Returns:
+        ``"to"``: agent is in To (normal auto-reply).
+        ``"cc"``: agent is in Cc and not To (private triage, no auto-reply).
+        ``"bcc"``: agent is in Bcc and not To/Cc (private auto-reply).
+        ``"envelope"``: transport stripped Bcc; Delivered-To / X-Original-To /
+            Envelope-To names the agent (private auto-reply).
+        ``None``: no inbound recipient provenance for the agent.
+    """
+    if not own_emails:
+        return "to"
+    if _header_mentions_agent(_header_values_ci(headers, ("To",)), own_emails):
+        return "to"
+    if _header_mentions_agent(_header_values_ci(headers, ("Cc",)), own_emails):
+        return "cc"
+    if _header_mentions_agent(_header_values_ci(headers, ("Bcc",)), own_emails):
+        return "bcc"
+    if _header_mentions_agent(_header_values_ci(headers, _ENVELOPE_RECIPIENT_HEADERS), own_emails):
+        return "envelope"
+    return None
+
+
 def fix_list_spacing(markdown_text: str) -> str:
     """
     Add blank lines before lists if missing.
@@ -361,6 +433,9 @@ class AgentEmail:
 
         Returns:
             List of UnrepliedEmail named tuples, sorted by date oldest-first.
+
+        Auto-reply candidates are To, Bcc, or envelope-delivered (stripped BCC)
+        messages. Cc is visible via ``list_messages`` but never auto-replied.
         """
         if folders is None:
             # Default to inbox only - caller can pass ["inbox", "archive"] if needed
@@ -378,40 +453,27 @@ class AgentEmail:
                 try:
                     content = email_file.read_text()
 
-                    # Extract message details
-                    message_id_match = re.search(r"Message-ID: (<[^>]+>)", content)
-                    subject_match = re.search(r"Subject: (.+)", content)
-                    from_match = re.search(r"From: (.+)", content)
-                    to_match = re.search(r"To: (.+)", content)
-
-                    if not (message_id_match and subject_match and from_match):
+                    # Parse the header block only. A "To:" line in a forwarded
+                    # body is not delivery evidence.
+                    headers, _body = self._markdown_to_email(content)
+                    message_id = (
+                        headers.get("Message-ID") or headers.get("Message-Id") or ""
+                    ).strip()
+                    subject = (headers.get("Subject") or "").strip()
+                    from_line = (headers.get("From") or "").strip()
+                    if not (message_id and subject and from_line):
                         continue
-
-                    message_id = message_id_match.group(1)
 
                     # Skip if we've already seen this message in another folder
                     if message_id in seen_message_ids:
                         continue
                     seen_message_ids.add(message_id)
 
-                    subject = subject_match.group(1)
-                    date_match = re.search(r"Date: (.+)", content)
-                    from_line = from_match.group(1)
-
-                    # Skip if not addressed to the agent's email
-                    # (only process emails sent TO the agent, not CC'd or other recipients)
-                    if to_match and self.own_emails:
-                        to_line = to_match.group(1)
-                        to_addrs = {addr.lower() for _, addr in getaddresses([to_line]) if addr}
-                        if to_addrs:
-                            is_addressed_to_agent = bool(to_addrs.intersection(self.own_emails))
-                        else:
-                            lower_to_line = to_line.lower()
-                            is_addressed_to_agent = any(
-                                own_email in lower_to_line for own_email in self.own_emails
-                            )
-                        if not is_addressed_to_agent:
-                            continue
+                    date_header = headers.get("Date", "")
+                    role = inbound_recipient_role(headers, self.own_emails)
+                    # Cc is for deliberate private triage, not the auto-reply loop.
+                    if role in (None, "cc"):
+                        continue
 
                     # Extract email from "Name <email>" format
                     sender = from_line
@@ -449,7 +511,7 @@ class AgentEmail:
                         continue
 
                     sort_date = self._parse_email_date(
-                        date_match.group(1) if date_match else "",
+                        date_header,
                         invalid_default=datetime.min.replace(tzinfo=timezone.utc),
                     )
                     unreplied_with_dates.append(
@@ -1782,19 +1844,10 @@ class AgentEmail:
                         )
                         continue
 
-                    # Convert to markdown format
+                    # Convert to markdown format. Keep envelope/Cc/Bcc so a
+                    # transport-stripped BCC remains attributable after import.
                     headers = []
-                    for key in [
-                        "MIME-Version",
-                        "From",
-                        "To",
-                        "Date",
-                        "Subject",
-                        "Message-ID",
-                        "In-Reply-To",
-                        "References",
-                        "Content-Type",
-                    ]:
+                    for key in _SYNC_HEADERS:
                         if key in email_msg:
                             headers.append(f"{key}: {email_msg[key]}")
 

--- a/packages/gptmail/tests/test_unreplied_emails.py
+++ b/packages/gptmail/tests/test_unreplied_emails.py
@@ -4,8 +4,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
-from gptmail.lib import AgentEmail, UnrepliedEmail
+import gptmail.cli as gptmail_cli
+from gptmail.lib import AgentEmail, UnrepliedEmail, inbound_recipient_role
 
 
 @pytest.fixture
@@ -66,6 +68,44 @@ def _write_email_with_raw_date(
             f"Subject: {subject}",
             "",
             "Body",
+        ]
+    )
+    path.write_text("\n".join(lines))
+
+
+def _write_maildir_email(
+    path: Path,
+    *,
+    message_id: str,
+    subject: str,
+    to: str,
+    cc: str | None = None,
+    bcc: str | None = None,
+    delivered_to: str | None = None,
+    from_header: str = "Friend <friend@example.com>",
+    extra_headers: list[str] | None = None,
+    body: str = "Body",
+) -> None:
+    lines = [
+        f"From: {from_header}",
+        f"To: {to}",
+    ]
+    if cc is not None:
+        lines.append(f"Cc: {cc}")
+    if bcc is not None:
+        lines.append(f"Bcc: {bcc}")
+    if delivered_to is not None:
+        lines.append(f"Delivered-To: {delivered_to}")
+    if extra_headers:
+        lines.extend(extra_headers)
+    lines.extend(
+        [
+            "Date: Tue, 08 Sep 2026 16:00:00 +0000",
+            f"Subject: {subject}",
+            f"Message-ID: {message_id}",
+            "Content-Type: text/plain; charset=utf-8",
+            "",
+            body,
         ]
     )
     path.write_text("\n".join(lines))
@@ -339,3 +379,230 @@ def test_get_thread_messages_keeps_malformed_dates_last(agent: AgentEmail) -> No
     thread_messages = agent.get_thread_messages(root_id)
 
     assert [message["id"] for message in thread_messages] == [root_id, reply_id]
+
+
+def test_inbound_recipient_role_ignores_body_to_line() -> None:
+    headers = {
+        "To": "other@example.com",
+        "From": "Friend <friend@example.com>",
+    }
+    assert inbound_recipient_role(headers, ("test@example.com",)) is None
+
+
+def test_maildir_sync_preserves_envelope_for_stripped_bcc(
+    agent: AgentEmail, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Gmail strips Bcc; Delivered-To on the agent's alias is the provenance."""
+    monkeypatch.setenv("AGENT_EMAIL_ALIASES", "alias@example.com")
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    aliased = AgentEmail(str(tmp_path), "test@example.com")
+
+    maildir = tmp_path / "maildir"
+    (maildir / "new").mkdir(parents=True)
+    message_id = "<stripped-bcc@example.com>"
+    _write_maildir_email(
+        maildir / "new" / "stripped-bcc",
+        message_id=message_id,
+        subject="Stripped BCC",
+        to="other@example.com",
+        delivered_to="alias@example.com",
+        body="Forwarded copy\nTo: Bob <test@example.com>\nshould not count",
+    )
+    aliased.external_maildir_folders["inbox"] = maildir
+
+    aliased.sync_from_maildir("inbox")
+
+    imported = (aliased.email_dir / "inbox" / aliased._format_filename(message_id)).read_text()
+    header_block = imported.split("\n\n", 1)[0]
+    assert "Delivered-To: alias@example.com" in header_block
+    assert "To: other@example.com" in header_block
+    assert [line for line in header_block.splitlines() if line.startswith("To:")] == [
+        "To: other@example.com"
+    ]
+    assert [entry.message_id for entry in aliased.get_unreplied_emails()] == [message_id]
+
+
+def test_maildir_sync_preserves_explicit_bcc_for_unreplied_detection(
+    agent: AgentEmail, tmp_path: Path
+) -> None:
+    maildir = tmp_path / "maildir"
+    (maildir / "new").mkdir(parents=True)
+    message_id = "<direct-bcc@example.com>"
+    _write_maildir_email(
+        maildir / "new" / "direct-bcc",
+        message_id=message_id,
+        subject="Direct BCC",
+        to="other@example.com",
+        bcc="Bob <test@example.com>",
+    )
+    agent.external_maildir_folders["inbox"] = maildir
+
+    agent.sync_from_maildir("inbox")
+
+    imported = (agent.email_dir / "inbox" / agent._format_filename(message_id)).read_text()
+    assert "Bcc: Bob <test@example.com>" in imported
+    assert [entry.message_id for entry in agent.get_unreplied_emails()] == [message_id]
+
+
+def test_cc_is_listed_but_not_auto_replied(agent: AgentEmail, tmp_path: Path) -> None:
+    maildir = tmp_path / "maildir"
+    (maildir / "new").mkdir(parents=True)
+    message_id = "<cc-only@example.com>"
+    _write_maildir_email(
+        maildir / "new" / "cc-only",
+        message_id=message_id,
+        subject="CC only",
+        to="other@example.com",
+        cc="Bob <test@example.com>",
+        delivered_to="test@example.com",
+    )
+    agent.external_maildir_folders["inbox"] = maildir
+
+    agent.sync_from_maildir("inbox")
+
+    imported = (agent.email_dir / "inbox" / agent._format_filename(message_id)).read_text()
+    assert "Cc: Bob <test@example.com>" in imported
+    assert agent.get_unreplied_emails() == []
+    listed_ids = [message_id_ for message_id_, _, _ in agent.list_messages("inbox")]
+    assert listed_ids == [message_id]
+
+
+def test_body_to_line_is_not_delivery_evidence(agent: AgentEmail) -> None:
+    inbox = agent.email_dir / "inbox"
+    _write_email_with_raw_date(
+        inbox / "body-to.md",
+        message_id="<body-to@example.com>",
+        subject="Body To trap",
+        sender="friend@example.com",
+        recipient="other@example.com",
+        date_header="Tue, 08 Sep 2026 16:00:00 +0000",
+    )
+    path = inbox / "body-to.md"
+    path.write_text(path.read_text() + "To: Bob <test@example.com>\n")
+
+    assert agent.get_unreplied_emails() == []
+
+
+def test_stripped_bcc_keeps_allowlist_and_self_exclusions(
+    agent: AgentEmail, tmp_path: Path
+) -> None:
+    maildir = tmp_path / "maildir"
+    (maildir / "new").mkdir(parents=True)
+    _write_maildir_email(
+        maildir / "new" / "untrusted",
+        message_id="<untrusted-bcc@example.com>",
+        subject="Untrusted BCC",
+        to="other@example.com",
+        delivered_to="test@example.com",
+        from_header="Stranger <stranger@example.com>",
+    )
+    _write_maildir_email(
+        maildir / "new" / "self-sent",
+        message_id="<self-bcc@example.com>",
+        subject="Self BCC",
+        to="other@example.com",
+        delivered_to="test@example.com",
+        from_header="Bob <test@example.com>",
+    )
+    agent.external_maildir_folders["inbox"] = maildir
+    agent.sync_from_maildir("inbox")
+
+    assert agent.get_unreplied_emails() == []
+
+
+def test_stripped_bcc_respects_completed_and_already_replied(agent: AgentEmail) -> None:
+    inbox = agent.email_dir / "inbox"
+    completed_id = "<completed-bcc@example.com>"
+    replied_id = "<replied-bcc@example.com>"
+    inbox.joinpath(agent._format_filename(completed_id)).write_text(
+        "\n".join(
+            [
+                "From: Friend <friend@example.com>",
+                "To: other@example.com",
+                "Delivered-To: test@example.com",
+                "Date: Tue, 08 Sep 2026 16:00:00 +0000",
+                "Subject: Completed BCC",
+                f"Message-ID: {completed_id}",
+                "",
+                "Body",
+            ]
+        )
+    )
+    inbox.joinpath(agent._format_filename(replied_id)).write_text(
+        "\n".join(
+            [
+                "From: Friend <friend@example.com>",
+                "To: other@example.com",
+                "Delivered-To: test@example.com",
+                "Date: Tue, 08 Sep 2026 16:01:00 +0000",
+                "Subject: Replied BCC",
+                f"Message-ID: {replied_id}",
+                "",
+                "Body",
+            ]
+        )
+    )
+    agent._mark_no_reply_needed(completed_id, "informational")
+    (agent.email_dir / "sent" / "already-replied.md").write_text(
+        "\n".join(
+            [
+                "From: Bob <test@example.com>",
+                "To: Friend <friend@example.com>",
+                f"In-Reply-To: {replied_id}",
+                "Subject: Re: Replied BCC",
+                "Message-ID: <sent-reply@example.com>",
+                "",
+                "Already answered",
+            ]
+        )
+    )
+
+    assert agent.get_unreplied_emails() == []
+
+
+def test_private_reply_targets_sender_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("EMAIL_ALLOWLIST", "friend@example.com")
+    monkeypatch.setenv("AGENT_EMAIL", "test@example.com")
+    monkeypatch.setattr(gptmail_cli, "get_workspace_dir", lambda: tmp_path)
+
+    message_id = "<private-bcc@example.com>"
+    agent = AgentEmail(str(tmp_path), "test@example.com")
+    (email_dir / "inbox" / agent._format_filename(message_id)).write_text(
+        "\n".join(
+            [
+                "From: Friend <friend@example.com>",
+                "To: Other <other@example.com>",
+                "Cc: Spectator <spectator@example.com>",
+                "Bcc: Bob <test@example.com>",
+                "Delivered-To: test@example.com",
+                "Date: Tue, 08 Sep 2026 16:00:00 +0000",
+                "Subject: Private analysis",
+                f"Message-ID: {message_id}",
+                "",
+                "Please look at this privately.",
+            ]
+        )
+    )
+
+    result = CliRunner().invoke(
+        gptmail_cli.cli, ["reply", message_id, "Private note for you only."]
+    )
+    assert result.exit_code == 0, result.output
+    drafts = list((email_dir / "drafts").glob("*.md"))
+    assert len(drafts) == 1
+    draft = drafts[0].read_text()
+    draft_headers, _ = draft.split("\n\n", 1)
+    assert "To: Friend <friend@example.com>" in draft_headers
+    assert "other@example.com" not in draft_headers
+    assert "spectator@example.com" not in draft_headers
+    assert not any(line.lower().startswith("bcc:") for line in draft_headers.splitlines())
+    assert not any(line.lower().startswith("cc:") for line in draft_headers.splitlines())
+    assert "Delivered-To:" not in draft_headers
+    body = draft.split("\n\n", 1)[1].lower()
+    assert "blind copy" not in body
+    assert "bcc'd" not in body and "bccd" not in body


### PR DESCRIPTION
## Summary

`get_unreplied_emails` required the agent in `To:`. A trusted-principal BCC with someone else in `To:` was therefore skipped, even though the message was in the agent's inbox.

Transport (Gmail IMAP) strips `Bcc`. The live copy of Erik's 2026-09-08 Lund estimate mail had `To: Matthias` and `Delivered-To: timetobuildbob@gmail.com` — no `Bcc` header. An earlier uncommitted patch that only looked for `Bcc:` would still have missed it.

This PR:

- Preserves `Cc`, `Bcc`, `Delivered-To`, `X-Original-To`, and `Envelope-To` through maildir → markdown sync
- Classifies recipients from the header block only (a `To:` line in a forwarded body is not delivery evidence)
- Treats **To / Bcc / envelope** as auto-reply candidates
- Leaves **Cc** visible via `list_messages` but out of the auto-reply loop (Cc always has `Delivered-To`, so envelope must not outrank Cc)
- Leaves `reply` targeting only the original sender — no Cc/Bcc/Delivered-To copied onto the draft

## Test plan

- [x] `uv run --with pytest pytest tests/test_unreplied_emails.py` — 16 passed
- [x] `uv run --with pytest pytest tests/` — 220 passed
- [x] `make typecheck` in `packages/gptmail` — clean
- [x] Fixtures only; no replay of live Lund messages

## Notes

Does not change sender allowlisting, self-exclusion, completed-message suppression, or exactly-once `In-Reply-To` checks. Those still apply after recipient classification.