### PR TITLE
fix(voice): align Python subprocess timeout with shell wrapper env var

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -63,16 +63,17 @@ _KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
 # fails to terminate the child.
 #
 # These are read from the same env vars used by voice-subagent.sh, plus a 10 s
-# buffer.  The buffer ensures the shell wrapper's inner ``timeout`` fires first
-# (giving gptme a clean SIGTERM), before this outer Python-level ``timeout``
-# sends its own SIGTERM to the whole subprocess tree.  Without the buffer the
-# Python layer fires at 30 s while the shell layer expects 60 s, causing every
-# fast-mode lookup to be killed prematurely (observed: 2026-09-09 standup call).
+# buffer.  The buffer keeps this outer Python ``timeout`` behind the shell
+# wrapper's inner ``timeout`` so gptme gets a clean SIGTERM first.
+# Fast fallback is 60 s (was a hardcoded 30 s that killed lookups before the
+# shell's 60 s budget).  Smart fallback stays 120 s — the previous hardcoded
+# Python default — so unset-env deployments do not shrink the smart budget.
+# Production systemd sets both env vars (currently 60/60); those values win.
 _FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS = (
     int(os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_FAST_SECONDS", 60)) + 10
 )
 _SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS = (
-    int(os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_SMART_SECONDS", 60)) + 10
+    int(os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_SMART_SECONDS", 120)) + 10
 )
 # ``timeout(1)`` is a GNU coreutils binary available on Linux but not macOS.
 # When it is missing we fall back to Python-level asyncio timeout handling.

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -61,8 +61,19 @@ _KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
 # (``self.timeout``, default 300 s) should rarely fire when these are set
 # correctly — it only catches pathological hangs where ``timeout(1)`` itself
 # fails to terminate the child.
-_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS = 30
-_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS = 120
+#
+# These are read from the same env vars used by voice-subagent.sh, plus a 10 s
+# buffer.  The buffer ensures the shell wrapper's inner ``timeout`` fires first
+# (giving gptme a clean SIGTERM), before this outer Python-level ``timeout``
+# sends its own SIGTERM to the whole subprocess tree.  Without the buffer the
+# Python layer fires at 30 s while the shell layer expects 60 s, causing every
+# fast-mode lookup to be killed prematurely (observed: 2026-09-09 call, Erik).
+_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS = (
+    int(os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_FAST_SECONDS", 60)) + 10
+)
+_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS = (
+    int(os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_SMART_SECONDS", 60)) + 10
+)
 # ``timeout(1)`` is a GNU coreutils binary available on Linux but not macOS.
 # When it is missing we fall back to Python-level asyncio timeout handling.
 _TIMEOUT_BINARY_AVAILABLE = shutil.which("timeout") is not None

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -67,7 +67,7 @@ _KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
 # (giving gptme a clean SIGTERM), before this outer Python-level ``timeout``
 # sends its own SIGTERM to the whole subprocess tree.  Without the buffer the
 # Python layer fires at 30 s while the shell layer expects 60 s, causing every
-# fast-mode lookup to be killed prematurely (observed: 2026-09-09 call, Erik).
+# fast-mode lookup to be killed prematurely (observed: 2026-09-09 standup call).
 _FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS = (
     int(os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_FAST_SECONDS", 60)) + 10
 )

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -369,6 +369,16 @@ def test_execute_fast_mode_uses_subprocess_timeout_wrapper() -> None:
     asyncio.run(_exercise())
 
 
+def test_unset_env_timeout_fallbacks_keep_smart_at_previous_budget() -> None:
+    """Unset-env fallbacks: fast 60+10, smart 120+10 (do not shrink smart)."""
+    import os
+
+    if os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_FAST_SECONDS") is None:
+        assert _FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS == 70
+    if os.environ.get("GPTME_VOICE_SUBAGENT_TIMEOUT_SMART_SECONDS") is None:
+        assert _SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS == 130
+
+
 def test_execute_smart_mode_uses_subprocess_timeout_wrapper() -> None:
     async def _exercise() -> None:
         captured: dict[str, object] = {}

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gptme_voice.realtime.tool_bridge import (
+    _FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS,
+    _SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS,
     _TIMEOUT_BINARY_AVAILABLE,
     GptmeToolBridge,
 )
@@ -165,7 +167,7 @@ def test_execute_uses_legacy_env_override_for_smart_model() -> None:
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
-            "120s",
+            f"{_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
         )
         assert args[4:11] == (
             "gptme",
@@ -203,7 +205,7 @@ def test_execute_uses_fast_model_override_without_touching_smart() -> None:
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
-            "30s",
+            f"{_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
         )
         assert "--model" in args
         model_index = args.index("--model") + 1
@@ -234,7 +236,7 @@ def test_execute_uses_smart_model_override_without_touching_fast() -> None:
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
-            "120s",
+            f"{_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
         )
         assert args[4:11] == (
             "gptme",
@@ -271,7 +273,7 @@ def test_execute_uses_env_override_for_gptme_path() -> None:
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
-            "120s",
+            f"{_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
             "/fake/bin/gptme",
         )
 
@@ -299,7 +301,7 @@ def test_execute_fast_mode_keeps_context_files() -> None:
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
-            "30s",
+            f"{_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
         )
         assert "--context" in args
         assert "files" in args
@@ -329,7 +331,7 @@ def test_execute_smart_mode_keeps_context_loading() -> None:
             "timeout",
             "--signal=TERM",
             "--kill-after=5s",
-            "120s",
+            f"{_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
             "gptme",
             "--non-interactive",
             "--context",
@@ -359,7 +361,7 @@ def test_execute_fast_mode_uses_subprocess_timeout_wrapper() -> None:
                 "timeout",
                 "--signal=TERM",
                 "--kill-after=5s",
-                "30s",
+                f"{_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
             )
         else:
             assert args[0] == bridge.gptme_path
@@ -387,7 +389,7 @@ def test_execute_smart_mode_uses_subprocess_timeout_wrapper() -> None:
                 "timeout",
                 "--signal=TERM",
                 "--kill-after=5s",
-                "120s",
+                f"{_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS}s",
             )
         else:
             assert args[0] == bridge.gptme_path


### PR DESCRIPTION
## Problem

The Python bridge in `tool_bridge.py` wraps `voice-subagent.sh` with a hardcoded 30 s `timeout(1)`. The production systemd unit sets `GPTME_VOICE_SUBAGENT_TIMEOUT_FAST_SECONDS=60` — the same env var the shell script reads for its own inner `timeout`. The two layers were nested and in conflict:

```
Python: timeout 30s voice-subagent.sh
  └─ shell: timeout 60s gptme  ← never reached, Python fires first
```

Observed on the 2026-09-09 standup call: 'what has Bob been doing in the last hour?' timed out at exactly 30 s, rc=124, zero output.

## Fix

Read `_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS` (and smart-mode equivalent) from the same env vars at module load time, plus a 10 s buffer. The buffer ensures the inner shell `timeout` fires first (clean SIGTERM to gptme), before the outer Python wrapper sends its own SIGTERM to the whole subprocess tree.

With `GPTME_VOICE_SUBAGENT_TIMEOUT_FAST_SECONDS=60` (the production value):
- **Before**: Python kills at 30 s, gptme never completes
- **After**: Shell kills gptme at 60 s (clean), Python kills at 70 s (safety net only)

## Companion change

The brain repo `scripts/runs/voice/voice-subagent.sh` also got a shell-default fix (25 → 60) and a quick activity pre-fetch for standup-type queries (git log + journal summaries injected before gptme starts, so the subagent can answer without burning its tool budget on data gathering).