### PR TITLE
fix(voice): route 'last hour' queries to pre-computed activity digest

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -478,8 +478,10 @@ def _prepend_activity_digest(digest_text: str, instructions: str) -> str:
     guidance = (
         "ACTIVITY DIGEST (pre-computed — do not read aloud):\n"
         "- A compact summary of recent work is loaded below. "
-        "Use it to answer 'what did you do today / in the last 12 hours?' "
-        "without spawning a subagent.\n"
+        "Use it to answer questions like 'what did you do today?', "
+        "'what happened in the last hour?', or 'what have you been working on?' "
+        "without spawning a subagent. The digest covers the most recent sessions "
+        "within the last 24 hours — 'last hour' questions are answerable from it.\n"
         "- Treat this as of the 'Generated at' timestamp shown in the digest; "
         "sessions that started after that point are not included.\n"
         "- For questions about specific task status or anything genuinely absent "

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -843,26 +843,25 @@ class VoiceServer:
                 self.body_adapter.name,
                 sorted(self.body_adapter.capabilities) or "none",
             )
+        self._handoff_writer: HandoffWriter | None = None
         if handoff_dir_env:
             if not handoff_secret_env:
                 logger.warning(
                     "GPTME_VOICE_HANDOFF_SECRET not set while GPTME_VOICE_HANDOFF_DIR is "
-                    "configured — using insecure fallback. Set GPTME_VOICE_HANDOFF_SECRET "
-                    "to a strong random value in production."
+                    "configured — handoff disabled. Set GPTME_VOICE_HANDOFF_SECRET "
+                    "to a strong random value; never fall back to a known default."
                 )
-            handoff_secret = (handoff_secret_env or "dev-only-secret").encode("utf-8")
-            self._handoff_writer: HandoffWriter | None = HandoffWriter(
-                Path(handoff_dir_env),
-                from_agent=handoff_agent_name,
-                secret=handoff_secret,
-            )
-            logger.info(
-                "Handoff enabled: from_agent=%s, dir=%s",
-                handoff_agent_name,
-                handoff_dir_env,
-            )
-        else:
-            self._handoff_writer = None
+            else:
+                self._handoff_writer = HandoffWriter(
+                    Path(handoff_dir_env),
+                    from_agent=handoff_agent_name,
+                    secret=handoff_secret_env.encode("utf-8"),
+                )
+                logger.info(
+                    "Handoff enabled: from_agent=%s, dir=%s",
+                    handoff_agent_name,
+                    handoff_dir_env,
+                )
 
         # Active connections: call_sid -> (twilio_ws, realtime_client)
         self._connections: dict[str, tuple] = {}

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -3047,6 +3047,22 @@ def test_prepend_activity_digest_includes_guidance_and_content() -> None:
 def test_prepend_activity_digest_tells_model_to_skip_subagent() -> None:
     result = _prepend_activity_digest("## Recent sessions\n", "instructions")
     assert "subagent" in result.lower()
+    # Regression: 2026-09-09 standup "what have you been doing in the last hour?"
+    # spawned a subagent because the guidance only named "today / last 12 hours".
+    assert "last hour" in result.lower()
+    assert "24 hours" in result.lower()
+
+
+def test_server_disables_handoff_without_explicit_secret(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Handoff must fail closed — never HMAC with a hardcoded default secret."""
+    monkeypatch.setenv("GPTME_VOICE_HANDOFF_DIR", str(tmp_path))
+    monkeypatch.delenv("GPTME_VOICE_HANDOFF_SECRET", raising=False)
+
+    server = VoiceServer()
+
+    assert server._handoff_writer is None
 
 
 # ── ASR partial deduplication ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

During the 2026-09-09 standup call, Erik asked "what has Bob been doing in the last hour?" The voice model spawned a subagent instead of reading the pre-computed activity digest — even though the digest covers recent sessions within the last 24 hours.

Root cause: the `_prepend_activity_digest` guidance only cited 'today / last 12 hours' as example use-cases, leaving 'last hour' phrasing uncovered. The model reasonably assumed it needed a live lookup.

## Fix

Expand the guidance examples to include 'last hour' phrasing and add a sentence clarifying that the digest covers the most recent 24 h — making last-hour questions answerable without a subagent round-trip.

Also fail-closed on the pre-existing HMAC fallback: if `GPTME_VOICE_HANDOFF_DIR` is set without `GPTME_VOICE_HANDOFF_SECRET`, handoff stays disabled instead of signing with the hardcoded `dev-only-secret` string. That fallback was guessable from source and was the unanchored P1 blocking self-merge. Production does not set `HANDOFF_DIR`, so this does not change the live voice server.

Complementary fix to #1643 (Python subprocess timeout alignment): #1643 ensures the subagent survives long enough if it is spawned; this PR prevents the unnecessary spawn for recap-style queries.

## Testing

Voice package tests: 358 passed, 2 skipped (`uv run --package gptme-voice pytest packages/gptme-voice/tests/`). Includes a regression assertion that the digest guidance mentions 'last hour', and a test that missing secret leaves `_handoff_writer` unset.
