### PR TITLE
feat(sessions): record reasoning_effort/reasoning_profile on session records

### DIFF
--- a/packages/gptme-sessions/README.md
+++ b/packages/gptme-sessions/README.md
@@ -105,6 +105,14 @@ gptme-sessions judge --update-store  # write scores back to the store
 gptme-sessions post-session --harness gptme --model opus \
   --trajectory ~/.local/share/gptme/logs/2026-03-07-foo/conversation.jsonl
 
+# Reasoning telemetry: --reasoning-profile is the semantic intent
+# (routine|default|deep); --reasoning-effort is the backend-native level the
+# harness ran with (low/medium/high/xhigh/max/ultra/...; free-form, unknown
+# values warn but never fail). Omit --reasoning-effort to fill it from the
+# trajectory (Claude Code `effort`, Codex `reasoning_effort`, gptme metadata).
+gptme-sessions post-session --harness claude-code --model claude-fable-5-1 \
+  --reasoning-profile deep --reasoning-effort high --trajectory ~/.claude/projects/x/id.jsonl
+
 # Append a record manually (deprecated: prefer post-session or sync)
 gptme-sessions append --harness claude-code --model opus --outcome productive
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -29,7 +29,13 @@ from .discovery import (
     session_datetime_from_path,
 )
 from . import attribution
-from .post_session import VALID_AB_GROUPS, VALID_CONTEXT_TIERS, post_session
+from .post_session import (
+    VALID_AB_GROUPS,
+    VALID_CONTEXT_TIERS,
+    VALID_REASONING_PROFILES,
+    check_reasoning_effort,
+    post_session,
+)
 from .replay import (
     ToolResultsMode,
     render_replay,
@@ -78,6 +84,8 @@ _USAGE_FIELD_MAP: dict[str, str] = {
     "first_turn_bytes": "first_turn_bytes",
     "context_peak_bytes": "context_peak_bytes",
     "session_total_bytes": "session_total_bytes",
+    "reasoning_effort": "reasoning_effort",
+    "reasoning_tokens": "reasoning_tokens",
 }
 
 # Fields whose absence should trigger ``sync --signals`` re-extraction.
@@ -234,7 +242,7 @@ def _refresh_pi_extract_result(record: SessionRecord, result: dict) -> bool:
     if not isinstance(usage, dict):
         return changed
 
-    latest_fields = {"model", "provider", "stop_reason"}
+    latest_fields = {"model", "provider", "stop_reason", "reasoning_effort"}
     for usage_key, record_key in _USAGE_FIELD_MAP.items():
         if record_key in record.annotated_fields:
             continue
@@ -2872,6 +2880,21 @@ def repair_grades(ctx: click.Context, dry_run: bool) -> None:
     help="A/B experiment group (control or treatment)",
 )
 @click.option("--tier-version", default=None, help="Context tier config version for this session")
+@click.option(
+    "--reasoning-profile",
+    default=None,
+    type=click.Choice(sorted(VALID_REASONING_PROFILES)),
+    help="Semantic reasoning profile requested for this session (routine, default, deep)",
+)
+@click.option(
+    "--reasoning-effort",
+    default=None,
+    help=(
+        "Backend-native reasoning effort the harness ran with (e.g. low, medium, high, "
+        "xhigh, max, ultra). Free-form, stored lowercase; unknown values warn but are "
+        "accepted. Omit to fill from the trajectory."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Output result as JSON")
 @click.pass_context
 def post_session_cmd(
@@ -2897,11 +2920,18 @@ def post_session_cmd(
     context_tier: str | None,
     ab_group: str | None,
     tier_version: str | None,
+    reasoning_profile: str | None,
+    reasoning_effort: str | None,
     as_json: bool,
 ) -> None:
     """Record a completed session: extract signals, determine outcome, append record."""
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
     deliverables = list(deliverables_raw) if deliverables_raw else None
+    if reasoning_effort is not None:
+        reasoning_effort = reasoning_effort.strip().lower() or None
+        _effort_warning = check_reasoning_effort(harness, reasoning_effort)
+        if _effort_warning:
+            click.echo(f"warning: {_effort_warning}", err=True)
     ps = post_session(
         store=store,
         harness=harness,
@@ -2925,6 +2955,8 @@ def post_session_cmd(
         context_tier=context_tier,
         ab_group=ab_group,
         tier_version=tier_version,
+        reasoning_profile=reasoning_profile,
+        reasoning_effort=reasoning_effort,
     )
     if as_json:
         click.echo(
@@ -2938,6 +2970,9 @@ def post_session_cmd(
                     "stop_reason": ps.stop_reason,
                     "cost_usd": ps.cost_usd,
                     "token_count": ps.token_count,
+                    "reasoning_effort": ps.reasoning_effort,
+                    "reasoning_profile": ps.reasoning_profile,
+                    "reasoning_tokens": ps.reasoning_tokens,
                 }
             )
         )

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -38,7 +38,13 @@ from .deliverables import (
 from .discovery import extract_project, extract_session_name
 from .failure_capture import capture_session_failure
 from .lesson_events import load_lesson_events
-from .record import SessionRecord, trajectory_revision_for
+from .record import (
+    KNOWN_REASONING_EFFORTS,
+    REASONING_PROFILES,
+    SessionRecord,
+    normalize_reasoning_effort,
+    trajectory_revision_for,
+)
 from .signals import extract_from_path
 from .smell import compute_smell_score
 from .store import SessionStore
@@ -233,6 +239,29 @@ VALID_CONTEXT_TIERS: frozenset[str] = frozenset({"standard", "extended", "large"
 #: can use a single source of truth for ``click.Choice``.
 VALID_AB_GROUPS: frozenset[str] = frozenset({"treatment", "control"})
 
+#: Valid values for the ``reasoning_profile`` parameter (semantic intent:
+#: routine / default / deep).  Re-exported from ``record`` for ``click.Choice``.
+VALID_REASONING_PROFILES: frozenset[str] = REASONING_PROFILES
+
+
+def check_reasoning_effort(harness: str, effort: str | None) -> str | None:
+    """Return a warning when ``effort`` is not a documented value for ``harness``.
+
+    Never raises: ``reasoning_effort`` is free-form by design so that a new
+    backend level (or a typo) can never cost us the whole session record —
+    that silent-drop failure is exactly what left ``weekly-review`` with zero
+    records when ``--reasoning-profile`` was rejected by click.
+    """
+    if effort is None:
+        return None
+    known = KNOWN_REASONING_EFFORTS.get(harness)
+    if known is None or effort in known:
+        return None
+    return (
+        f"reasoning_effort {effort!r} is not a documented level for harness {harness!r} "
+        f"(known: {', '.join(sorted(known))}); storing as-is"
+    )
+
 
 @dataclass
 class PostSessionResult:
@@ -261,6 +290,10 @@ class PostSessionResult:
         stop_reason:           Harness-native final assistant stop reason.
         cost_usd:              Harness-reported USD-equivalent cost. For subscription
                                providers this may be nominal rather than billed spend.
+        reasoning_effort:      Backend-native reasoning effort (lowercase), from the
+                               caller or the trajectory.
+        reasoning_profile:     Semantic reasoning profile requested by the caller.
+        reasoning_tokens:      Summed thinking/reasoning output tokens, when exposed.
     """
 
     record: SessionRecord
@@ -282,6 +315,9 @@ class PostSessionResult:
     provider: str | None = None
     stop_reason: str | None = None
     cost_usd: float | None = None
+    reasoning_effort: str | None = None
+    reasoning_profile: str | None = None
+    reasoning_tokens: int | None = None
 
 
 def post_session(
@@ -314,6 +350,8 @@ def post_session(
     failure_reason: str | None = None,
     error: str | None = None,
     commit_trailers: Mapping[str, Sequence[str]] | None = None,
+    reasoning_profile: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> PostSessionResult:
     """Record a completed agent session and extract trajectory signals.
 
@@ -332,6 +370,16 @@ def post_session(
         A/B group assignment for this session (e.g. ``"treatment"`` or ``"control"``).
     tier_version:
         Version of the context tier configuration used for this session.
+    reasoning_profile:
+        Semantic reasoning profile the caller requested for this session —
+        one of ``"routine"``, ``"default"``, ``"deep"`` (see
+        ``VALID_REASONING_PROFILES``).  Invalid values raise ``ValueError``.
+    reasoning_effort:
+        Backend-native reasoning effort the harness actually ran with
+        (``"low"``/``"high"``/``"xhigh"``/``"ultra"``/...).  Stored lowercase.
+        Unknown values are accepted with a warning — never rejected.  When
+        omitted, filled from the trajectory (Claude Code ``effort``, Codex
+        ``reasoning_effort``, gptme ``metadata.reasoning_effort``).
     parent_session_id:
         ``session_id`` of the session that spawned this one.  Defaults to the
         ``BOB_PARENT_SESSION_ID`` environment variable so spawners only have to
@@ -455,6 +503,16 @@ def post_session(
         raise ValueError(
             f"Invalid ab_group {ab_group!r}. Expected one of {sorted(VALID_AB_GROUPS)}"
         )
+    if reasoning_profile is not None and reasoning_profile not in VALID_REASONING_PROFILES:
+        raise ValueError(
+            f"Invalid reasoning_profile {reasoning_profile!r}. "
+            f"Expected one of {sorted(VALID_REASONING_PROFILES)}"
+        )
+    reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+    _effort_warning = check_reasoning_effort(harness, reasoning_effort)
+    if _effort_warning:
+        logger.warning(_effort_warning)
+    reasoning_tokens: int | None = None
 
     grade: float | None = None
     signals: dict[str, Any] | None = None
@@ -509,6 +567,13 @@ def post_session(
                     stop_reason = _stop_reason
                 if not isinstance(_cost, bool) and isinstance(_cost, (int, float)):
                     cost_usd = float(_cost)
+                # Reasoning telemetry: caller-supplied effort wins; otherwise
+                # take what the harness recorded in the trajectory.
+                if reasoning_effort is None:
+                    reasoning_effort = normalize_reasoning_effort(usage.get("reasoning_effort"))
+                _reasoning_tokens = usage.get("reasoning_tokens")
+                if not isinstance(_reasoning_tokens, bool) and isinstance(_reasoning_tokens, int):
+                    reasoning_tokens = _reasoning_tokens
                 _in = usage.get("input_tokens")
                 _out = usage.get("output_tokens")
                 _cc = usage.get("cache_creation_tokens")
@@ -893,6 +958,14 @@ def post_session(
         record_kwargs["stop_reason"] = stop_reason
     if cost_usd is not None:
         record_kwargs["cost_usd"] = cost_usd
+    if reasoning_effort is None and signals:
+        reasoning_effort = normalize_reasoning_effort(signals.get("reasoning_effort"))
+    if reasoning_effort is not None:
+        record_kwargs["reasoning_effort"] = reasoning_effort
+    if reasoning_profile is not None:
+        record_kwargs["reasoning_profile"] = reasoning_profile
+    if reasoning_tokens is not None:
+        record_kwargs["reasoning_tokens"] = reasoning_tokens
     if outcome_flip_reason is not None:
         record_kwargs["outcome_flip_reason"] = outcome_flip_reason
     if context_tier is not None:
@@ -1061,6 +1134,9 @@ def post_session(
         provider=provider,
         stop_reason=stop_reason,
         cost_usd=cost_usd,
+        reasoning_effort=reasoning_effort,
+        reasoning_profile=reasoning_profile,
+        reasoning_tokens=reasoning_tokens,
         token_count=token_count,
         input_tokens=input_tokens,
         output_tokens=output_tokens,

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -56,6 +56,36 @@ DISPATCH_KINDS: frozenset[str] = frozenset(
     ]
 )
 
+# Semantic reasoning profile requested by the caller (the routing contract in
+# knowledge/technical-designs/reasoning-profile-routing-contract.md).  This is
+# the *intent* — "how hard should the model think for this kind of work" —
+# independent of which backend-native knob the harness turned to honor it.
+REASONING_PROFILES: frozenset[str] = frozenset({"routine", "default", "deep"})
+
+# Backend-native reasoning effort strings we have observed per harness.  These
+# are *documentation and warning* sets, never a hard validation gate: a grade
+# must never be lost because a harness introduced a new effort level.  Unknown
+# values are stored lowercase as-is.
+KNOWN_REASONING_EFFORTS: dict[str, frozenset[str]] = {
+    "claude-code": frozenset({"low", "medium", "high", "max"}),
+    "codex": frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "ultra"}),
+    "gptme": frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"}),
+    "pi": frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"}),
+}
+
+
+def normalize_reasoning_effort(value: object) -> str | None:
+    """Return ``value`` as a lowercase, stripped effort string, or ``None``.
+
+    Non-string and empty values map to ``None`` so a corrupt JSONL row cannot
+    persist an int or a bare space as an effort level.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
 # Scalar fields the ``annotate`` CLI can explicitly override. Persisting this
 # provenance lets later source extraction distinguish operator decisions from
 # values it owns and may refresh.
@@ -480,6 +510,17 @@ class SessionRecord:
     # an override that happens to equal the source value at annotation time.
     annotated_fields: list[str] = field(default_factory=list)
 
+    # Reasoning telemetry (cross-harness).  ``reasoning_effort`` is the
+    # backend-native knob as the harness reports it (Claude Code ``effort``,
+    # Codex ``reasoning_effort``, gptme ``metadata.reasoning_effort``), stored
+    # lowercase.  ``reasoning_profile`` is the semantic profile the caller
+    # requested (see ``REASONING_PROFILES``).  ``reasoning_tokens`` is the
+    # summed thinking/reasoning output tokens when the trajectory exposes them.
+    # All ``None`` on records written before these fields existed.
+    reasoning_effort: str | None = None
+    reasoning_profile: str | None = None
+    reasoning_tokens: int | None = None
+
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``recommended_confidence``, ``notes``).
@@ -541,6 +582,14 @@ class SessionRecord:
         # Discard unrecognized dispatch_kind values for the same reason.
         if self.dispatch_kind is not None and self.dispatch_kind not in DISPATCH_KINDS:
             self.dispatch_kind = None
+        # Reasoning telemetry: effort is free-form but always lowercase; profile
+        # is a closed semantic set so typos never reach the selector.
+        self.reasoning_effort = normalize_reasoning_effort(self.reasoning_effort)
+        if self.reasoning_profile is not None:
+            _profile = normalize_reasoning_effort(self.reasoning_profile)
+            self.reasoning_profile = _profile if _profile in REASONING_PROFILES else None
+        if isinstance(self.reasoning_tokens, bool) or not isinstance(self.reasoning_tokens, int):
+            self.reasoning_tokens = None
         # A session cannot be its own parent.  A spawner that leaks its own id
         # into the child environment would otherwise create a self-loop that
         # silently breaks every lineage walk.

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -291,6 +291,139 @@ _GH_ISSUE_CREATE_CMD_RE = re.compile(r"\bgh\s+issue\s+create\b")
 _CI_FAILURE_LOG_CMD_RE = re.compile(r"gh\s+run\s+view\b.*--log-failed")
 
 
+# Reasoning-effort field names, per harness.  Kept together so the
+# cross-harness telemetry contract is visible in one place:
+#   Claude Code: top-level ``effort`` on ``type=assistant`` records (sibling of
+#                ``message``), thinking tokens under
+#                ``message.usage.output_tokens_details.thinking_tokens``.
+#   Codex:       ``turn_context.payload.effort`` (also mirrored under
+#                ``collaboration_mode.settings.reasoning_effort``) and, on older
+#                rollouts, ``reasoning_effort`` inside the developer message's
+#                ``internal_chat_message_metadata_passthrough`` which may be a
+#                dict *or* a JSON-encoded string.  Reasoning tokens under
+#                ``total_token_usage.reasoning_output_tokens``.
+#   gptme:       ``metadata.reasoning_effort`` on assistant messages and
+#                ``metadata.usage.reasoning_tokens`` (gptme/gptme PR in flight;
+#                both optional).
+_REASONING_EFFORT_RE = re.compile(r'\\?"reasoning_effort\\?"\s*:\s*\\?"([A-Za-z_-]+)')
+
+
+def _dominant_value(values: list[str]) -> str | None:
+    """Most common entry of ``values``; ties resolve to the first seen."""
+    if not values:
+        return None
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    best = max(counts.values())
+    for value in values:
+        if counts[value] == best:
+            return value
+    return None  # pragma: no cover - unreachable
+
+
+def _find_nested_key(obj: object, key: str, *, depth: int = 6) -> object:
+    """Depth-first lookup of ``key`` in nested dicts/lists (bounded depth)."""
+    if depth < 0:
+        return None
+    if isinstance(obj, dict):
+        if key in obj:
+            return obj[key]
+        for value in obj.values():
+            found = _find_nested_key(value, key, depth=depth - 1)
+            if found is not None:
+                return found
+    elif isinstance(obj, list):
+        for value in obj:
+            found = _find_nested_key(value, key, depth=depth - 1)
+            if found is not None:
+                return found
+    return None
+
+
+def _normalize_effort(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _cc_reasoning_telemetry(msgs: list[dict]) -> tuple[str | None, int | None]:
+    """Return ``(reasoning_effort, thinking_tokens)`` for a Claude Code trajectory.
+
+    ``reasoning_effort`` is the dominant top-level ``effort`` across assistant
+    records (ties → first seen).  ``thinking_tokens`` sums
+    ``message.usage.output_tokens_details.thinking_tokens`` and is ``None``
+    when no assistant record carried the detail block.
+    """
+    efforts: list[str] = []
+    thinking_total = 0
+    thinking_seen = False
+    for record in msgs:
+        if record.get("type") != "assistant":
+            continue
+        effort = _normalize_effort(record.get("effort"))
+        if effort is not None:
+            efforts.append(effort)
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        details = usage.get("output_tokens_details")
+        if not isinstance(details, dict):
+            continue
+        thinking = _as_int(details.get("thinking_tokens"))
+        if thinking is not None:
+            thinking_total += thinking
+            thinking_seen = True
+    return _dominant_value(efforts), (thinking_total if thinking_seen else None)
+
+
+def _codex_reasoning_effort(msgs: list[dict]) -> str | None:
+    """Dominant reasoning effort across a Codex rollout (ties → first seen).
+
+    Reads ``turn_context.payload.effort`` first (present since mid-2026),
+    falling back to ``collaboration_mode.settings.reasoning_effort`` and to
+    ``reasoning_effort`` inside a developer message's
+    ``internal_chat_message_metadata_passthrough`` (dict or JSON string).
+    """
+    efforts: list[str] = []
+    for record in msgs:
+        rec_type = record.get("type", "")
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        if rec_type == "turn_context":
+            effort = _normalize_effort(payload.get("effort"))
+            if effort is None:
+                effort = _normalize_effort(_find_nested_key(payload, "reasoning_effort"))
+            if effort is not None:
+                efforts.append(effort)
+        elif rec_type == "response_item":
+            passthrough = payload.get("internal_chat_message_metadata_passthrough")
+            if passthrough is None:
+                continue
+            effort = None
+            if isinstance(passthrough, str):
+                try:
+                    parsed = json.loads(passthrough)
+                except (ValueError, TypeError):
+                    parsed = None
+                if parsed is not None:
+                    effort = _normalize_effort(_find_nested_key(parsed, "reasoning_effort"))
+                if effort is None:
+                    match = _REASONING_EFFORT_RE.search(passthrough)
+                    if match:
+                        effort = _normalize_effort(match.group(1))
+            else:
+                effort = _normalize_effort(_find_nested_key(passthrough, "reasoning_effort"))
+            if effort is not None:
+                efforts.append(effort)
+    return _dominant_value(efforts)
+
+
 def parse_trajectory(jsonl_path: Path) -> list[dict]:
     """Parse a JSONL trajectory file into a list of records."""
     msgs = []
@@ -485,11 +618,18 @@ def extract_signals(msgs: list[dict]) -> dict:
 
     # Track recent (tool, path) pairs for retry detection
     recent_sigs: list[str] = []
+    reasoning_efforts: list[str] = []
 
     for msg in msgs:
         role = msg.get("role", "")
         content = msg.get("content", "") or ""
         ts_str = msg.get("timestamp", "")
+        if role == "assistant":
+            _meta = msg.get("metadata")
+            if isinstance(_meta, dict):
+                _effort = _normalize_effort(_meta.get("reasoning_effort"))
+                if _effort is not None:
+                    reasoning_efforts.append(_effort)
 
         # Parse timestamps for duration
         if ts_str:
@@ -590,6 +730,7 @@ def extract_signals(msgs: list[dict]) -> dict:
         "deliverables": deliverables,
         "deliverable_details": deliverable_details,
         "summarizer_fired": summarizer_fired,
+        "reasoning_effort": _dominant_value(reasoning_efforts),
     }
 
 
@@ -1198,6 +1339,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
         tool_time_total[name] = round(sum(durs), 1)
         tool_time_max[name] = round(max(durs), 1)
     total_tool_time_s = round(sum(tool_time_total.values()), 1)
+    cc_reasoning_effort, cc_thinking_tokens = _cc_reasoning_telemetry(msgs)
 
     return {
         "tool_calls": tool_calls,
@@ -1222,6 +1364,8 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
         "ci_fixed": ci_fixed,
         "deliverables": deliverables,
         "deliverable_details": deliverable_details,
+        "reasoning_effort": cc_reasoning_effort,
+        "thinking_tokens": cc_thinking_tokens or 0,
     }
 
 
@@ -1317,6 +1461,9 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     model: str | None = None
     sys_prompt_tokens: int | None = None
     context_peak_tokens: int | None = None
+    reasoning_efforts: list[str] = []
+    reasoning_tokens = 0
+    reasoning_seen = False
 
     # --- Byte-level metrics (model-independent; ErikBjare/bob#738) ---
     sys_prompt_bytes: int | None = None
@@ -1397,6 +1544,14 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         if not isinstance(reported_cost, bool) and isinstance(reported_cost, (int, float)):
             cost += float(reported_cost)
             cost_found = True
+        # Reasoning telemetry (gptme/gptme in-flight PR; both fields optional).
+        _effort = _normalize_effort(metadata.get("reasoning_effort"))
+        if _effort is not None:
+            reasoning_efforts.append(_effort)
+        _reasoning = _as_int(usage.get("reasoning_tokens"))
+        if _reasoning is not None:
+            reasoning_tokens += _reasoning
+            reasoning_seen = True
 
     total_tokens = input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens
     has_byte_metrics = any(
@@ -1421,6 +1576,11 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     }
     if cost_found:
         result["cost"] = cost
+    _dominant_effort = _dominant_value(reasoning_efforts)
+    if _dominant_effort is not None:
+        result["reasoning_effort"] = _dominant_effort
+    if reasoning_seen:
+        result["reasoning_tokens"] = reasoning_tokens
     return result
 
 
@@ -1600,6 +1760,11 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
     }
     if stop_reason is not None:
         result["stop_reason"] = stop_reason
+    cc_effort, cc_thinking = _cc_reasoning_telemetry(msgs)
+    if cc_effort is not None:
+        result["reasoning_effort"] = cc_effort
+    if cc_thinking is not None:
+        result["reasoning_tokens"] = cc_thinking
     return result
 
 
@@ -1618,9 +1783,21 @@ def _combine_cc_usage(parts: list[dict]) -> dict:
     result = {
         field: sum(_as_int(part.get(field)) or 0 for part in parts) for field in additive_fields
     }
+    # Reasoning tokens are additive too, but only when some part observed them —
+    # ``None`` must stay distinguishable from "thought zero tokens".
+    if any(part.get("reasoning_tokens") is not None for part in parts):
+        result["reasoning_tokens"] = sum(
+            _as_int(part.get("reasoning_tokens")) or 0 for part in parts
+        )
     # Parent metadata describes the aggregate session. Fall back to a child
     # only when the parent did not carry the field at all.
-    for field in ("model", "sys_prompt_tokens", "context_peak_tokens", "stop_reason"):
+    for field in (
+        "model",
+        "sys_prompt_tokens",
+        "context_peak_tokens",
+        "stop_reason",
+        "reasoning_effort",
+    ):
         value = next((part.get(field) for part in parts if part.get(field) is not None), None)
         if value is not None:
             result[field] = value
@@ -1895,6 +2072,7 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
         "retry_count": len(retry_candidates),
         "deliverables": deliverables,
         "deliverable_details": deliverable_details,
+        "reasoning_effort": _codex_reasoning_effort(msgs),
     }
 
 
@@ -2092,6 +2270,7 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
         and rate_limit_secondary is None
         and final_total is None
         and context_peak_tokens is None
+        and _codex_reasoning_effort(msgs) is None
     ):
         return {}
     result: dict = {}
@@ -2121,6 +2300,13 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
         result["context_peak_tokens"] = context_peak_tokens
     if context_window is not None:
         result["context_window"] = context_window
+    codex_effort = _codex_reasoning_effort(msgs)
+    if codex_effort is not None:
+        result["reasoning_effort"] = codex_effort
+    if final_total is not None:
+        reasoning_tokens = _as_int(final_total.get("reasoning_output_tokens"))
+        if reasoning_tokens is not None:
+            result["reasoning_tokens"] = reasoning_tokens
     return result
 
 

--- a/packages/gptme-sessions/tests/test_reasoning_effort.py
+++ b/packages/gptme-sessions/tests/test_reasoning_effort.py
@@ -1,0 +1,534 @@
+"""Reasoning-effort telemetry: record fields, per-harness extraction, CLI plumbing.
+
+Background: ``post-session-grade.sh`` passed ``--reasoning-profile`` whenever a
+run set ``GRADE_REASONING_PROFILE``; click rejected the unknown option, the
+``|| true`` swallowed the error, and no session record was written at all.
+These tests pin the flags, the record fields, and the "never lose a grade over
+this field" contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptme_sessions.cli import cli
+from gptme_sessions.post_session import (
+    VALID_REASONING_PROFILES,
+    check_reasoning_effort,
+    post_session,
+)
+from gptme_sessions.record import (
+    KNOWN_REASONING_EFFORTS,
+    REASONING_PROFILES,
+    SessionRecord,
+    normalize_reasoning_effort,
+)
+from gptme_sessions.signals import (
+    _combine_cc_usage,
+    extract_from_path,
+    extract_signals,
+    extract_signals_cc,
+    extract_signals_codex,
+    extract_usage_cc,
+    extract_usage_codex,
+    extract_usage_gptme,
+)
+from gptme_sessions.store import SessionStore
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _cc_assistant(
+    *, effort: str | None = "high", thinking: int | None = 285, ts: str = "2026-09-09T10:00:00.000Z"
+) -> dict:
+    usage: dict = {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 100,
+        "cache_read_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    if thinking is not None:
+        usage["output_tokens_details"] = {"thinking_tokens": thinking}
+    record: dict = {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "role": "assistant",
+            "model": "claude-fable-5-1",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": usage,
+        },
+    }
+    # ``effort`` is a sibling of ``message`` on real CC trajectories, not inside it.
+    if effort is not None:
+        record["effort"] = effort
+    return record
+
+
+def _codex_meta() -> dict:
+    return {
+        "timestamp": "2026-09-09T02:04:18.000Z",
+        "type": "session_meta",
+        "payload": {"originator": "codex_exec", "id": "abc"},
+    }
+
+
+def _codex_turn_context(effort: str | None = "ultra", *, mirror_only: bool = False) -> dict:
+    payload: dict = {"model": "gpt-6-astra", "cwd": "/home/bob/bob"}
+    if effort is not None:
+        if not mirror_only:
+            payload["effort"] = effort
+        payload["collaboration_mode"] = {
+            "mode": "default",
+            "settings": {"model": "gpt-6-astra", "reasoning_effort": effort},
+        }
+    return {"timestamp": "2026-09-09T02:04:20.197Z", "type": "turn_context", "payload": payload}
+
+
+def _codex_developer_message(passthrough: object) -> dict:
+    return {
+        "timestamp": "2026-09-09T02:04:20.194Z",
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": "developer",
+            "content": [{"type": "input_text", "text": "instructions"}],
+            "internal_chat_message_metadata_passthrough": passthrough,
+        },
+    }
+
+
+def _codex_token_count(reasoning: int = 6415) -> dict:
+    return {
+        "timestamp": "2026-09-09T02:10:00.000Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {"input_tokens": 1000},
+                "total_token_usage": {
+                    "input_tokens": 3000,
+                    "output_tokens": 400,
+                    "cached_input_tokens": 2000,
+                    "reasoning_output_tokens": reasoning,
+                    "total_tokens": 3400,
+                },
+                "model_context_window": 400000,
+            },
+        },
+    }
+
+
+def _gptme_assistant(
+    *,
+    effort: str | None = "high",
+    reasoning_tokens: int | None = 120,
+    ts: str = "2026-09-09T10:00:00",
+) -> dict:
+    usage: dict = {
+        "input_tokens": 500,
+        "output_tokens": 80,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+    }
+    if reasoning_tokens is not None:
+        usage["reasoning_tokens"] = reasoning_tokens
+    metadata: dict = {"model": "anthropic/claude-opus-4-6", "usage": usage}
+    if effort is not None:
+        metadata["reasoning_effort"] = effort
+    return {"role": "assistant", "content": "hello", "timestamp": ts, "metadata": metadata}
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# SessionRecord
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRecordFields:
+    def test_defaults_are_none(self) -> None:
+        r = SessionRecord()
+        assert r.reasoning_effort is None
+        assert r.reasoning_profile is None
+        assert r.reasoning_tokens is None
+
+    def test_round_trip(self) -> None:
+        r = SessionRecord(reasoning_effort="High", reasoning_profile="deep", reasoning_tokens=42)
+        d = r.to_dict()
+        assert d["reasoning_effort"] == "high"
+        assert d["reasoning_profile"] == "deep"
+        assert d["reasoning_tokens"] == 42
+        back = SessionRecord.from_dict(json.loads(json.dumps(d)))
+        assert back.reasoning_effort == "high"
+        assert back.reasoning_profile == "deep"
+        assert back.reasoning_tokens == 42
+
+    def test_effort_is_free_form_but_lowercased(self) -> None:
+        # A backend level we have never seen must survive — never be dropped.
+        r = SessionRecord(reasoning_effort="  Galactic ")
+        assert r.reasoning_effort == "galactic"
+        assert SessionRecord(reasoning_effort="").reasoning_effort is None
+        assert SessionRecord(reasoning_effort=3).reasoning_effort is None  # type: ignore[arg-type]
+
+    def test_profile_is_a_closed_set(self) -> None:
+        assert SessionRecord(reasoning_profile="Routine").reasoning_profile == "routine"
+        assert SessionRecord(reasoning_profile="turbo").reasoning_profile is None
+        assert REASONING_PROFILES == {"routine", "default", "deep"}
+        assert VALID_REASONING_PROFILES == REASONING_PROFILES
+
+    def test_reasoning_tokens_rejects_non_int(self) -> None:
+        assert SessionRecord(reasoning_tokens=True).reasoning_tokens is None  # type: ignore[arg-type]
+        assert SessionRecord(reasoning_tokens="12").reasoning_tokens is None  # type: ignore[arg-type]
+
+    def test_old_records_without_fields_still_load(self) -> None:
+        legacy = {"session_id": "abcd1234", "harness": "claude-code", "model": "opus"}
+        r = SessionRecord.from_dict(legacy)
+        assert r.reasoning_effort is None
+        assert r.reasoning_profile is None
+        assert "reasoning_effort" in r.to_dict()
+
+    def test_store_persists_fields(self, tmp_path: Path) -> None:
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(reasoning_effort="xhigh", reasoning_profile="routine"))
+        loaded = SessionStore(sessions_dir=tmp_path).load_all()
+        assert loaded[0].reasoning_effort == "xhigh"
+        assert loaded[0].reasoning_profile == "routine"
+
+
+def test_normalize_reasoning_effort() -> None:
+    assert normalize_reasoning_effort(" XHigh ") == "xhigh"
+    assert normalize_reasoning_effort("") is None
+    assert normalize_reasoning_effort(None) is None
+    assert normalize_reasoning_effort(["high"]) is None
+
+
+def test_check_reasoning_effort_warns_but_never_raises() -> None:
+    assert check_reasoning_effort("claude-code", None) is None
+    assert check_reasoning_effort("claude-code", "high") is None
+    warning = check_reasoning_effort("claude-code", "ultra")
+    assert warning is not None and "ultra" in warning and "claude-code" in warning
+    # Harnesses without a documented set are silently accepted.
+    assert check_reasoning_effort("copilot-cli", "anything") is None
+    assert "ultra" in KNOWN_REASONING_EFFORTS["codex"]
+
+
+# ---------------------------------------------------------------------------
+# Claude Code extractor
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeExtraction:
+    def test_signals_read_top_level_effort_and_sum_thinking(self) -> None:
+        msgs = [
+            _cc_assistant(effort="high", thinking=285),
+            _cc_assistant(effort="high", thinking=15, ts="2026-09-09T10:01:00.000Z"),
+            _cc_assistant(effort="max", thinking=None, ts="2026-09-09T10:02:00.000Z"),
+        ]
+        signals = extract_signals_cc(msgs)
+        assert signals["reasoning_effort"] == "high"
+        assert signals["thinking_tokens"] == 300
+
+    def test_effort_inside_message_is_not_the_contract(self) -> None:
+        # Guard against reading a hypothetical ``message.effort`` — the real
+        # field is top-level. A record with neither yields None, not a guess.
+        rec = _cc_assistant(effort=None, thinking=None)
+        rec["message"]["effort"] = "low"
+        signals = extract_signals_cc([rec])
+        assert signals["reasoning_effort"] is None
+        assert signals["thinking_tokens"] == 0
+
+    def test_tie_resolves_to_first_seen(self) -> None:
+        msgs = [
+            _cc_assistant(effort="low"),
+            _cc_assistant(effort="max", ts="2026-09-09T10:01:00.000Z"),
+        ]
+        assert extract_signals_cc(msgs)["reasoning_effort"] == "low"
+
+    def test_usage_carries_effort_and_reasoning_tokens(self) -> None:
+        usage = extract_usage_cc([_cc_assistant(effort="High", thinking=285)])
+        assert usage["reasoning_effort"] == "high"
+        assert usage["reasoning_tokens"] == 285
+
+    def test_usage_omits_reasoning_keys_when_absent(self) -> None:
+        usage = extract_usage_cc([_cc_assistant(effort=None, thinking=None)])
+        assert "reasoning_effort" not in usage
+        assert "reasoning_tokens" not in usage
+
+    def test_combine_cc_usage_sums_tokens_and_prefers_parent_effort(self) -> None:
+        parent = {"input_tokens": 1, "reasoning_effort": "high", "reasoning_tokens": 10}
+        child = {"input_tokens": 1, "reasoning_effort": "low", "reasoning_tokens": 5}
+        combined = _combine_cc_usage([parent, child])
+        assert combined["reasoning_effort"] == "high"
+        assert combined["reasoning_tokens"] == 15
+        # None stays None when no part observed thinking tokens.
+        assert "reasoning_tokens" not in _combine_cc_usage([{"input_tokens": 1}])
+
+    def test_extract_from_path_end_to_end(self, tmp_path: Path) -> None:
+        traj = _write_jsonl(tmp_path / "cc.jsonl", [_cc_assistant(effort="high", thinking=285)])
+        result = extract_from_path(traj)
+        assert result["format"] == "claude_code"
+        assert result["reasoning_effort"] == "high"
+        assert result["usage"]["reasoning_effort"] == "high"
+        assert result["usage"]["reasoning_tokens"] == 285
+
+
+# ---------------------------------------------------------------------------
+# Codex extractor
+# ---------------------------------------------------------------------------
+
+
+class TestCodexExtraction:
+    def test_turn_context_effort(self) -> None:
+        msgs = [_codex_meta(), _codex_turn_context("ultra"), _codex_token_count(6415)]
+        assert extract_signals_codex(msgs)["reasoning_effort"] == "ultra"
+        usage = extract_usage_codex(msgs)
+        assert usage["reasoning_effort"] == "ultra"
+        assert usage["reasoning_tokens"] == 6415
+        assert usage["model"] == "gpt-6-astra"
+
+    def test_collaboration_mode_mirror_when_top_level_effort_missing(self) -> None:
+        msgs = [_codex_meta(), _codex_turn_context("xhigh", mirror_only=True)]
+        assert extract_signals_codex(msgs)["reasoning_effort"] == "xhigh"
+
+    def test_passthrough_json_in_string(self) -> None:
+        passthrough = json.dumps(
+            {
+                "turn_id": "t1",
+                "collaboration_mode": {"settings": {"reasoning_effort": "high"}},
+            }
+        )
+        msgs = [_codex_meta(), _codex_developer_message(passthrough), _codex_turn_context(None)]
+        assert extract_signals_codex(msgs)["reasoning_effort"] == "high"
+        assert extract_usage_codex(msgs)["reasoning_effort"] == "high"
+
+    def test_passthrough_escaped_string_falls_back_to_regex(self) -> None:
+        # Doubly-encoded: the string is not valid JSON on its own, but the
+        # escaped key/value pair is still visible to the regex.
+        passthrough = 'prefix {\\"reasoning_effort\\":\\"medium\\",\\"x\\":1} suffix'
+        msgs = [_codex_meta(), _codex_developer_message(passthrough)]
+        assert extract_signals_codex(msgs)["reasoning_effort"] == "medium"
+
+    def test_passthrough_dict(self) -> None:
+        msgs = [
+            _codex_meta(),
+            _codex_developer_message({"turn_id": "t1", "reasoning_effort": "Low"}),
+        ]
+        assert extract_signals_codex(msgs)["reasoning_effort"] == "low"
+
+    def test_no_effort_anywhere(self) -> None:
+        msgs = [
+            _codex_meta(),
+            _codex_turn_context(None),
+            _codex_developer_message({"turn_id": "t"}),
+        ]
+        assert extract_signals_codex(msgs)["reasoning_effort"] is None
+        assert "reasoning_effort" not in extract_usage_codex(msgs)
+
+    def test_extract_from_path_end_to_end(self, tmp_path: Path) -> None:
+        traj = _write_jsonl(
+            tmp_path / "rollout.jsonl",
+            [_codex_meta(), _codex_turn_context("ultra"), _codex_token_count(77)],
+        )
+        result = extract_from_path(traj)
+        assert result["format"] == "codex"
+        assert result["reasoning_effort"] == "ultra"
+        assert result["usage"]["reasoning_tokens"] == 77
+
+
+# ---------------------------------------------------------------------------
+# gptme extractor
+# ---------------------------------------------------------------------------
+
+
+class TestGptmeExtraction:
+    def test_metadata_effort_and_usage_reasoning_tokens(self) -> None:
+        msgs = [
+            {"role": "user", "content": "hi", "timestamp": "2026-09-09T09:59:00"},
+            _gptme_assistant(effort="high", reasoning_tokens=120),
+            _gptme_assistant(effort="high", reasoning_tokens=30, ts="2026-09-09T10:01:00"),
+        ]
+        assert extract_signals(msgs)["reasoning_effort"] == "high"
+        usage = extract_usage_gptme(msgs)
+        assert usage["reasoning_effort"] == "high"
+        assert usage["reasoning_tokens"] == 150
+
+    def test_tolerates_absence(self) -> None:
+        msgs = [
+            {"role": "user", "content": "hi", "timestamp": "2026-09-09T09:59:00"},
+            _gptme_assistant(effort=None, reasoning_tokens=None),
+        ]
+        assert extract_signals(msgs)["reasoning_effort"] is None
+        usage = extract_usage_gptme(msgs)
+        assert "reasoning_effort" not in usage
+        assert "reasoning_tokens" not in usage
+        assert usage["input_tokens"] == 500
+
+    def test_legacy_flat_metadata_still_reads_reasoning_tokens(self) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "x",
+            "timestamp": "2026-09-09T10:00:00",
+            "metadata": {"input_tokens": 10, "output_tokens": 5, "reasoning_tokens": 3},
+        }
+        assert extract_usage_gptme([msg])["reasoning_tokens"] == 3
+
+
+# ---------------------------------------------------------------------------
+# post_session plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestPostSession:
+    def test_fills_effort_from_cc_trajectory(self, tmp_path: Path) -> None:
+        traj = _write_jsonl(tmp_path / "cc.jsonl", [_cc_assistant(effort="high", thinking=285)])
+        store = SessionStore(sessions_dir=tmp_path / "sessions")
+        result = post_session(
+            store=store, harness="claude-code", model="unknown", trajectory_path=traj
+        )
+        assert result.reasoning_effort == "high"
+        assert result.record.reasoning_effort == "high"
+        assert result.reasoning_tokens == 285
+        assert result.record.reasoning_tokens == 285
+        assert result.record.reasoning_profile is None
+        persisted = SessionStore(sessions_dir=tmp_path / "sessions").load_all()
+        assert persisted[0].reasoning_effort == "high"
+        assert persisted[0].reasoning_tokens == 285
+
+    def test_fills_effort_from_codex_trajectory(self, tmp_path: Path) -> None:
+        traj = _write_jsonl(
+            tmp_path / "rollout.jsonl",
+            [_codex_meta(), _codex_turn_context("ultra"), _codex_token_count(6415)],
+        )
+        store = SessionStore(sessions_dir=tmp_path / "sessions")
+        result = post_session(store=store, harness="codex", model="unknown", trajectory_path=traj)
+        assert result.record.reasoning_effort == "ultra"
+        assert result.record.reasoning_tokens == 6415
+
+    def test_caller_effort_wins_over_trajectory(self, tmp_path: Path) -> None:
+        traj = _write_jsonl(tmp_path / "cc.jsonl", [_cc_assistant(effort="high")])
+        store = SessionStore(sessions_dir=tmp_path / "sessions")
+        result = post_session(
+            store=store,
+            harness="claude-code",
+            model="unknown",
+            trajectory_path=traj,
+            reasoning_effort="MAX",
+            reasoning_profile="deep",
+        )
+        assert result.record.reasoning_effort == "max"
+        assert result.record.reasoning_profile == "deep"
+
+    def test_unknown_effort_is_kept_with_warning(self, tmp_path: Path, caplog) -> None:
+        store = SessionStore(sessions_dir=tmp_path)
+        with caplog.at_level("WARNING", logger="gptme_sessions.post_session"):
+            result = post_session(
+                store=store, harness="claude-code", model="unknown", reasoning_effort="galactic"
+            )
+        assert result.record.reasoning_effort == "galactic"
+        assert any("galactic" in rec.message for rec in caplog.records)
+        # The grade/record must never be lost because of this field.
+        assert len(store.load_all()) == 1
+
+    def test_invalid_profile_raises(self, tmp_path: Path) -> None:
+        store = SessionStore(sessions_dir=tmp_path)
+        with pytest.raises(ValueError, match="reasoning_profile"):
+            post_session(store=store, harness="gptme", model="x", reasoning_profile="turbo")
+
+    def test_no_trajectory_no_fields(self, tmp_path: Path) -> None:
+        store = SessionStore(sessions_dir=tmp_path)
+        result = post_session(store=store, harness="gptme", model="x")
+        assert result.record.reasoning_effort is None
+        assert result.record.reasoning_tokens is None
+        assert result.reasoning_profile is None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _invoke(args: list[str], sessions_dir: Path):
+    return CliRunner().invoke(cli, ["--sessions-dir", str(sessions_dir), *args])
+
+
+class TestPostSessionCli:
+    def test_flags_land_on_record(self, tmp_path: Path) -> None:
+        # This exact invocation shape (``--reasoning-profile`` present) used to
+        # die with "No such option" and silently drop the whole record.
+        res = _invoke(
+            [
+                "post-session",
+                "--harness",
+                "claude-code",
+                "--model",
+                "claude-fable-5-1",
+                "--run-type",
+                "autonomous",
+                "--reasoning-profile",
+                "deep",
+                "--reasoning-effort",
+                "High",
+                "--json",
+            ],
+            tmp_path,
+        )
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output.strip().splitlines()[-1])
+        assert payload["reasoning_effort"] == "high"
+        assert payload["reasoning_profile"] == "deep"
+        assert payload["reasoning_tokens"] is None
+        records = SessionStore(sessions_dir=tmp_path).load_all()
+        assert records[0].reasoning_effort == "high"
+        assert records[0].reasoning_profile == "deep"
+
+    def test_profile_is_validated(self, tmp_path: Path) -> None:
+        res = _invoke(
+            ["post-session", "--harness", "gptme", "--reasoning-profile", "turbo"], tmp_path
+        )
+        assert res.exit_code != 0
+        assert "Invalid value for '--reasoning-profile'" in res.output
+
+    def test_unknown_effort_warns_but_records(self, tmp_path: Path) -> None:
+        res = _invoke(
+            ["post-session", "--harness", "codex", "--reasoning-effort", "galactic"],
+            tmp_path,
+        )
+        assert res.exit_code == 0, res.output
+        assert "galactic" in res.output and "not a documented level" in res.output
+        assert SessionStore(sessions_dir=tmp_path).load_all()[0].reasoning_effort == "galactic"
+
+    def test_effort_filled_from_trajectory_when_flag_omitted(self, tmp_path: Path) -> None:
+        traj = _write_jsonl(
+            tmp_path / "rollout.jsonl",
+            [_codex_meta(), _codex_turn_context("ultra"), _codex_token_count(9)],
+        )
+        sessions = tmp_path / "sessions"
+        res = _invoke(
+            [
+                "post-session",
+                "--harness",
+                "codex",
+                "--trajectory",
+                str(traj),
+                "--reasoning-profile",
+                "routine",
+                "--json",
+            ],
+            sessions,
+        )
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output.strip().splitlines()[-1])
+        assert payload["reasoning_effort"] == "ultra"
+        assert payload["reasoning_profile"] == "routine"
+        assert payload["reasoning_tokens"] == 9


### PR DESCRIPTION
## The bug: a silently dropped session record

`scripts/util/post-session-grade.sh` (in the bob workspace) passes `--reasoning-profile "$GRADE_REASONING_PROFILE"` to `gptme-sessions post-session` whenever a run sets that variable. `post-session` had no such option, so click exited 2 with `No such option: --reasoning-profile`. The wrapper runs the call under `|| true`, so nothing surfaced — and **no session record was written at all**, not just a missing field. That is why `weekly-review` has been reporting 0 session records for reasoning-profiled runs.

A grade must never be lost because of a telemetry field, so this PR adds the option and makes the effort field deliberately lenient.

## What's added

**`SessionRecord`** (`record.py`) — three additive tail fields, `None` on every pre-existing record:

| field | type | meaning |
|---|---|---|
| `reasoning_effort` | `str \| None` | backend-native level as the harness reports it (`low`/`medium`/`high`/`xhigh`/`max`/`ultra`/…), stored lowercase, **free-form** |
| `reasoning_profile` | `str \| None` | semantic intent requested by the caller — closed set `routine` / `default` / `deep` (`REASONING_PROFILES`) |
| `reasoning_tokens` | `int \| None` | summed thinking/reasoning output tokens when the trajectory exposes them |

`__post_init__` lowercases effort, discards unknown profiles (same treatment as `attempt_kind`/`dispatch_kind`), and drops non-int token values. Serialization is via the existing `asdict`/`from_dict` path; the JSONL store round-trips them with no schema change.

**Extractors** (`signals.py`):
- **Claude Code**: `reasoning_effort` = dominant top-level `effort` on `type=assistant` records (it is a sibling of `message`, not inside it); `thinking_tokens` (signals) / `reasoning_tokens` (usage) = Σ `message.usage.output_tokens_details.thinking_tokens`. `_combine_cc_usage` sums tokens across subagents and prefers the parent's effort.
- **Codex**: `turn_context.payload.effort` first (present in rollouts since mid-2026), then `collaboration_mode.settings.reasoning_effort`, then `reasoning_effort` inside the developer message's `internal_chat_message_metadata_passthrough` — handled as a dict, as a JSON string, and via regex when the string is doubly-escaped. `reasoning_tokens` from `total_token_usage.reasoning_output_tokens`.
- **gptme**: `metadata.reasoning_effort` and `metadata.usage.reasoning_tokens` (both optional; the in-flight gptme PR adds them — absence is tolerated).

Pi already emitted `reasoning_tokens` in its usage dict; with the `_USAGE_FIELD_MAP` entry it now lands on the record too, and `sync --signals` backfills both new keys.

**CLI** (`post-session`):
- `--reasoning-profile {routine,default,deep}` — `click.Choice`, validated.
- `--reasoning-effort <str>` — lowercased; values outside the documented per-harness set (`KNOWN_REASONING_EFFORTS`) print a warning to stderr and are **stored as-is**. Never a hard failure. When omitted, the value is filled from the trajectory signals.
- Both are echoed in `--json` output, and `PostSessionResult` carries all three fields.

## Tests

`tests/test_reasoning_effort.py` (36 tests): record round-trip/normalization/legacy load, each extractor shape (CC top-level `effort`, Codex `turn_context`, mirror-only, passthrough dict, passthrough JSON-in-string, escaped-string regex fallback), `post_session` plumbing (trajectory fill, caller-wins, unknown-effort-kept-with-warning, invalid-profile raises), and the CLI flags including the exact invocation shape that used to die with "No such option".

Package suite: 1501 passed. mypy clean. Pre-commit hooks pass.

## Follow-ups (not in this PR)
- Bob-side `scripts/util/post-session-grade.sh` can also pass `--reasoning-effort` from the run's resolved effort so the caller-supplied value wins over the trajectory heuristic.
- Bob's `scripts/session-db.py` sqlite projection does not enumerate these columns (it doesn't enumerate `stop_reason` either) — add them when the selector starts conditioning on effort.

https://claude.ai/code/session_018AkNLrV28EtBKVEGGWNFJf
