### PR TITLE
ci(test-packages): retry apt-get update on transient mirror errors

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -135,7 +135,19 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update
+          # Retry apt-get update to handle transient repository errors
+          for i in {1..3}; do
+            if sudo apt-get update -o Acquire::http::Timeout=30; then
+              break
+            fi
+            if [ $i -lt 3 ]; then
+              echo "apt-get update failed, retrying in 5s..."
+              sleep 5
+            else
+              # Continue anyway - system deps may not be critical if already installed
+              echo "apt-get update failed after 3 attempts, continuing..."
+            fi
+          done
           sudo apt-get install -y portaudio19-dev libportaudio2
 
       - name: Install dependencies


### PR DESCRIPTION
why: the Chrome apt repo hit a transient "Hash Sum mismatch" that failed the install step on gptme/gptme-contrib#1646's CI once.

what: retry `apt-get update` up to 3× with a 30s HTTP timeout on transient repository errors before falling through to the install step. The install itself (`apt-get install -y portaudio19-dev libportaudio2`) still fails the job hard on a real failure — no `|| true` swallowing it.

Split out of gptme/gptme-contrib#1646 (workflow paths are gate-protected, so keeping this there blocked that PR from self-merging).