### PR TITLE
fix(self-merge): recognize Greptile underscore marker

### DIFF
--- a/scripts/github/greptile-merge-signal.py
+++ b/scripts/github/greptile-merge-signal.py
@@ -33,7 +33,7 @@ BOT_ALLOWLIST_ENV = "GREPTILE_MERGE_SIGNAL_BOT_ALLOWLIST"
 MIN_SCORE_ENV = "GREPTILE_MERGE_SIGNAL_MIN_SCORE"
 
 SAFE_TO_MERGE_RE = re.compile(r"\bsafe to merge\b", re.IGNORECASE)
-SUMMARY_MARKER_RE = re.compile(r"greptile summary", re.IGNORECASE)
+SUMMARY_MARKER_RE = re.compile(r"greptile[ _-]+summary", re.IGNORECASE)
 SCORE_PATTERNS = (
     re.compile(r"confidence\s+score[^0-9]*(?P<score>[0-5])\s*/\s*5", re.IGNORECASE),
     re.compile(r"\bscore[^0-9]*(?P<score>[0-5])\s*/\s*5", re.IGNORECASE),

--- a/tests/test_greptile_merge_signal_provenance.py
+++ b/tests/test_greptile_merge_signal_provenance.py
@@ -53,6 +53,14 @@ def test_extract_reviewed_commit_from_footer() -> None:
     assert gms._extract_reviewed_commit(_summary(HEAD)["body"]) == HEAD
 
 
+def test_current_underscore_summary_marker_is_detected() -> None:
+    summary = _summary(HEAD)
+    summary["body"] = summary["body"].replace(
+        "<h3>Greptile Summary</h3>", "<!-- greptile_summary -->"
+    )
+    assert gms._latest_allowlisted_summary([summary], {"greptile-apps[bot]"}) == summary
+
+
 def test_extract_reviewed_commit_absent() -> None:
     assert gms._extract_reviewed_commit(_summary(None)["body"]) is None
 


### PR DESCRIPTION
## Problem

Greptile now marks its upserted summary comments with `<!-- greptile_summary -->`, while `greptile-merge-signal.py` only recognized the legacy visible phrase `Greptile Summary`. A fresh 5/5 review therefore appeared absent to the self-merge gate.

Observed on gptme/gptme#3807: the summary names head `811ef5110`, but the signal returned `no_allowlisted_summary_comment`, forcing the gate onto a stale own-review fallback.

## Fix

Accept spaces, underscores, or hyphens between `greptile` and `summary`. The existing bot allowlist, score, safe-to-merge, and reviewed-head provenance gates remain unchanged.

## Verification

- `uv run pytest tests/test_greptile_merge_signal_provenance.py -q` — 9 passed
- `uv run ruff check scripts/github/greptile-merge-signal.py tests/test_greptile_merge_signal_provenance.py`
- Live signal against gptme/gptme#3807 now returns `summary_found: true`, score 5, and reviewed head `811ef511017c...`

Closes gptme/gptme-contrib#1649
