### PR TITLE
fix(harness_models): ignore the @provider pin when normalizing gptme routes for pricing

### DIFF
--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -349,7 +349,25 @@ def pricing_key_for_model(
             if model == provider_model:
                 normalized_model = short_name
                 break
+        else:
+            # The ``@provider`` suffix is an OpenRouter routing pin, not a
+            # different model: when a route is re-pinned (2026-09-10:
+            # ``deepseek-v4-flash-0731@deepseek`` -> ``@together,fireworks,
+            # inceptron`` after OpenRouter dropped the official endpoint) every
+            # session recorded under the old pin must keep pricing to the
+            # same short name, or cost analysis silently drops them.
+            stripped = _strip_provider_pin(model)
+            for short_name, provider_model in routes.items():
+                if stripped == _strip_provider_pin(provider_model):
+                    normalized_model = short_name
+                    break
     return harness, normalized_model
+
+
+def _strip_provider_pin(model: str) -> str:
+    """Drop an OpenRouter ``@provider[,provider...]`` pin from a model id."""
+    base, _, _ = model.partition("@")
+    return base
 
 
 class HarnessCostRow(TypedDict):

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -228,6 +228,57 @@ def test_config_model_routes_drive_pricing_key() -> None:
     )
 
 
+def test_pricing_key_for_model_ignores_openrouter_provider_pin() -> None:
+    """An OpenRouter ``@provider[,provider...]`` pin is routing, not a model change.
+
+    2026-09-10: the deepseek-v4-flash route was re-pinned from
+    ``...-0731@deepseek`` to ``...-0731@together,fireworks,inceptron`` after
+    OpenRouter dropped the official endpoint. Sessions recorded under the old
+    pin (or with no pin at all) must still resolve to the same pricing key as
+    the currently configured route, or cost analysis silently drops them.
+    """
+    cfg = HarnessQuotaConfig(
+        model_routes={
+            "deepseek-v4-flash": (
+                "openrouter/deepseek/deepseek-v4-flash-0731@together,fireworks,inceptron"
+            )
+        }
+    )
+    # The exact current route still matches directly.
+    assert pricing_key_for_model(
+        "gptme",
+        "openrouter/deepseek/deepseek-v4-flash-0731@together,fireworks,inceptron",
+        config=cfg,
+    ) == ("gptme", "deepseek-v4-flash")
+    # The old pin normalizes to the same short name via the pin-insensitive fallback.
+    assert pricing_key_for_model(
+        "gptme",
+        "openrouter/deepseek/deepseek-v4-flash-0731@deepseek",
+        config=cfg,
+    ) == ("gptme", "deepseek-v4-flash")
+    # An unpinned record also normalizes to the same short name.
+    assert pricing_key_for_model(
+        "gptme",
+        "openrouter/deepseek/deepseek-v4-flash-0731",
+        config=cfg,
+    ) == ("gptme", "deepseek-v4-flash")
+
+
+def test_pricing_key_for_model_exact_match_wins_over_pin_fallback() -> None:
+    """When multiple routes share a base model, an exact match is preferred.
+
+    The pin-insensitive fallback only runs when no route matches exactly
+    (Python's ``for``/``else``), so a route that is currently pinned still
+    wins outright over stripping pins on every candidate.
+    """
+    cfg = HarnessQuotaConfig(
+        model_routes={"deepseek-v4-pro": "openrouter/deepseek/deepseek-v4-pro@deepseek"}
+    )
+    assert pricing_key_for_model(
+        "gptme", "openrouter/deepseek/deepseek-v4-pro@deepseek", config=cfg
+    ) == ("gptme", "deepseek-v4-pro")
+
+
 def test_config_aware_model_source_helpers() -> None:
     """openrouter_models / local_models / gptme_openrouter_context read config."""
     cfg = HarnessQuotaConfig(


### PR DESCRIPTION
## Why

`pricing_key_for_model()` in `packages/gptme-usage/src/gptme_usage/harness_models.py` normalizes a gptme model id to its canonical pricing short name by matching it exactly against the current route string in `GPTME_MODEL_ROUTES` / `config.model_routes`.

On 2026-09-10 the `deepseek-v4-flash` route was re-pinned from `openrouter/deepseek/deepseek-v4-flash-0731@deepseek` to `...-0731@together,fireworks,inceptron` after OpenRouter dropped the official endpoint. Because the match was exact-string-only, every session recorded under the old pin (or with no pin at all) lost its pricing key the moment the route flipped — cost analysis silently drops any row it can't price.

The `@provider[,provider...]` suffix is an OpenRouter routing pin, not a different model, so it shouldn't gate pricing-key resolution.

## What

- Add a pin-insensitive fallback to `pricing_key_for_model`: when no route matches the model id exactly, strip any `@provider` suffix from both the model id and each candidate route via a new `_strip_provider_pin` helper, and match on that instead.
- An exact match still wins outright (via Python's `for`/`else`), so a route on its current pin is never routed through the fallback unnecessarily.

## Tests

Added to `packages/gptme-usage/tests/test_harness_quota_config.py`:
- `test_pricing_key_for_model_ignores_openrouter_provider_pin` — asserts the old pin (`@deepseek`), the new pin (`@together,fireworks,inceptron`), and an unpinned record all normalize to the same `deepseek-v4-flash` short name against a config route pinned to the new provider list.
- `test_pricing_key_for_model_exact_match_wins_over_pin_fallback` — asserts an exact route match still wins outright.

`uv run pytest packages/gptme-usage -q` → 91 passed. `ruff check`, `ruff format --check`, and `mypy` (strict) all clean on the touched files.

## Note

The brain's `tests/test_session_cost_analysis.py` went red on 2026-09-10 from this same re-pin; ErikBjare/bob#1228 tracks that.