### PR TITLE
fix(activity-summary): recognize Fable quota exhaustion

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -30,6 +30,7 @@ _RETRY_DELAY_S = 5
 # slot is futile. Keep prefixes narrow so transient errors use the normal retry path.
 _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS = (
     "you've hit your weekly limit",
+    "you've reached your fable limit",
     "your organization has disabled claude subscription access",
 )
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -214,6 +214,26 @@ def test_call_claude_code_quota_marker_in_stderr(mock_run, mock_sleep, mock_gptm
 @patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
+def test_call_claude_code_fable_limit_uses_backend_fallback(mock_run, mock_sleep, mock_gptme):
+    """The current Fable-limit wording must route to gptme without retries."""
+    mock_run.return_value = _make_completed_process(
+        returncode=1,
+        stdout=(
+            "You've reached your Fable limit. Switch to another model, or manage "
+            "usage credits at claude.ai/settings/usage, to continue."
+        ),
+    )
+    mock_gptme.return_value = '{"narrative": "fallback summary"}'
+
+    assert call_claude_code("test prompt", max_retries=3) == ('{"narrative": "fallback summary"}')
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+    assert mock_run.call_count == 1
+    assert mock_sleep.call_count == 0
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
 def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_sleep, mock_gptme):
     """ClaudeQuotaExhaustedError must be catchable as CalledProcessError."""
     from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError


### PR DESCRIPTION
## Problem

Claude Code now reports exhausted Fable allowance as \`You've reached your Fable limit\`. The activity-summary backend only recognized the older weekly-limit wording, so it retried the same dead slot three times and never reached the configured gptme fallback. Bob's 2026-09-10 daily summary consequently stayed missing and the health alert fired for 12 hours.

## Fix

Classify the current Fable-limit wording as a permanent, slot-scoped subscription failure. This takes the existing fallback-slot and gptme-backend path immediately instead of burning retries.

## Verification

- Added a regression with the exact live message; it proves one Claude attempt, zero retry sleeps, and successful gptme fallback.
- \`uv run --package gptme-activity-summary pytest packages/gptme-activity-summary/tests/test_cc_backend.py -q\` — 78 passed.
- Ruff, formatting, typecheck, and commit hooks pass.

This does not change quota policy or credentials; it only recognizes the provider's current error wording.