### PR TITLE
feat(sessions): preserve launcher dispatch causes

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1405,14 +1405,11 @@ def plan_item(
         runner_argv += ["--model", model]
     runner_argv.append(prompt)
 
-    runner_env: dict[str, str] = {}
+    # Every backend shares the recorded id with launch receipts and nested
+    # dispatchers; retain backend-specific aliases for trajectory discovery.
+    runner_env: dict[str, str] = {"BOB_SESSION_ID": session_id}
     if backend == "claude-code":
         runner_env["CC_SESSION_ID"] = session_id
-    elif backend == "gptme":
-        # run.sh uses this id for its trajectory sentinel. Without it the
-        # sentinel is keyed by the runner PID and run-item cannot recover the
-        # trajectory for post_session grading/token extraction.
-        runner_env["BOB_SESSION_ID"] = session_id
     elif backend == "grok-build":
         runner_env["GROK_BUILD_SESSION_ID"] = session_id
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -491,7 +491,10 @@ def test_plan_runner_argv_and_env(tmp_path) -> None:
     ]
     assert flags[7:9] == ["--timeout", "900"]
     assert flags[9:11] == ["--model", "claude-sonnet-4-6"]
-    assert plan.runner_env == {"CC_SESSION_ID": plan.session_id}
+    assert plan.runner_env == {
+        "BOB_SESSION_ID": plan.session_id,
+        "CC_SESSION_ID": plan.session_id,
+    }
     assert plan.trajectory_path.endswith(f"/{plan.session_id}.jsonl")
 
 
@@ -505,8 +508,19 @@ def test_plan_grok_build_env(tmp_path) -> None:
     plan, _, _ = _plan_for(
         tmp_path, make_item(), FakeLifecycleIO(), backend="grok-build"
     )
-    assert plan.runner_env == {"GROK_BUILD_SESSION_ID": plan.session_id}
+    assert plan.runner_env == {
+        "BOB_SESSION_ID": plan.session_id,
+        "GROK_BUILD_SESSION_ID": plan.session_id,
+    }
     assert plan.trajectory_path == ""  # CC prediction only
+
+
+@pytest.mark.parametrize(
+    "backend", ["claude-code", "gptme", "grok-build", "codex", "pi"]
+)
+def test_plan_shares_record_id_with_every_backend(tmp_path, backend) -> None:
+    plan, _, _ = _plan_for(tmp_path, make_item(), FakeLifecycleIO(), backend=backend)
+    assert plan.runner_env["BOB_SESSION_ID"] == plan.session_id
 
 
 # --- Dry-run ExecutionPlan ---

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -333,6 +333,7 @@ def post_session(
     parent_session_id: str | None = None,
     dispatch_kind: str | None = None,
     dispatch_id: str | None = None,
+    dispatch_cause: dict[str, Any] | None = None,
     category: str | None = None,
     recommended_category: str | None = None,
     selector_mode: str | None = None,
@@ -395,6 +396,12 @@ def post_session(
         use for dispatcher-run→child joins.  Defaults to the harness-neutral
         ``BOB_DISPATCH_ID`` environment variable, falling back to
         ``PM_DISPATCH_ID`` for the project-monitoring path.
+    dispatch_cause:
+        Launcher-captured cause object, with caller-defined ``kind``/``id``
+        and optional ``parent_session_id``, ``task``, ``pr``, or other metadata.
+        When omitted, read JSON from ``BOB_DISPATCH_CAUSE``. Malformed JSON and
+        non-object values are ignored. An explicit object, including an empty
+        one, takes precedence. This does not change the lineage fields above.
     run_type:
         Pipeline / trigger name (e.g. ``"autonomous"``, ``"monitoring"``).
         Kept for backward compatibility; prefer ``trigger`` going forward.
@@ -998,6 +1005,16 @@ def post_session(
     )
     if resolved_dispatch_id is not None:
         record_kwargs["dispatch_id"] = resolved_dispatch_id
+    resolved_dispatch_cause = dispatch_cause
+    if resolved_dispatch_cause is None:
+        raw_dispatch_cause = os.environ.get("BOB_DISPATCH_CAUSE")
+        if raw_dispatch_cause:
+            try:
+                resolved_dispatch_cause = json.loads(raw_dispatch_cause)
+            except json.JSONDecodeError:
+                pass
+    if isinstance(resolved_dispatch_cause, dict):
+        record_kwargs["dispatch_cause"] = resolved_dispatch_cause
     if actual_category is not None:
         record_kwargs["category"] = actual_category
     if recommended_category is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -375,6 +375,10 @@ class SessionRecord:
     # Complements ``parent_session_id``; use for dispatcher-run→child joins when
     # the dispatcher has no session_id of its own.
     dispatch_id: str | None = None
+    # Launcher-captured reason for dispatch, separate from spawn mechanism.
+    # Callers define kind/id and may include parent_session_id, task, pr, or
+    # dispatcher-specific metadata. None means the cause was not recorded.
+    dispatch_cause: dict[str, Any] | None = None
 
     # Work classification
     category: str | None = None  # inferred from commits/files (what actually happened)
@@ -582,6 +586,8 @@ class SessionRecord:
         # Discard unrecognized dispatch_kind values for the same reason.
         if self.dispatch_kind is not None and self.dispatch_kind not in DISPATCH_KINDS:
             self.dispatch_kind = None
+        if self.dispatch_cause is not None and not isinstance(self.dispatch_cause, dict):
+            self.dispatch_cause = None
         # Reasoning telemetry: effort is free-form but always lowercase; profile
         # is a closed semantic set so typos never reach the selector.
         self.reasoning_effort = normalize_reasoning_effort(self.reasoning_effort)

--- a/packages/gptme-sessions/tests/test_dispatch_cause.py
+++ b/packages/gptme-sessions/tests/test_dispatch_cause.py
@@ -1,0 +1,95 @@
+"""Launch causes survive recording independently of the dispatch mechanism."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gptme_sessions.post_session import post_session
+from gptme_sessions.record import SessionRecord
+from gptme_sessions.store import SessionStore
+
+
+CAUSE = {
+    "kind": "pr-review",
+    "id": "review-42",
+    "parent_session_id": "parent-123",
+    "task": "review-change",
+    "pr": "gptme/gptme#42",
+    "unit": "review-slot-0",
+    "release": "v1",
+}
+
+
+def test_dispatch_cause_roundtrip_preserves_lineage(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("BOB_DISPATCH_CAUSE", '{"kind": "stale-env"}')
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="gptme",
+        session_id="child-123",
+        parent_session_id="parent-123",
+        dispatch_kind="worker",
+        dispatch_id="worker-run-7",
+        dispatch_cause=CAUSE,
+    )
+    assert result.record.dispatch_cause == CAUSE
+    [reloaded] = store.load_all()
+    assert reloaded.dispatch_cause == CAUSE
+    assert reloaded.parent_session_id == "parent-123"
+    assert reloaded.dispatch_kind == "worker"
+    assert reloaded.dispatch_id == "worker-run-7"
+    assert json.loads(reloaded.to_json())["dispatch_cause"] == CAUSE
+
+
+def test_dispatch_cause_environment_fallback(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("BOB_DISPATCH_CAUSE", json.dumps(CAUSE))
+    store = SessionStore(sessions_dir=tmp_path)
+    post_session(store=store, harness="gptme", session_id="env-child")
+    [record] = store.load_all()
+    assert record.dispatch_cause == CAUSE
+
+
+def test_explicit_empty_cause_overrides_environment(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("BOB_DISPATCH_CAUSE", json.dumps(CAUSE))
+    result = post_session(
+        store=SessionStore(sessions_dir=tmp_path), harness="gptme", dispatch_cause={}
+    )
+    assert result.record.dispatch_cause == {}
+
+
+@pytest.mark.parametrize("raw", ["{broken", "[]", '"timer"', "42", "true", "null", ""])
+def test_invalid_environment_cause_does_not_prevent_recording(tmp_path: Path, monkeypatch, raw):
+    monkeypatch.setenv("BOB_DISPATCH_CAUSE", raw)
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(store=store, harness="gptme", session_id="invalid-env")
+    assert result.record.dispatch_cause is None
+    [reloaded] = store.load_all()
+    assert reloaded.session_id == "invalid-env"
+    assert reloaded.dispatch_cause is None
+
+
+@pytest.mark.parametrize("value", [[], "timer", 42, True])
+def test_invalid_record_cause_is_dropped(value):
+    record = SessionRecord.from_dict({"session_id": "invalid-row", "dispatch_cause": value})
+    assert record.dispatch_cause is None
+    assert record.to_dict()["dispatch_cause"] is None
+
+
+def test_invalid_argument_does_not_fall_back_to_stale_environment(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("BOB_DISPATCH_CAUSE", json.dumps(CAUSE))
+    result = post_session(
+        store=SessionStore(sessions_dir=tmp_path),
+        harness="gptme",
+        dispatch_cause="invalid",  # type: ignore[arg-type]
+    )
+    assert result.record.dispatch_cause is None
+
+
+def test_missing_cause_remains_unrecorded(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("BOB_DISPATCH_CAUSE", raising=False)
+    result = post_session(store=SessionStore(sessions_dir=tmp_path), harness="gptme")
+    assert result.record.dispatch_cause is None
+    legacy = SessionRecord.from_dict({"session_id": "old", "dispatch_kind": "worker"})
+    assert legacy.dispatch_cause is None
+    assert legacy.dispatch_kind == "worker"


### PR DESCRIPTION
Launchers can identify why a session was dispatched, but the session recorder currently retains only the spawn mechanism and lineage. Add an optional `dispatch_cause` object to `SessionRecord` and `post_session`, with a `BOB_DISPATCH_CAUSE` JSON environment fallback, so the recorded cause survives JSONL storage without being inferred afterward.

Explicit objects (including `{}`) override the environment. Malformed JSON and non-object inputs are ignored; old records keep `None`. Cause kinds and additional metadata belong to the caller. Existing `dispatch_kind`, `dispatch_id`, and `parent_session_id` behavior is unchanged.

The run-item planner also passes its record ID as `BOB_SESSION_ID` for every backend, preserving the existing Claude Code and Grok aliases. This lets launch receipts and nested dispatchers use the same ID as the resulting session record.

Validation: 370 targeted tests passed across dispatch cause/lineage, SessionRecord/post_session, and run-item tests. Pre-commit checks include repository package typechecking and duplication detection. This draft supplies the shared schema for a separate launcher-side capture integration; it does not infer causes or backfill historical records.
