### PR TITLE
fix(activity-summary): retain fallback trajectories and diagnostics

### DIFF
--- a/packages/gptme-activity-summary/README.md
+++ b/packages/gptme-activity-summary/README.md
@@ -80,7 +80,8 @@ partial output on timeout. Its path is logged before launching the child.
 Allocation failure returns an empty result without launching an unlogged child;
 a diagnostic write failure is logged and does not discard the model response.
 
-Claude calls clear inherited parent session identity and use a fresh
+Claude requires a CLI with `--session-id` support (verified on 2.1.269).
+Calls clear inherited parent session identity and use a fresh
 `--session-id` for every attempt, including retries and configured alternate
 credential slots. Ordinary calls retain Claude's native project trajectories.
 Alternate slots use private `claude-slot-*` state directories; only the temporary

--- a/packages/gptme-activity-summary/README.md
+++ b/packages/gptme-activity-summary/README.md
@@ -69,3 +69,23 @@ gptme-activity-summary smart --date yesterday
 ## License
 
 MIT
+
+## Backend trace retention
+
+The gptme fallback keeps each invocation under
+`$XDG_STATE_HOME/gptme-activity-summary/gptme-*` (default:
+`~/.local/state/gptme-activity-summary/`). The private directory contains the
+native conversation plus `stdout.log` and `stderr.log`, including captured
+partial output on timeout. Its path is logged before launching the child.
+Allocation failure returns an empty result without launching an unlogged child;
+a diagnostic write failure is logged and does not discard the model response.
+
+Claude calls clear inherited parent session identity and use a fresh
+`--session-id` for every attempt, including retries and configured alternate
+credential slots. Ordinary calls retain Claude's native project trajectories.
+Alternate slots use private `claude-slot-*` state directories; only the temporary
+credential symlink is removed after exit. Existing retry debug logs are retained.
+
+These backends do not automatically prune traces. They may contain journal
+content and provider diagnostics; keep their private permissions when archiving.
+Archive native files without following any conversation `workspace` symlink.

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -9,15 +9,15 @@ import json
 import logging
 import re
 import shlex
-import shutil
 import subprocess
-import tempfile
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from gptme_activity_summary.gptme_backend import call_gptme
+from gptme_activity_summary.traces import create_trace_dir
 
 logger = logging.getLogger(__name__)
 
@@ -81,19 +81,20 @@ def _try_with_credential_file(
     base_env: dict,
     timeout: int,
 ) -> subprocess.CompletedProcess:
-    """Run ``claude -p`` with a specific credential file via a temporary CLAUDE_CONFIG_DIR.
+    """Run ``claude -p`` with a specific credential file via an isolated CLAUDE_CONFIG_DIR.
 
-    Creates a temporary directory containing only a ``.credentials.json`` symlink
+    Creates a durable directory initially containing only a ``.credentials.json`` symlink
     pointing at *cred_path*, sets ``CLAUDE_CONFIG_DIR`` to that directory, and
     runs *cmd* (which is expected to be ``["claude", "-p", "-", ...]``).  The
-    temporary directory is removed after the call regardless of outcome.
+    credential symlink is removed after the call; session artifacts are retained.
 
     This avoids mutating the shared live symlink (``~/.claude/.credentials.json``),
     making it safe to call from concurrent sessions.
     """
-    tmpdir = Path(tempfile.mkdtemp(prefix="gptme-cc-slot-"))
+    tmpdir = create_trace_dir("claude-slot-")
+    logger.warning("Claude fallback slot traces retained in %s", tmpdir)
+    cred_link = tmpdir / ".credentials.json"
     try:
-        cred_link = tmpdir / ".credentials.json"
         cred_link.symlink_to(cred_path.resolve())
         slot_env = dict(base_env)
         slot_env["CLAUDE_CONFIG_DIR"] = str(tmpdir)
@@ -106,7 +107,7 @@ def _try_with_credential_file(
             env=slot_env,
         )
     finally:
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        cred_link.unlink(missing_ok=True)
 
 
 def call_claude_code(
@@ -127,8 +128,8 @@ def call_claude_code(
         prompt: The prompt to send to Claude Code
         timeout: Maximum time to wait for response (seconds)
         max_retries: Maximum number of retry attempts per failure type
-        diagnostic_dir: Directory for Claude debug logs. Defaults to a stable
-            temporary directory so scheduled failures retain diagnostics.
+        diagnostic_dir: Directory for Claude debug logs. Defaults to
+            ~/.local/state/gptme-activity-summary so failures retain diagnostics.
         narrative_key: Expected top-level JSON key for the narrative field in
             the response (e.g. ``"narrative"`` or ``"month_narrative"``). When
             set, the gptme fallback accepts this exact key or any other key in
@@ -147,13 +148,7 @@ def call_claude_code(
     import os
 
     env = os.environ.copy()
-    # Allow nesting: unset all CC env vars. Historically we also passed
-    # --no-session-persistence unconditionally, but for non-nested callers that
-    # prevents CC from writing a full trajectory to ~/.claude/projects/. Only
-    # pass the flag when actually nested (CLAUDECODE set in parent env) as a
-    # belt-and-suspenders safeguard against the empty-output bug
-    # (gptme/gptme-contrib#585). See: ErikBjare/bob#681.
-    nested = bool(env.get("CLAUDECODE"))
+    # Clear parent identity and give each attempt its own persisted session.
     env.pop("CLAUDECODE", None)
     env.pop("CLAUDE_CODE_ENTRYPOINT", None)
     env.pop("CC_SESSION_ID", None)
@@ -168,7 +163,7 @@ def call_claude_code(
 
     # Fallback credential paths for permanent subscription failures. When the
     # active slot is unavailable, call_claude_code tries each path in order via
-    # a temp CLAUDE_CONFIG_DIR. Extract here (before the subprocess env is locked)
+    # an isolated CLAUDE_CONFIG_DIR. Extract here (before the subprocess env is locked)
     # and strip from the env so the subprocess never sees it (prevents recursion).
     # Format: colon-separated absolute paths to credential files.
     # Example: /home/bob/.claude/.credentials.json.alice:/home/bob/.claude/.credentials.json.erik
@@ -193,8 +188,6 @@ def call_claude_code(
         cmd = prefix + ["claude", "-p", "-"]
     else:
         cmd = ["claude", "-p", "-"]
-    if nested:
-        cmd.append("--no-session-persistence")
 
     if diagnostic_dir is None:
         try:
@@ -207,7 +200,7 @@ def call_claude_code(
 
     while attempt <= max_retries or plain_retry_pending:
         debug_file: Path | None = None
-        attempt_cmd = list(cmd)
+        attempt_cmd = [*cmd, "--session-id", str(uuid.uuid4())]
         # Keep the healthy path compatible with Claude versions that predate
         # --debug-file. Enable tracing only after an actual failure triggered a
         # retry, and make diagnostics best-effort so they cannot block Claude.
@@ -222,15 +215,6 @@ def call_claude_code(
                 )
                 diagnostic_dir = None
             else:
-                # Prune files older than 7 days on first retry to cap disk growth
-                if attempt == 2:
-                    cutoff = time.time() - 7 * 86400
-                    for old_log in diagnostic_dir.glob("claude-*.log"):
-                        try:
-                            if old_log.stat().st_mtime < cutoff:
-                                old_log.unlink(missing_ok=True)
-                        except OSError:
-                            pass
                 debug_file = diagnostic_dir / f"claude-{invocation_id}-attempt-{attempt}.log"
                 attempt_cmd.extend(["--debug-file", str(debug_file)])
         result = subprocess.run(
@@ -278,7 +262,11 @@ def call_claude_code(
                     for fb_attempt in range(1, max_retries + 1):
                         try:
                             fb_result = _try_with_credential_file(
-                                cmd, prompt, fb_cred, env, timeout
+                                [*cmd, "--session-id", str(uuid.uuid4())],
+                                prompt,
+                                fb_cred,
+                                env,
+                                timeout,
                             )
                         except (OSError, subprocess.TimeoutExpired) as exc:
                             logger.warning("Fallback slot %s failed to run: %s", fb_cred.name, exc)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -17,10 +17,10 @@ import os
 import re
 import shutil
 import subprocess
-import tempfile
-from pathlib import Path
 
 from json_repair import repair_json
+
+from .traces import create_trace_dir, save_output
 
 logger = logging.getLogger(__name__)
 
@@ -110,11 +110,10 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
     ):
         env.pop(key, None)
 
-    # Create the private log dir inside the try so a full/unwritable temp
-    # filesystem returns "" instead of raising (never-raise contract).
-    isolated_logs = None
+    # Keep allocation inside the never-raise boundary, but retain all traces.
     try:
-        isolated_logs = Path(tempfile.mkdtemp(prefix="gptme-activity-summary-"))
+        isolated_logs = create_trace_dir("gptme-")
+        logger.warning("gptme fallback traces retained in %s", isolated_logs)
         env["GPTME_LOGS_HOME"] = str(isolated_logs)
         result = subprocess.run(
             cmd,
@@ -124,15 +123,17 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
             timeout=timeout,
             env=env,
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
+        save_output(isolated_logs, result.stdout, result.stderr)
+    except subprocess.TimeoutExpired as exc:
+        save_output(isolated_logs, exc.stdout, exc.stderr)
+        logger.warning("gptme fallback timed out; traces in %s", isolated_logs)
+        return ""
+    except OSError as exc:
         logger.warning("gptme fallback failed to run: %s", exc)
         return ""
     except Exception as exc:  # noqa: BLE001 - best-effort adapter must not raise
         logger.warning("gptme fallback errored unexpectedly: %s", exc)
         return ""
-    finally:
-        if isolated_logs is not None:
-            shutil.rmtree(isolated_logs, ignore_errors=True)
 
     if result.returncode != 0:
         logger.warning(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/traces.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/traces.py
@@ -1,0 +1,27 @@
+"""Private, durable invocation directories shared by summary backends."""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def create_trace_dir(prefix: str) -> Path:
+    """Allocate an isolated 0700 directory; never automatically delete traces."""
+    state_home = os.environ.get("XDG_STATE_HOME")
+    root = Path(state_home) if state_home else Path.home() / ".local" / "state"
+    root = root / "gptme-activity-summary"
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return Path(tempfile.mkdtemp(prefix=prefix, dir=root)).resolve()
+
+
+def save_output(root: Path, stdout: str | bytes | None, stderr: str | bytes | None) -> None:
+    """Retain full CLI diagnostics, including partial output after timeout."""
+    for name, output in (("stdout.log", stdout), ("stderr.log", stderr)):
+        try:
+            data = output.encode("utf-8") if isinstance(output, str) else output or b""
+            (root / name).write_bytes(data)
+        except OSError as exc:
+            logger.warning("Cannot save %s in %s: %s", name, root, exc)

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -251,8 +251,6 @@ def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_s
 
 @patch.dict(
     "os.environ",
-    # Explicitly clear CLAUDECODE so nested detection doesn't append
-    # --no-session-persistence and complicate the cmd assertion.
     {"GPTME_CC_CMD_PREFIX": "/opt/bin/slot-wrap --slot alice --", "CLAUDECODE": ""},
     clear=False,
 )
@@ -275,7 +273,8 @@ def test_call_claude_code_cmd_prefix_empty_env_unchanged(mock_run):
     mock_run.return_value = _make_completed_process(stdout='{"ok": true}')
     call_claude_code("test prompt")
     cmd = mock_run.call_args[0][0]
-    assert cmd == ["claude", "-p", "-"]
+    assert cmd[:3] == ["claude", "-p", "-"]
+    assert cmd[3] == "--session-id"
 
 
 @patch.dict("os.environ", {"GPTME_CC_CMD_PREFIX": "wrapper '"}, clear=True)
@@ -457,21 +456,19 @@ def test_call_claude_code_unsets_all_cc_env_vars(mock_run):
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_no_session_persistence_when_nested(mock_run, mock_sleep):
-    """--no-session-persistence is passed only when CLAUDECODE is set (nested)."""
+def test_call_claude_code_preserves_session_when_nested(mock_run, mock_sleep):
+    """Nested calls still write trajectories with a fresh session identity."""
     import os
 
     mock_run.return_value = _make_completed_process(stdout="test output")
 
-    # Nested case: CLAUDECODE set → flag present as belt-and-suspenders safeguard
+    # Nested case: clearing parent identity must not disable persistence.
     os.environ["CLAUDECODE"] = "1"
     try:
         call_claude_code("test prompt")
         cmd = mock_run.call_args[0][0]
-        assert "--no-session-persistence" in cmd, (
-            "Must pass --no-session-persistence when nested (CLAUDECODE set) "
-            "to prevent empty-output bug (gptme/gptme-contrib#585)"
-        )
+        assert "--no-session-persistence" not in cmd
+        assert "--session-id" in cmd
     finally:
         os.environ.pop("CLAUDECODE", None)
 

--- a/packages/gptme-activity-summary/tests/test_gptme_backend.py
+++ b/packages/gptme-activity-summary/tests/test_gptme_backend.py
@@ -476,7 +476,7 @@ def test_call_gptme_returns_empty_when_disabled(monkeypatch):
     assert call_gptme("ignored prompt") == ""
 
 
-def test_call_gptme_isolates_parent_session_logs(monkeypatch):
+def test_call_gptme_isolates_parent_session_logs(monkeypatch, tmp_path):
     """Nested gptme must not inherit the parent session's GPTME_LOGS_HOME/NAME.
 
     Incident 2026-08-30: a parent autonomous session exported
@@ -494,6 +494,7 @@ def test_call_gptme_isolates_parent_session_logs(monkeypatch):
     monkeypatch.setenv("GPTME_WORKSPACE", "/home/bob/bob")
     monkeypatch.setenv("GPTME_SUBPROCESS", "1")
 
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     captured: dict = {}
 
     def fake_run(*args, **kwargs):
@@ -516,11 +517,11 @@ def test_call_gptme_isolates_parent_session_logs(monkeypatch):
     logs_home = env.get("GPTME_LOGS_HOME")
     assert logs_home, "must set a private GPTME_LOGS_HOME"
     assert logs_home != "/tmp/gptme-logs-parent-session"
-    assert "gptme-activity-summary-" in logs_home
-    # Isolated dir is cleaned up after the call.
+    assert "gptme-activity-summary" in logs_home
+    # Isolated dir survives the call.
     from pathlib import Path
 
-    assert not Path(logs_home).exists()
+    assert Path(logs_home).is_dir()
 
 
 def test_call_gptme_returns_empty_when_tempdir_fails(monkeypatch):
@@ -540,7 +541,7 @@ def test_call_gptme_returns_empty_when_tempdir_fails(monkeypatch):
             return_value="/usr/bin/gptme",
         ),
         patch(
-            "gptme_activity_summary.gptme_backend.tempfile.mkdtemp",
+            "gptme_activity_summary.traces.tempfile.mkdtemp",
             side_effect=OSError("No space left on device"),
         ),
         patch("gptme_activity_summary.gptme_backend.subprocess.run") as run_mock,

--- a/packages/gptme-activity-summary/tests/test_trace_retention.py
+++ b/packages/gptme-activity-summary/tests/test_trace_retention.py
@@ -1,0 +1,125 @@
+"""Exercise trace retention through real, provider-free child processes."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gptme_activity_summary.cc_backend import _try_with_credential_file, call_claude_code
+from gptme_activity_summary.gptme_backend import call_gptme
+
+
+@pytest.mark.parametrize("outcome", ["success", "failure", "timeout"])
+def test_gptme_retains_child_trace(tmp_path, monkeypatch, caplog, outcome):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", "1")
+    monkeypatch.setenv("TRACE_OUTCOME", outcome)
+    marker = tmp_path / "child-path"
+    monkeypatch.setenv("TRACE_MARKER", str(marker))
+    child = tmp_path / "gptme"
+    child.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys, time\n"
+        "from pathlib import Path\n"
+        "root = Path(os.environ['GPTME_LOGS_HOME'])\n"
+        "Path(os.environ['TRACE_MARKER']).write_text(str(root))\n"
+        "conversation = root / 'conversation'\n"
+        "conversation.mkdir()\n"
+        "(conversation / 'conversation.jsonl').write_text('retained trajectory\\n')\n"
+        "(conversation / 'workspace').symlink_to(Path.cwd(), target_is_directory=True)\n"
+        "print('diagnostic-' + 'x' * 500, file=sys.stderr, flush=True)\n"
+        "print(json.dumps({'type': 'message', 'role': 'assistant', "
+        "'content': '{\"narrative\": \"done\"}'}), flush=True)\n"
+        "if os.environ['TRACE_OUTCOME'] == 'timeout': time.sleep(30)\n"
+        "sys.exit(76 if os.environ['TRACE_OUTCOME'] == 'failure' else 0)\n"
+    )
+    child.chmod(0o700)
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ["PATH"])
+    result = call_gptme("test prompt", timeout=1 if outcome == "timeout" else 10)
+    assert result == ('{"narrative": "done"}' if outcome == "success" else "")
+    root = Path(marker.read_text())
+    assert (root / "conversation/conversation.jsonl").read_text() == "retained trajectory\n"
+    assert root.is_relative_to(tmp_path / "state")
+    assert root.stat().st_mode & 0o777 == 0o700
+    assert (root / "conversation/workspace").is_symlink()
+    assert "x" * 500 in (root / "stderr.log").read_text()
+    assert '"role": "assistant"' in (root / "stdout.log").read_text()
+    assert str(root) in caplog.text
+
+
+@pytest.mark.parametrize("returncode", [0, 1, None])
+def test_credential_slot_retains_trace(tmp_path, monkeypatch, caplog, returncode):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    cred = tmp_path / "credentials.json"
+    cred.write_text("{}")
+    marker = tmp_path / "slot-path"
+    code = (
+        "import os, sys, time; from pathlib import Path; "
+        "p = Path(os.environ['CLAUDE_CONFIG_DIR']); "
+        f"Path({str(marker)!r}).write_text(str(p)); "
+        "(p / 'projects').mkdir(); "
+        "(p / 'projects/trace.jsonl').write_text('slot trajectory'); "
+        + ("time.sleep(30)" if returncode is None else f"sys.exit({returncode})")
+    )
+    args = ([sys.executable, "-c", code], "prompt", cred, dict(os.environ), 1)
+    if returncode is None:
+        with pytest.raises(subprocess.TimeoutExpired):
+            _try_with_credential_file(*args)
+    else:
+        result = _try_with_credential_file(*args)
+        assert result.returncode == returncode
+    root = Path(marker.read_text())
+    assert (root / "projects/trace.jsonl").read_text() == "slot trajectory"
+    assert root.is_relative_to(tmp_path / "state")
+    assert not (root / ".credentials.json").is_symlink()
+    assert cred.read_text() == "{}"
+    assert str(root) in caplog.text
+
+
+def test_claude_retries_keep_distinct_sessions(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    old_log = tmp_path / "claude-historical.log"
+    old_log.write_text("historical diagnostic")
+    os.utime(old_log, (1, 1))
+    with patch("subprocess.run") as run, patch("time.sleep"):
+        run.side_effect = [
+            subprocess.CompletedProcess([], 1, "", "transient"),
+            subprocess.CompletedProcess([], 0, "answer", ""),
+        ]
+        assert call_claude_code("prompt", diagnostic_dir=tmp_path) == "answer"
+    commands = [call.args[0] for call in run.call_args_list]
+    assert all("--no-session-persistence" not in cmd for cmd in commands)
+    ids = [cmd[cmd.index("--session-id") + 1] for cmd in commands]
+    assert len(set(ids)) == 2
+    assert old_log.read_text() == "historical diagnostic"
+
+
+def test_trace_directory_default_and_isolation(tmp_path, monkeypatch):
+    from gptme_activity_summary.traces import create_trace_dir
+
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    first = create_trace_dir("gptme-")
+    second = create_trace_dir("gptme-")
+    assert first != second
+    assert first.parent == second.parent == tmp_path / ".local/state/gptme-activity-summary"
+    assert first.is_dir() and second.is_dir()
+
+
+def test_output_write_failure_preserves_response(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK", "1")
+    with (
+        patch("shutil.which", return_value="gptme"),
+        patch("subprocess.run") as run,
+        patch.object(Path, "write_bytes", side_effect=OSError("disk full")),
+    ):
+        run.return_value = subprocess.CompletedProcess(
+            [], 0, '{"type":"message","role":"assistant","content":"answer"}', ""
+        )
+        assert call_gptme("prompt") == "answer"
+    assert "Cannot save stdout.log" in caplog.text
+    assert "Cannot save stderr.log" in caplog.text

--- a/packages/gptme-activity-summary/tests/test_trace_retention.py
+++ b/packages/gptme-activity-summary/tests/test_trace_retention.py
@@ -38,7 +38,7 @@ def test_gptme_retains_child_trace(tmp_path, monkeypatch, caplog, outcome):
     )
     child.chmod(0o700)
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ["PATH"])
-    result = call_gptme("test prompt", timeout=1 if outcome == "timeout" else 10)
+    result = call_gptme("test prompt", timeout=5 if outcome == "timeout" else 10)
     assert result == ('{"narrative": "done"}' if outcome == "success" else "")
     root = Path(marker.read_text())
     assert (root / "conversation/conversation.jsonl").read_text() == "retained trajectory\n"
@@ -64,7 +64,7 @@ def test_credential_slot_retains_trace(tmp_path, monkeypatch, caplog, returncode
         "(p / 'projects/trace.jsonl').write_text('slot trajectory'); "
         + ("time.sleep(30)" if returncode is None else f"sys.exit({returncode})")
     )
-    args = ([sys.executable, "-c", code], "prompt", cred, dict(os.environ), 1)
+    args = ([sys.executable, "-c", code], "prompt", cred, dict(os.environ), 5)
     if returncode is None:
         with pytest.raises(subprocess.TimeoutExpired):
             _try_with_credential_file(*args)


### PR DESCRIPTION
Summary generation discarded fallback conversations on every exit, making failed runs impossible to diagnose after the process ended. Keep each gptme invocation in a private XDG state directory, log its location, and preserve native conversations plus full stdout/stderr, including partial timeout output.

Apply the same retention contract to Claude: nested calls and retries use fresh persisted session IDs, alternate credential slots retain their trace directories while removing the credential symlink, and historical retry debug logs are no longer pruned. The Claude CLI must support `--session-id` (verified on 2.1.269). Account selection and fallback enablement stay as configured.

Validation: reproduced six retention failures on current master; 273 package tests pass, package typecheck and Ruff pass. A real installed gptme `mock/echo` invocation returned its narrative and retained conversation.jsonl, events.jsonl, stdout.log and stderr.log after exit. New tests exercise real subprocesses on success/failure/timeout, isolation, credential cleanup, and diagnostic write failures. The full suite ran with `GPTME_CC_EXTRA_PROJECTS_DIRS=` to isolate fixtures from the host archive.
